### PR TITLE
arch: introduce conversationReminders module + migrate ConversationFormScreen

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "browser": true,
     "es2021": true,

--- a/src/__tests__/conversationReminders.test.ts
+++ b/src/__tests__/conversationReminders.test.ts
@@ -1,0 +1,253 @@
+import moment from 'moment'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/locales', () => ({
+  default: {
+    t: vi.fn((key: string) => key),
+  },
+}))
+
+import { Conversation } from '../types/conversation'
+import { sync } from '../lib/conversationReminders'
+
+const makeAdapter = () => ({
+  scheduleNotificationAsync: vi.fn(async () => 'fake-id'),
+  cancelScheduledNotificationAsync: vi.fn(async () => undefined),
+})
+
+const makeConversation = (
+  overrides: Partial<Conversation> = {}
+): Conversation => ({
+  id: 'conv-1',
+  contact: { id: 'contact-1' },
+  date: new Date(),
+  isBibleStudy: false,
+  ...overrides,
+})
+
+describe('conversationReminders.sync', () => {
+  it('schedules a notification at followUpDate minus offset when creating with notifyMe', async () => {
+    const adapter = makeAdapter()
+    let scheduledId = 0
+    adapter.scheduleNotificationAsync.mockImplementation(async () => {
+      scheduledId += 1
+      return `scheduled-${scheduledId}`
+    })
+
+    const followUpDate = moment().add(1, 'day').toDate()
+    const conversation = makeConversation({
+      followUp: {
+        date: followUpDate,
+        notifyMe: true,
+        topic: 'Hebrews 11',
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous: undefined,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.scheduleNotificationAsync).toHaveBeenCalledTimes(1)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('scheduled-1')
+    const expectedTrigger = moment(followUpDate).subtract(2, 'hours').toDate()
+    expect(result[0].date.getTime()).toBe(expectedTrigger.getTime())
+  })
+
+  it('does not schedule when notifyMe is false', async () => {
+    const adapter = makeAdapter()
+    const conversation = makeConversation({
+      followUp: {
+        date: moment().add(1, 'day').toDate(),
+        notifyMe: false,
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous: undefined,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.scheduleNotificationAsync).not.toHaveBeenCalled()
+    expect(result).toEqual([])
+  })
+
+  it('does not schedule when there is no followUp at all', async () => {
+    const adapter = makeAdapter()
+    const conversation = makeConversation()
+
+    const result = await sync(
+      {
+        conversation,
+        previous: undefined,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.scheduleNotificationAsync).not.toHaveBeenCalled()
+    expect(result).toEqual([])
+  })
+
+  it('preserves existing notifications when followUp is unchanged', async () => {
+    const adapter = makeAdapter()
+    const followUpDate = moment().add(1, 'day').toDate()
+    const previousNotifications = [
+      {
+        id: 'kept-1',
+        date: moment(followUpDate).subtract(2, 'hours').toDate(),
+      },
+    ]
+    const previous = makeConversation({
+      followUp: {
+        date: followUpDate,
+        notifyMe: true,
+        topic: 'Hebrews 11',
+        notifications: previousNotifications,
+      },
+    })
+    const conversation = makeConversation({
+      followUp: {
+        date: followUpDate,
+        notifyMe: true,
+        topic: 'Hebrews 11',
+        notifications: previousNotifications,
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.cancelScheduledNotificationAsync).not.toHaveBeenCalled()
+    expect(adapter.scheduleNotificationAsync).not.toHaveBeenCalled()
+    expect(result).toEqual(previousNotifications)
+  })
+
+  it('cancels old notifications and schedules new when followUp changes', async () => {
+    const adapter = makeAdapter()
+    adapter.scheduleNotificationAsync.mockResolvedValue('new-id')
+    const oldFollowUpDate = moment().add(1, 'day').toDate()
+    const newFollowUpDate = moment().add(2, 'days').toDate()
+    const previousNotifications = [
+      { id: 'old-1', date: oldFollowUpDate },
+      { id: 'old-2', date: oldFollowUpDate },
+    ]
+    const previous = makeConversation({
+      followUp: {
+        date: oldFollowUpDate,
+        notifyMe: true,
+        notifications: previousNotifications,
+      },
+    })
+    const conversation = makeConversation({
+      followUp: {
+        date: newFollowUpDate,
+        notifyMe: true,
+        notifications: previousNotifications,
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.cancelScheduledNotificationAsync).toHaveBeenCalledTimes(2)
+    expect(adapter.cancelScheduledNotificationAsync).toHaveBeenCalledWith(
+      'old-1'
+    )
+    expect(adapter.cancelScheduledNotificationAsync).toHaveBeenCalledWith(
+      'old-2'
+    )
+    expect(adapter.scheduleNotificationAsync).toHaveBeenCalledTimes(1)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('new-id')
+    expect(result[0].date.getTime()).toBe(
+      moment(newFollowUpDate).subtract(2, 'hours').toDate().getTime()
+    )
+  })
+
+  it('cancels old notifications and returns empty when followUp removes notifyMe', async () => {
+    const adapter = makeAdapter()
+    const followUpDate = moment().add(1, 'day').toDate()
+    const previousNotifications = [{ id: 'old-1', date: followUpDate }]
+    const previous = makeConversation({
+      followUp: {
+        date: followUpDate,
+        notifyMe: true,
+        notifications: previousNotifications,
+      },
+    })
+    const conversation = makeConversation({
+      followUp: {
+        date: followUpDate,
+        notifyMe: false,
+        notifications: previousNotifications,
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.cancelScheduledNotificationAsync).toHaveBeenCalledWith(
+      'old-1'
+    )
+    expect(adapter.scheduleNotificationAsync).not.toHaveBeenCalled()
+    expect(result).toEqual([])
+  })
+
+  it('does not schedule when the trigger date is already in the past', async () => {
+    const adapter = makeAdapter()
+    // Follow-up is 1 hour from now, offset is 2 hours -> trigger is 1 hour ago.
+    const conversation = makeConversation({
+      followUp: {
+        date: moment().add(1, 'hour').toDate(),
+        notifyMe: true,
+      },
+    })
+
+    const result = await sync(
+      {
+        conversation,
+        previous: undefined,
+        contactName: 'John Doe',
+        notifyMeOffset: { amount: 2, unit: 'hours' },
+      },
+      adapter
+    )
+
+    expect(adapter.scheduleNotificationAsync).not.toHaveBeenCalled()
+    expect(result).toEqual([])
+  })
+})

--- a/src/lib/conversationReminders.ts
+++ b/src/lib/conversationReminders.ts
@@ -1,0 +1,109 @@
+import * as Notifications from 'expo-notifications'
+import moment from 'moment'
+import _ from 'lodash'
+import { Conversation, Notification } from '../types/conversation'
+import i18n from './locales'
+
+export type NotificationsAdapter = {
+  scheduleNotificationAsync: (
+    request: Notifications.NotificationRequestInput
+  ) => Promise<string>
+  cancelScheduledNotificationAsync: (id: string) => Promise<void>
+}
+
+export type ReminderOffset = {
+  amount?: number
+  unit?: moment.unitOfTime.DurationConstructor
+}
+
+export type SyncInput = {
+  conversation: Conversation
+  previous?: Conversation
+  contactName: string
+  notifyMeOffset: ReminderOffset
+  pickEmoji?: () => string
+  onError?: (error: unknown) => void
+}
+
+const defaultAdapter: NotificationsAdapter = {
+  scheduleNotificationAsync: Notifications.scheduleNotificationAsync,
+  cancelScheduledNotificationAsync:
+    Notifications.cancelScheduledNotificationAsync,
+}
+
+export const sync = async (
+  input: SyncInput,
+  adapter: NotificationsAdapter = defaultAdapter
+): Promise<Notification[]> => {
+  const { conversation, previous, contactName, notifyMeOffset } = input
+  if (!conversation.followUp) return []
+
+  // Deep-equal short-circuit: if nothing about the follow-up changed we keep
+  // the existing scheduled OS notifications untouched. Mirrors the prior
+  // ConversationFormScreen behavior where a save with no follow-up edits did
+  // not cancel-and-reschedule.
+  const followUpUnchanged =
+    previous?.followUp !== undefined &&
+    _.isEqual(previous.followUp, conversation.followUp)
+  if (followUpUnchanged) {
+    return conversation.followUp.notifications ?? []
+  }
+
+  // Follow-up changed (date, notifyMe, topic, …): cancel any prior reminders
+  // before deciding whether to schedule a fresh one. Mirrors the prior
+  // ConversationFormScreen flow. allSettled keeps a single bad cancel from
+  // bringing down the whole save (the screen's previous fire-and-forget
+  // forEach had the same fault tolerance).
+  const priorNotifications = previous?.followUp?.notifications ?? []
+  await Promise.allSettled(
+    priorNotifications.map(({ id }) =>
+      adapter.cancelScheduledNotificationAsync(id)
+    )
+  )
+
+  if (!conversation.followUp.notifyMe) return []
+
+  const triggerDate = moment(conversation.followUp.date)
+    .subtract(notifyMeOffset.amount, notifyMeOffset.unit)
+    .toDate()
+
+  if (!moment(triggerDate).isAfter(moment())) {
+    return []
+  }
+
+  const emoji = input.pickEmoji ? input.pickEmoji() : ''
+  const topic = conversation.followUp.topic
+  const body = `${i18n.t('notification_part1')} ${contactName} ${i18n.t(
+    'notification_part2'
+  )} ${notifyMeOffset.amount} ${notifyMeOffset.unit}. ${emoji}${
+    topic && `${i18n.t('reminder_topic')}${topic}`
+  }`
+
+  try {
+    const id = await adapter.scheduleNotificationAsync({
+      content: {
+        title: i18n.t('reminder_title'),
+        body,
+        sound: true,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: triggerDate,
+      },
+    })
+    return [{ date: triggerDate, id }]
+  } catch (error) {
+    input.onError?.(error)
+    return []
+  }
+}
+
+export const cancel = async (
+  notifications: Notification[] | undefined,
+  adapter: NotificationsAdapter = defaultAdapter
+): Promise<void> => {
+  if (!notifications || notifications.length === 0) return
+  await Promise.allSettled(
+    notifications.map(({ id }) => adapter.cancelScheduledNotificationAsync(id))
+  )
+}

--- a/src/screens/ConversationFormScreen.tsx
+++ b/src/screens/ConversationFormScreen.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 import { View, Alert } from 'react-native'
 import Text from '../components/MyText'
-import * as Notifications from 'expo-notifications'
 import * as Crypto from 'expo-crypto'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as Sentry from '@sentry/react-native'
@@ -12,7 +11,7 @@ import useTheme from '../contexts/theme'
 import Divider from '../components/Divider'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import Section from '../components/inputs/Section'
-import { Conversation, Notification } from '../types/conversation'
+import { Conversation } from '../types/conversation'
 import InputRowContainer from '../components/inputs/InputRowContainer'
 import { DateTimePickerEvent } from '@react-native-community/datetimepicker'
 import TextInputRow from '../components/inputs/TextInputRow'
@@ -32,7 +31,6 @@ import {
   faIdCard,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons'
-import _ from 'lodash'
 import Button from '../components/Button'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { usePreferences } from '../stores/preferences'
@@ -41,6 +39,7 @@ import useNotifications from '../hooks/notifications'
 import { useToastController } from '@tamagui/toast'
 import { RootStackParamList } from '../types/rootStack'
 import { deriveOffsetFromDates } from '../lib/notificationOffset'
+import { sync as syncConversationReminders } from '../lib/conversationReminders'
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Conversation Form'>
 type MomentOffset = {
@@ -297,90 +296,32 @@ const ConversationFormScreen = ({ route, navigation }: Props) => {
 
   const submit = useCallback(() => {
     return new Promise((resolve) => {
-      const cancelExistingNotification = () => {
-        conversationToUpdate?.followUp?.notifications?.forEach(
-          async ({ id }) => {
-            await Notifications.cancelScheduledNotificationAsync(id)
-          }
-        )
-      }
-
-      const scheduleNotifications = async () => {
-        if (!conversation.followUp) {
-          return []
-        }
-
-        const notificationChanged = !_.isEqual(
-          conversationToUpdate?.followUp,
-          conversation.followUp
-        )
-
-        if (notificationChanged) {
-          cancelExistingNotification()
-        }
-
-        if (!conversation.followUp.notifyMe) {
-          return []
-        }
-
-        const notifications: Notification[] = []
-
-        const selectedDate = moment(conversation.followUp?.date)
-          .subtract(notifyMeOffset.amount, notifyMeOffset.unit)
-          .toDate()
-
-        const getRandomEmoji = () => {
-          const emojis = [
-            '😀',
-            '✨',
-            '🚀',
-            '⭐',
-            '🎉',
-            '💨',
-            '👀',
-            '💪',
-            '⏱️',
-            '🌟',
-          ]
-          const randomIndex = Math.floor(Math.random() * emojis.length)
-          return emojis[randomIndex]
-        }
-
-        if (moment(selectedDate).isAfter(moment())) {
-          try {
-            const id = await Notifications.scheduleNotificationAsync({
-              content: {
-                title: i18n.t('reminder_title'),
-                body: `${i18n.t('notification_part1')} ${
-                  selectedContact!.name
-                } ${i18n.t('notification_part2')} ${notifyMeOffset.amount} ${
-                  notifyMeOffset.unit
-                }. ${getRandomEmoji()}${
-                  conversation.followUp.topic &&
-                  `${i18n.t('reminder_topic')}${conversation.followUp.topic}`
-                }`,
-                sound: true,
-              },
-              trigger: {
-                type: Notifications.SchedulableTriggerInputTypes.DATE,
-                date: selectedDate,
-              },
-            })
-
-            notifications.push({
-              date: selectedDate,
-              id,
-            })
-          } catch (error) {
-            Sentry.captureException(error)
-          }
-        }
-
-        return notifications
+      const pickEmoji = () => {
+        const emojis = [
+          '😀',
+          '✨',
+          '🚀',
+          '⭐',
+          '🎉',
+          '💨',
+          '👀',
+          '💪',
+          '⏱️',
+          '🌟',
+        ]
+        const randomIndex = Math.floor(Math.random() * emojis.length)
+        return emojis[randomIndex]
       }
 
       if (notificationsAllowed) {
-        scheduleNotifications()
+        syncConversationReminders({
+          conversation,
+          previous: conversationToUpdate,
+          contactName: selectedContact?.name ?? '',
+          notifyMeOffset,
+          pickEmoji,
+          onError: (error) => Sentry.captureException(error),
+        })
           .then((notifications) => {
             const conversationWithNotificationIds: Conversation = {
               ...conversation,
@@ -414,10 +355,9 @@ const ConversationFormScreen = ({ route, navigation }: Props) => {
   }, [
     addConversation,
     conversation,
-    conversationToUpdate?.followUp,
+    conversationToUpdate,
     notificationsAllowed,
-    notifyMeOffset.amount,
-    notifyMeOffset.unit,
+    notifyMeOffset,
     params.conversationToEditId,
     selectedContact,
     toast,


### PR DESCRIPTION
## Summary

- Adds `src/lib/conversationReminders.ts` as the single owner of OS notification scheduling for conversation follow-ups (cancel-old, compute-trigger, format-body, schedule-new, return ids), with a `NotificationsAdapter` and `pickEmoji` injection point so the module is testable against a fake `expo-notifications`.
- Migrates `ConversationFormScreen.submit` to call `sync()` instead of inline `Notifications.*` plumbing — net ~60 lines deleted from the screen. Trigger time, body text, future-date guard, Sentry capture, and persistence shape are unchanged.
- One side-effect that aligns with the issue's explicit acceptance criterion: an edit which leaves the follow-up untouched no longer re-schedules a duplicate reminder.
- Pulls in the `root: true` ESLint config patch from another branch so the project's `pnpm run lint` (and the pre-push hook) passes when run from inside `.claude/worktrees/`.

Closes #313

## Test plan

- [x] `pnpm testFinal` — 416 tests pass, including 7 new `conversationReminders` integration tests
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Manual smoke: create a new conversation with follow-up + notifyMe → reminder fires at `followUp.date - offset` with the expected body
- [ ] Manual smoke: edit a conversation, change nothing, save → no duplicate reminder is scheduled (system list is unchanged)
- [ ] Manual smoke: edit a conversation, change the follow-up date → old reminder cancelled, new one scheduled at the new trigger
- [ ] Manual smoke: edit a conversation, untick `notifyMe` → old reminder cancelled, no new reminder scheduled