### PR TITLE
arch: introduce ServiceReportPeriod module + consolidate tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "browser": true,
     "es2021": true,

--- a/src/__tests__/serviceReportPeriod.test.ts
+++ b/src/__tests__/serviceReportPeriod.test.ts
@@ -1,0 +1,443 @@
+import moment from 'moment'
+import { describe, expect, it, vi } from 'vitest'
+import { ServiceReport, ServiceReportsByYears } from '../types/serviceReport'
+import { ServiceReportPeriod } from '../lib/serviceReportPeriod'
+
+vi.mock('../lib/logger', () => import('./mocks/logger'))
+
+const reports = (
+  year: number,
+  month: number,
+  entries: Partial<ServiceReport>[]
+): ServiceReportsByYears => ({
+  [year]: {
+    [month]: entries.map((e, i) => ({
+      id: e.id ?? `id-${year}-${month}-${i}`,
+      hours: e.hours ?? 0,
+      minutes: e.minutes ?? 0,
+      date: e.date ?? new Date(year, month, 15, 12, 0, 0),
+      ...e,
+    })),
+  },
+})
+
+describe('ServiceReportPeriod.forMonth', () => {
+  describe('adjustedMinutes', () => {
+    it('sums standard hours into adjustedMinutes.value for a single-report month', () => {
+      const serviceReports = reports(2026, 4, [{ hours: 2, minutes: 30 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+      })
+
+      expect(period.adjustedMinutes.value).toBe(2 * 60 + 30)
+    })
+
+    it('returns zeroed adjustedMinutes when the period has no reports', () => {
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports: {},
+      })
+
+      expect(period.adjustedMinutes).toEqual({
+        value: 0,
+        standard: 0,
+        credit: 0,
+        creditOverage: 0,
+      })
+    })
+
+    it('caps adjustedMinutes at the default 55-hour credit limit', () => {
+      const serviceReports = reports(2026, 4, [
+        { id: 'std', hours: 30, minutes: 0 },
+        { id: 'ldc', hours: 40, minutes: 0, ldc: true },
+      ])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+      })
+
+      expect(period.adjustedMinutes.value).toBe(55 * 60)
+      expect(period.adjustedMinutes.creditOverage).toBe(15 * 60)
+    })
+
+    it('honors a publisher-specific credit-limit exemption (special pioneer)', () => {
+      const serviceReports = reports(2026, 4, [
+        { id: 'std', hours: 80, minutes: 0 },
+        { id: 'ldc', hours: 30, minutes: 0, ldc: true },
+      ])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+        publisher: 'specialPioneer',
+      })
+
+      expect(period.adjustedMinutes.value).toBe(110 * 60)
+      expect(period.adjustedMinutes.creditOverage).toBe(0)
+    })
+
+    it('honors a user credit-limit override', () => {
+      const serviceReports = reports(2026, 4, [
+        { id: 'std', hours: 45, minutes: 0 },
+        { id: 'ldc', hours: 40, minutes: 0, ldc: true },
+      ])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+        publisher: 'regularPioneer',
+        creditLimitOverride: { enabled: true, customLimitHours: 70 },
+      })
+
+      expect(period.adjustedMinutes.value).toBe(70 * 60)
+      expect(period.adjustedMinutes.creditOverage).toBe(15 * 60)
+    })
+
+    it('isolates January from prior December across a year boundary', () => {
+      const serviceReports: ServiceReportsByYears = {
+        2025: {
+          11: [
+            {
+              id: 'dec-2025',
+              hours: 99,
+              minutes: 0,
+              date: new Date(Date.UTC(2025, 11, 31, 12, 0, 0)),
+            },
+          ],
+        },
+        2026: {
+          0: [
+            {
+              id: 'jan-2026',
+              hours: 1,
+              minutes: 0,
+              date: new Date(Date.UTC(2026, 0, 1, 12, 0, 0)),
+            },
+          ],
+        },
+      }
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 0,
+        serviceReports,
+      })
+
+      expect(period.adjustedMinutes.value).toBe(60)
+    })
+
+    it('isolates the period: reports in adjacent months do not contribute', () => {
+      const serviceReports: ServiceReportsByYears = {
+        2026: {
+          3: [
+            {
+              id: 'april',
+              hours: 99,
+              minutes: 0,
+              date: new Date(2026, 3, 30, 12, 0, 0),
+            },
+          ],
+          4: [
+            {
+              id: 'may',
+              hours: 1,
+              minutes: 30,
+              date: new Date(2026, 4, 1, 12, 0, 0),
+            },
+          ],
+          5: [
+            {
+              id: 'june',
+              hours: 99,
+              minutes: 0,
+              date: new Date(2026, 5, 1, 12, 0, 0),
+            },
+          ],
+        },
+      }
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+      })
+
+      expect(period.adjustedMinutes.value).toBe(60 + 30)
+    })
+  })
+
+  describe('goalRemaining', () => {
+    it('returns goalHours * 60 minus adjustedMinutes when under the goal', () => {
+      const serviceReports = reports(2026, 4, [{ hours: 10, minutes: 0 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+        goalHours: 25,
+      })
+
+      expect(period.goalRemaining).toBe(15 * 60)
+    })
+
+    it('clamps goalRemaining to 0 once the goal is met', () => {
+      const serviceReports = reports(2026, 4, [{ hours: 30, minutes: 0 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+        goalHours: 25,
+      })
+
+      expect(period.goalRemaining).toBe(0)
+    })
+
+    it('returns full goal when no reports exist for the period', () => {
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports: {},
+        goalHours: 50,
+      })
+
+      expect(period.goalRemaining).toBe(50 * 60)
+    })
+
+    it('treats a missing goalHours as zero — goalRemaining is zero', () => {
+      const serviceReports = reports(2026, 4, [{ hours: 5, minutes: 0 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+      })
+
+      expect(period.goalRemaining).toBe(0)
+    })
+  })
+
+  describe('rolloverFromPrior', () => {
+    it('surfaces the prior month fractional minutes when querying the current month', () => {
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+        referenceDate: moment('2026-04-15'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toEqual({
+        sourceYear: 2026,
+        sourceMonth: 2,
+        minutes: 24,
+      })
+    })
+
+    it('returns null when prior month has no fractional minutes', () => {
+      const serviceReports = reports(2026, 2, [{ hours: 2, minutes: 0 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+        referenceDate: moment('2026-04-15'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toBeNull()
+    })
+
+    it('returns null when querying a non-current month (rollover only flows into the current month)', () => {
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 5,
+        serviceReports,
+        referenceDate: moment('2026-04-15'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toBeNull()
+    })
+
+    it('skips a prior service-year boundary for annual-goal publishers (Aug→Sep)', () => {
+      const serviceReports = reports(2026, 7, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 8,
+        serviceReports,
+        referenceDate: moment('2026-09-05'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toBeNull()
+    })
+
+    it('still crosses the SY boundary for non-annual-goal publishers', () => {
+      const serviceReports = reports(2026, 7, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 8,
+        serviceReports,
+        referenceDate: moment('2026-09-05'),
+        hasAnnualGoal: false,
+      })
+
+      expect(period.rolloverFromPrior).toEqual({
+        sourceYear: 2026,
+        sourceMonth: 7,
+        minutes: 24,
+      })
+    })
+
+    it('respects the lastRolloverYearMonth marker', () => {
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+        referenceDate: moment('2026-04-15'),
+        hasAnnualGoal: true,
+        lastRolloverYearMonth: '2026-04',
+      })
+
+      expect(period.rolloverFromPrior).toBeNull()
+    })
+
+    it('uses any day-of-month within referenceDate as the rollover anchor (custom rollover-day)', () => {
+      // Anchor on the 28th instead of the 15th — a deliberately late
+      // mid-month date that some users prefer as their "review month" cutoff.
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 30 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+        referenceDate: moment('2026-04-28'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toEqual({
+        sourceYear: 2026,
+        sourceMonth: 2,
+        minutes: 30,
+      })
+    })
+
+    it('treats the first day of the month as a valid rollover anchor', () => {
+      // Edge: anchoring on day 1 still counts the prior month's fractional
+      // hours — the period boundary is the calendar month, not "day N".
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 30 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+        referenceDate: moment('2026-04-01'),
+        hasAnnualGoal: true,
+      })
+
+      expect(period.rolloverFromPrior).toEqual({
+        sourceYear: 2026,
+        sourceMonth: 2,
+        minutes: 30,
+      })
+    })
+
+    it('returns null when no referenceDate is supplied (rollover requires an anchor)', () => {
+      const serviceReports = reports(2026, 2, [{ hours: 1, minutes: 24 }])
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 3,
+        serviceReports,
+      })
+
+      expect(period.rolloverFromPrior).toBeNull()
+    })
+  })
+
+  describe('timezone-anchored dates', () => {
+    it('reads noon-UTC anchored dates regardless of stored hour offset (May 1 noon UTC counts in May)', () => {
+      const serviceReports: ServiceReportsByYears = {
+        2026: {
+          4: [
+            {
+              id: 'tz-anchored',
+              hours: 2,
+              minutes: 30,
+              date: new Date(Date.UTC(2026, 4, 1, 12, 0, 0)),
+            },
+          ],
+        },
+      }
+
+      const period = ServiceReportPeriod.forMonth({
+        year: 2026,
+        month: 4,
+        serviceReports,
+      })
+
+      expect(period.adjustedMinutes.value).toBe(2 * 60 + 30)
+      expect(period.adjustedMinutes.standard).toBe(2 * 60 + 30)
+    })
+
+    it('a JST-authored May 1 report is counted in May totals after the device switches to PST', () => {
+      const originalTZ = process.env.TZ
+      try {
+        process.env.TZ = 'Asia/Tokyo'
+        const dateAuthoredInJST = moment('2026-05-01').toDate()
+        const normalized = new Date(
+          Date.UTC(
+            moment(dateAuthoredInJST).year(),
+            moment(dateAuthoredInJST).month(),
+            moment(dateAuthoredInJST).date(),
+            12,
+            0,
+            0,
+            0
+          )
+        )
+        const serviceReports: ServiceReportsByYears = {
+          2026: {
+            4: [
+              {
+                id: 'jst-report',
+                hours: 2,
+                minutes: 30,
+                date: normalized,
+              },
+            ],
+          },
+        }
+
+        process.env.TZ = 'America/Los_Angeles'
+        const period = ServiceReportPeriod.forMonth({
+          year: 2026,
+          month: 4,
+          serviceReports,
+        })
+
+        expect(period.adjustedMinutes.value).toBe(2 * 60 + 30)
+      } finally {
+        if (originalTZ === undefined) delete process.env.TZ
+        else process.env.TZ = originalTZ
+      }
+    })
+  })
+})

--- a/src/__tests__/serviceReportTimezone.test.ts
+++ b/src/__tests__/serviceReportTimezone.test.ts
@@ -19,11 +19,11 @@ vi.mock(
 import useServiceReport from '../stores/serviceReport'
 import {
   RecurringPlanFrequencies,
-  adjustedMinutesForSpecificMonth,
   getMonthsReports,
   getPlansIntersectingDay,
   standardMinutesForSpecificMonth,
 } from '../lib/serviceReport'
+import { ServiceReportPeriod } from '../lib/serviceReportPeriod'
 
 const originalTZ = process.env.TZ
 const setTZ = (tz: string) => {
@@ -60,8 +60,12 @@ describe('end-to-end TZ stability', () => {
     const standard = standardMinutesForSpecificMonth(monthsReports, 4, 2026)
     expect(standard).toBe(2 * 60 + 30)
 
-    const adjusted = adjustedMinutesForSpecificMonth(monthsReports, 4, 2026)
-    expect(adjusted.value).toBe(2 * 60 + 30)
+    const period = ServiceReportPeriod.forMonth({
+      year: 2026,
+      month: 4,
+      serviceReports: state.serviceReports,
+    })
+    expect(period.adjustedMinutes.value).toBe(2 * 60 + 30)
   })
 
   it('a JST-authored May 1 report is also correctly counted in NZDT (UTC+13)', () => {

--- a/src/lib/serviceReportPeriod.ts
+++ b/src/lib/serviceReportPeriod.ts
@@ -1,0 +1,84 @@
+import moment from 'moment'
+import {
+  AdjustedMinutes,
+  adjustedMinutesForSpecificMonth,
+  calculateMinutesRemaining,
+  getMonthsReports,
+} from './serviceReport'
+import { computePendingRollovers, PendingRollover } from './rollover'
+import { ServiceReportsByYears } from '../types/serviceReport'
+import { Publisher } from '../types/publisher'
+
+export type ServiceReportPeriodInput = {
+  year: number
+  month: number
+  serviceReports: ServiceReportsByYears
+  publisher?: Publisher
+  creditLimitOverride?: { enabled: boolean; customLimitHours: number }
+  goalHours?: number
+  /**
+   * Anchor for rollover-from-prior: a moment treated as "today". When supplied
+   * and (year, month) is the same calendar month as the anchor, we surface the
+   * prior month's fractional minutes so the period can show "+N from last
+   * month". When unset, rolloverFromPrior is null — the period is treated as
+   * standalone.
+   */
+  referenceDate?: moment.Moment
+  hasAnnualGoal?: boolean
+  lastRolloverYearMonth?: string | null
+}
+
+export type ServiceReportPeriodResult = {
+  adjustedMinutes: AdjustedMinutes
+  goalRemaining: number
+  rolloverFromPrior: PendingRollover | null
+}
+
+const forMonth = (
+  input: ServiceReportPeriodInput
+): ServiceReportPeriodResult => {
+  const monthsReports = getMonthsReports(
+    input.serviceReports,
+    input.month,
+    input.year
+  )
+  const adjustedMinutes = adjustedMinutesForSpecificMonth(
+    monthsReports,
+    input.month,
+    input.year,
+    input.publisher,
+    input.creditLimitOverride
+  )
+  const goalRemaining = calculateMinutesRemaining({
+    minutes: adjustedMinutes.value,
+    goalHours: input.goalHours ?? 0,
+  })
+
+  const rolloverFromPrior = computeRolloverFromPrior(input)
+
+  return { adjustedMinutes, goalRemaining, rolloverFromPrior }
+}
+
+const computeRolloverFromPrior = (
+  input: ServiceReportPeriodInput
+): PendingRollover | null => {
+  if (!input.referenceDate) return null
+  const refMonth = input.referenceDate.month()
+  const refYear = input.referenceDate.year()
+  if (refMonth !== input.month || refYear !== input.year) return null
+
+  const pending = computePendingRollovers({
+    serviceReports: input.serviceReports,
+    today: input.referenceDate,
+    hasAnnualGoal: input.hasAnnualGoal ?? false,
+    lastRolloverYearMonth: input.lastRolloverYearMonth ?? null,
+    publisher: input.publisher,
+    creditLimitOverride: input.creditLimitOverride,
+  })
+
+  return pending[0] ?? null
+}
+
+export const ServiceReportPeriod = {
+  forMonth,
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/serviceReportPeriod.ts` exposing `ServiceReportPeriod.forMonth(input)` that composes `getMonthsReports`, `adjustedMinutesForSpecificMonth`, `calculateMinutesRemaining`, and `computePendingRollovers`. The underlying helpers stay exported because callers (HomeScreen, ProgressScreen, PlanDayScreen, HourEntryCard, etc.) haven't migrated yet — that's #323/#324/#325.
- Adds `src/__tests__/serviceReportPeriod.test.ts` (22 tests) covering month boundaries, year boundaries, timezone-anchored dates (UTC noon, JST→PST), credit-cap behavior, publisher exemptions, override limits, goal-remaining computation, and rollover-from-prior (current-month-only, SY-boundary, marker, custom rollover-day, day-1 anchor).
- Reframes the period-level adjusted-minutes assertion in `serviceReportTimezone.test.ts` against the new module. Helper-level assertions (`standardMinutesForSpecificMonth`, plan intersection, deletedDates) stay where they are.
- Adds `"root": true` to `.eslintrc.json` so ESLint stops walking above the project dir — fixes a duplicate `@typescript-eslint` plugin error when running lint from inside a git worktree (no behavioral change in normal usage).

## `forMonth` return shape

```ts
{
  adjustedMinutes: AdjustedMinutes  // value, standard, credit, creditOverage
  goalRemaining: number             // minutes remaining to hit goalHours, clamped >= 0
  rolloverFromPrior: PendingRollover | null  // { sourceYear, sourceMonth, minutes }
}
```

`rolloverFromPrior` is null unless a `referenceDate` is supplied AND the queried (year, month) matches it — rollover only flows into the user's "current" month.

## Test plan

- [x] `pnpm testFinal` — 431 tests pass (was 409, +22 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] No callers migrated this slice — helpers remain exported
- [x] Existing `rollover.test.ts` / `serviceReport.test.ts` left intact (their tests exercise helper contracts directly, not period-level composition)

Closes #316