### PR TITLE
feat(assistant): add projection + recommendation engine (pure libs)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,10 @@
 # AGENTS.md
 
-Guide for AI coding agents working in WitnessWork. This is an iOS project only, this app is not made to support Android.
+WitnessWork is a field service assistant app for Jehovah's Witnesses. This is an iOS project only, this app is not made to support Android. The goal of the app is to encourage and assist users in scheduling their service-time to hit their publisher goals, keep track of contacts & appointments, and minimize the amount of mental overhead in calculating their progress and what's up-next.
+
+## Jehovah's Witness sensitivities
+
+Do not use the word "magic" or magic-wands in i18n or iconography
 
 ## NEVER REVERT OR DESTROY UNSTAGED WORK DESTRUCTIVELY, UNDER ANY CIRCUMSTANCES
 

--- a/src/__tests__/assistantRecommendation.test.ts
+++ b/src/__tests__/assistantRecommendation.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../lib/logger', () => import('./mocks/logger'))
+
+import { generateRecommendation } from '../lib/assistantRecommendation'
+import { momentStoredDate, normalizeDateForStorage } from '../lib/normalizeDate'
+import type { Conversation } from '../types/conversation'
+import type { DayPlan, RecurringPlan } from '../types/serviceReport'
+
+const baseInput = {
+  year: 2026,
+  month: 4, // May
+  today: normalizeDateForStorage('2026-05-01'),
+  monthlyGoalHours: 50,
+  loggedAdjustedMinutes: 0,
+  dayPlans: [] as DayPlan[],
+  recurringPlans: [] as RecurringPlan[],
+  conversations: [] as Conversation[],
+  excludedWeekdays: [] as number[],
+  assistantHistory: [],
+}
+
+describe('generateRecommendation', () => {
+  it('returns null when the monthly goal is 0', () => {
+    expect(
+      generateRecommendation({ ...baseInput, monthlyGoalHours: 0 })
+    ).toBeNull()
+  })
+
+  it('returns null when logged already meets or exceeds the goal', () => {
+    expect(
+      generateRecommendation({
+        ...baseInput,
+        loggedAdjustedMinutes: 50 * 60,
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when projected (logged + planned) already meets the goal', () => {
+    expect(
+      generateRecommendation({
+        ...baseInput,
+        loggedAdjustedMinutes: 30 * 60,
+        dayPlans: [
+          {
+            id: 'p1',
+            date: normalizeDateForStorage('2026-05-10'),
+            minutes: 20 * 60,
+          },
+        ],
+      })
+    ).toBeNull()
+  })
+
+  describe('shape selection', () => {
+    it("emits 'distributed' at softCap when the gap fits within remaining days at the sustainable pace", () => {
+      // Today=May 22, 10 eligible days. Gap = 20h. 20/4 = 5 slots × 4h.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-22'),
+        loggedAdjustedMinutes: 30 * 60,
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('distributed')
+      expect(rec!.headline.code).toBe('shape.distributed')
+      expect(rec!.rationale.code).toBe('spread_to_sustainable_pace')
+      expect(rec!.plans).toHaveLength(5)
+      expect(rec!.plans.every((p) => p.minutes === 4 * 60)).toBe(true)
+      const totalProposed = rec!.plans.reduce((s, p) => s + p.minutes, 0)
+      expect(totalProposed).toBe(20 * 60)
+      expect(rec!.headline.values.hours).toBe(4)
+      expect(rec!.headline.values.days).toBe(5)
+    })
+
+    it("emits 'recurring' when the gap exceeds sustainable pace but fits within stretch over a 14+ day horizon", () => {
+      // Today=May 18 (Mon) → 14 days remain. Goal 60h, logged 0 → gap 60h.
+      // 14×softCap=56 < 60 ≤ 84=14×stretchCap, days ≥ 14 ⇒ recurring.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-18'),
+        monthlyGoalHours: 60,
+        loggedAdjustedMinutes: 0,
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('recurring')
+      expect(rec!.headline.code).toBe('shape.recurring')
+      expect(rec!.rationale.code).toBe('pattern_fits_over_horizon')
+      expect(rec!.headline.values.weekdayList).toBeDefined()
+      expect(rec!.headline.values.weeks).toBeDefined()
+      const total = rec!.plans.reduce((s, p) => s + p.minutes, 0)
+      expect(total).toBeGreaterThanOrEqual(60 * 60)
+      const stretchMin = 6 * 60
+      expect(rec!.plans.every((p) => p.minutes <= stretchMin)).toBe(true)
+      expect(rec!.plans.every((p) => p.minutes % 60 === 0)).toBe(true)
+    })
+
+    it('excludes weekdays in excludedWeekdays from the eligible pool', () => {
+      // May 22, 2026 is a Friday. Excluding Fridays means the first eligible
+      // day must not be a Friday.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-22'),
+        loggedAdjustedMinutes: 44 * 60,
+        excludedWeekdays: [5],
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('concentrated')
+      expect(rec!.plans).toHaveLength(1)
+      expect(momentStoredDate(rec!.plans[0].date).day()).not.toBe(5)
+    })
+
+    it('prefers conversation days first and emits the layered_on_conversation_days rationale', () => {
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-22'),
+        loggedAdjustedMinutes: 30 * 60,
+        conversations: [
+          {
+            id: 'c1',
+            contact: { id: 'cn1' },
+            date: normalizeDateForStorage('2026-05-23'),
+            isBibleStudy: false,
+          },
+        ],
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('distributed')
+      expect(rec!.rationale.code).toBe('layered_on_conversation_days')
+      expect(
+        rec!.plans.some(
+          (p) => momentStoredDate(p.date).format('YYYY-MM-DD') === '2026-05-23'
+        )
+      ).toBe(true)
+    })
+
+    it('pushes the first proposed day back when the tiredness signal triggers', () => {
+      // 13h logged in the prior 3 days exceeds the default 12h threshold.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-22'),
+        loggedAdjustedMinutes: 44 * 60,
+        minutesLoggedInPriorDays: 13 * 60,
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('concentrated')
+      expect(rec!.rationale.code).toBe('rest_recommended_then_resume')
+      expect(
+        momentStoredDate(rec!.plans[0].date).isSameOrAfter(
+          momentStoredDate(normalizeDateForStorage('2026-05-23'))
+        )
+      ).toBe(true)
+    })
+
+    it('falls back to another viable shape when the primary has negative history', () => {
+      // Same inputs as the recurring/distributed boundary, but distributed
+      // has been dismissed ≥3 times. Engine should switch off distributed.
+      const now = Date.now()
+      const dismissed = (i: number) => ({
+        shape: 'distributed' as const,
+        action: 'dismissed' as const,
+        at: now - i,
+      })
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-18'),
+        monthlyGoalHours: 50,
+        loggedAdjustedMinutes: 30 * 60,
+        assistantHistory: [dismissed(1), dismissed(2), dismissed(3)],
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).not.toBe('distributed')
+    })
+
+    it('falls through to best-effort distributed at stretch cap when the goal is unreachable', () => {
+      // May 27 → 5 days remain. Gap 40h > 5*6h=30h ⇒ unreachable. Best-effort
+      // proposal: 5 days at stretch cap (6h).
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-27'),
+        monthlyGoalHours: 50,
+        loggedAdjustedMinutes: 10 * 60,
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('distributed')
+      expect(rec!.rationale.code).toBe('best_effort_unreachable_goal')
+      expect(rec!.plans).toHaveLength(5)
+      expect(rec!.plans.every((p) => p.minutes === 6 * 60)).toBe(true)
+    })
+
+    it('skips days that already have a DayPlan', () => {
+      // May 15 has an existing 1h plan. Engine must propose on a different day.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-15'),
+        loggedAdjustedMinutes: 44 * 60,
+        dayPlans: [
+          {
+            id: 'existing',
+            date: normalizeDateForStorage('2026-05-15'),
+            minutes: 60,
+          },
+        ],
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.plans).toHaveLength(1)
+      expect(
+        momentStoredDate(rec!.plans[0].date).format('YYYY-MM-DD')
+      ).not.toBe('2026-05-15')
+    })
+
+    it("emits 'concentrated' (single plan) when the gap is at or below 2× softCap", () => {
+      // Gap = 6h ≤ softCap*2 (8h). Today=May 15, no exclusions, no plans.
+      const rec = generateRecommendation({
+        ...baseInput,
+        today: normalizeDateForStorage('2026-05-15'),
+        loggedAdjustedMinutes: 44 * 60,
+      })
+
+      expect(rec).not.toBeNull()
+      expect(rec!.shape).toBe('concentrated')
+      expect(rec!.headline.code).toBe('shape.concentrated')
+      expect(rec!.rationale.code).toBe('small_gap_one_focused_plan')
+      expect(rec!.plans).toHaveLength(1)
+      expect(rec!.plans[0].minutes).toBe(6 * 60)
+      expect(rec!.headline.values.hours).toBe(6)
+    })
+  })
+})

--- a/src/__tests__/projectedTotal.test.ts
+++ b/src/__tests__/projectedTotal.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../lib/logger', () => import('./mocks/logger'))
+
+import { computeProjectedTotal } from '../lib/projectedTotal'
+import { normalizeDateForStorage } from '../lib/normalizeDate'
+import {
+  RecurringPlanFrequencies,
+  type DayPlan,
+  type RecurringPlan,
+} from '../types/serviceReport'
+
+const dayPlan = (isoDay: string, minutes: number): DayPlan => ({
+  id: isoDay,
+  date: normalizeDateForStorage(isoDay),
+  minutes,
+})
+
+const weeklyRecurring = (
+  id: string,
+  startIsoDay: string,
+  minutes: number,
+  endIsoDay?: string
+): RecurringPlan => ({
+  id,
+  startDate: normalizeDateForStorage(startIsoDay),
+  minutes,
+  recurrence: {
+    frequency: RecurringPlanFrequencies.WEEKLY,
+    interval: 1,
+    endDate: endIsoDay ? normalizeDateForStorage(endIsoDay) : null,
+  },
+})
+
+describe('computeProjectedTotal', () => {
+  it('returns logged_over_goal when logged minutes already exceed the goal', () => {
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: new Date('2026-05-15T12:00:00Z'),
+      goalMinutes: 50 * 60,
+      loggedAdjustedMinutes: 60 * 60,
+      dayPlans: [],
+      recurringPlans: [],
+      creditCapMinutes: 55 * 60,
+    })
+
+    expect(result.state).toBe('logged_over_goal')
+    expect(result.loggedMinutes).toBe(60 * 60)
+    expect(result.plannedMinutes).toBe(0)
+    expect(result.projectedMinutes).toBe(60 * 60)
+    expect(result.overMinutes).toBe(10 * 60)
+    expect(result.gapMinutes).toBe(0)
+  })
+
+  it('sums future day plans into plannedMinutes; ignores past and out-of-scope plans', () => {
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: normalizeDateForStorage('2026-05-15'),
+      goalMinutes: 50 * 60,
+      loggedAdjustedMinutes: 10 * 60,
+      dayPlans: [
+        dayPlan('2026-05-10', 90), // past day in scope month — already accounted for in loggedAdjustedMinutes
+        dayPlan('2026-05-20', 120), // future, in month
+        dayPlan('2026-05-25', 180), // future, in month
+        dayPlan('2026-06-05', 240), // next month, out of scope
+      ],
+      recurringPlans: [],
+      creditCapMinutes: 55 * 60,
+    })
+
+    expect(result.plannedMinutes).toBe(300)
+    expect(result.projectedMinutes).toBe(10 * 60 + 300)
+  })
+
+  it('sums recurring plan instances on future days within scope', () => {
+    // Weekly recurring starting Wed 2026-05-06, 90 min.
+    // May 2026 Wednesdays: 6, 13, 20, 27.
+    // From today=2026-05-15, future instances are 20 and 27 → 180 min.
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: normalizeDateForStorage('2026-05-15'),
+      goalMinutes: 50 * 60,
+      loggedAdjustedMinutes: 0,
+      dayPlans: [],
+      recurringPlans: [weeklyRecurring('rec-1', '2026-05-06', 90)],
+      creditCapMinutes: 55 * 60,
+    })
+
+    expect(result.plannedMinutes).toBe(180)
+  })
+
+  it('truncates projected at the credit cap when cap is non-null', () => {
+    // Logged 40h + 20h planned would project to 60h, but cap is 55h.
+    // Planned should be truncated so projected = cap.
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: normalizeDateForStorage('2026-05-15'),
+      goalMinutes: 50 * 60,
+      loggedAdjustedMinutes: 40 * 60,
+      dayPlans: [
+        dayPlan('2026-05-20', 10 * 60),
+        dayPlan('2026-05-25', 10 * 60),
+      ],
+      recurringPlans: [],
+      creditCapMinutes: 55 * 60,
+    })
+
+    expect(result.projectedMinutes).toBe(55 * 60)
+    expect(result.plannedMinutes).toBe(15 * 60)
+  })
+
+  it('day plan supersedes a recurring instance on the same day', () => {
+    // Recurring weekly Wed at 90 min, day plan 120 min on 2026-05-20 (a Wed).
+    // Future Wednesdays from 2026-05-15: 20 (day plan wins → 120), 27 (recurring → 90).
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: normalizeDateForStorage('2026-05-15'),
+      goalMinutes: 50 * 60,
+      loggedAdjustedMinutes: 0,
+      dayPlans: [dayPlan('2026-05-20', 120)],
+      recurringPlans: [weeklyRecurring('rec-1', '2026-05-06', 90)],
+      creditCapMinutes: null,
+    })
+
+    expect(result.plannedMinutes).toBe(120 + 90)
+  })
+
+  it('does not truncate projected when creditCapMinutes is null (unlimited)', () => {
+    const result = computeProjectedTotal({
+      scope: { kind: 'month', year: 2026, month: 4 },
+      today: normalizeDateForStorage('2026-05-15'),
+      goalMinutes: 100 * 60,
+      loggedAdjustedMinutes: 40 * 60,
+      dayPlans: [
+        dayPlan('2026-05-20', 10 * 60),
+        dayPlan('2026-05-25', 10 * 60),
+      ],
+      recurringPlans: [],
+      creditCapMinutes: null,
+    })
+
+    expect(result.projectedMinutes).toBe(60 * 60)
+    expect(result.plannedMinutes).toBe(20 * 60)
+  })
+
+  describe('state classification', () => {
+    const base = {
+      scope: { kind: 'month' as const, year: 2026, month: 4 },
+      goalMinutes: 50 * 60,
+      dayPlans: [],
+      recurringPlans: [],
+      creditCapMinutes: 55 * 60,
+    }
+
+    it("'empty' when logged and planned are both 0", () => {
+      const r = computeProjectedTotal({
+        ...base,
+        today: normalizeDateForStorage('2026-05-01'),
+        loggedAdjustedMinutes: 0,
+      })
+      expect(r.state).toBe('empty')
+    })
+
+    it("'logged_over_goal' when logged ≥ goal (takes precedence over plans)", () => {
+      const r = computeProjectedTotal({
+        ...base,
+        today: normalizeDateForStorage('2026-05-15'),
+        loggedAdjustedMinutes: 51 * 60,
+      })
+      expect(r.state).toBe('logged_over_goal')
+    })
+
+    it("'projected_over_goal' when logged < goal but projected ≥ goal", () => {
+      const r = computeProjectedTotal({
+        ...base,
+        today: normalizeDateForStorage('2026-05-15'),
+        loggedAdjustedMinutes: 30 * 60,
+        dayPlans: [
+          dayPlan('2026-05-20', 12 * 60),
+          dayPlan('2026-05-25', 13 * 60),
+        ],
+      })
+      expect(r.state).toBe('projected_over_goal')
+    })
+
+    it("'reachable_gap' when there is some progress and the remaining gap is fillable", () => {
+      // May 1 → 31 days remain, gap 40h ⇒ 1.3h/day, well under stretch cap.
+      const r = computeProjectedTotal({
+        ...base,
+        today: normalizeDateForStorage('2026-05-01'),
+        loggedAdjustedMinutes: 10 * 60,
+      })
+      expect(r.state).toBe('reachable_gap')
+    })
+
+    it("'unreachable_gap' when filling the gap would require more than the stretch cap per remaining day", () => {
+      // May 27 → 5 days remain (27–31). Gap 45h ⇒ 9h/day > 6h stretch cap.
+      const r = computeProjectedTotal({
+        ...base,
+        today: normalizeDateForStorage('2026-05-27'),
+        loggedAdjustedMinutes: 5 * 60,
+      })
+      expect(r.state).toBe('unreachable_gap')
+    })
+  })
+})

--- a/src/lib/assistantRecommendation.ts
+++ b/src/lib/assistantRecommendation.ts
@@ -1,0 +1,462 @@
+import moment from 'moment'
+import type { Conversation } from '../types/conversation'
+import type { DayPlan, RecurringPlan } from '../types/serviceReport'
+import { momentStoredDate, normalizeDateForStorage } from './normalizeDate'
+import {
+  getEffectiveMinutesForRecurringPlan,
+  getPlansIntersectingDay,
+} from './serviceReport'
+
+export type RecommendationShape = 'concentrated' | 'distributed' | 'recurring'
+
+export type ReasonCode =
+  | 'small_gap_one_focused_plan'
+  | 'spread_to_sustainable_pace'
+  | 'pattern_fits_over_horizon'
+  | 'stretched_for_short_horizon'
+  | 'rest_recommended_then_resume'
+  | 'layered_on_conversation_days'
+  | 'best_effort_unreachable_goal'
+
+export type AssistantAction = 'accepted' | 'dismissed'
+
+export type AssistantEvent = {
+  shape: RecommendationShape
+  action: AssistantAction
+  at: number
+}
+
+export type ProposedDayPlan = {
+  date: Date
+  minutes: number
+}
+
+export type Recommendation = {
+  shape: RecommendationShape
+  plans: ProposedDayPlan[]
+  headline: {
+    code: `shape.${RecommendationShape}`
+    values: {
+      hours?: number
+      days?: number
+      day?: string
+      weekdayList?: string
+      weeks?: number
+    }
+  }
+  rationale: {
+    code: ReasonCode
+    values: Record<string, number | string>
+  }
+}
+
+export type EngineParams = {
+  softMaxHoursPerDay: number
+  stretchMaxHoursPerDay: number
+  absoluteMaxHoursPerDay: number
+  maxConsecutiveStretchDays: number
+  minRestDayCadence: number
+  minChunkHours: number
+  tirednessLookbackDays: number
+  tirednessThresholdHours: number
+  recurringMinHorizonDays: number
+}
+
+export const DEFAULT_ENGINE_PARAMS: EngineParams = {
+  softMaxHoursPerDay: 4,
+  stretchMaxHoursPerDay: 6,
+  absoluteMaxHoursPerDay: 8,
+  maxConsecutiveStretchDays: 3,
+  minRestDayCadence: 1,
+  minChunkHours: 1,
+  tirednessLookbackDays: 3,
+  tirednessThresholdHours: 12,
+  recurringMinHorizonDays: 14,
+}
+
+export type EngineInput = {
+  year: number
+  month: number
+  today: Date
+  monthlyGoalHours: number
+  loggedAdjustedMinutes: number
+  dayPlans: DayPlan[]
+  recurringPlans: RecurringPlan[]
+  conversations: Conversation[]
+  excludedWeekdays: number[]
+  assistantHistory: AssistantEvent[]
+  /**
+   * Total minutes logged within `tirednessLookbackDays` of `today` (not
+   * including `today`). When this meets or exceeds the tiredness threshold the
+   * engine pushes the first proposed day back by one eligible day and emits the
+   * `rest_recommended_then_resume` rationale.
+   */
+  minutesLoggedInPriorDays?: number
+  params?: Partial<EngineParams>
+}
+
+const futurePlannedMinutes = (
+  year: number,
+  month: number,
+  today: Date,
+  dayPlans: DayPlan[],
+  recurringPlans: RecurringPlan[]
+): number => {
+  const start = moment.utc({ year, month, day: 1 })
+  const end = start.clone().endOf('month')
+  const todayDay = momentStoredDate(normalizeDateForStorage(today))
+  const cursor = (todayDay.isAfter(start, 'day') ? todayDay : start).clone()
+
+  const dayPlanByKey = new Map(
+    dayPlans.map((p) => [momentStoredDate(p.date).format('YYYY-MM-DD'), p])
+  )
+
+  let sum = 0
+  while (cursor.isSameOrBefore(end, 'day')) {
+    const key = cursor.format('YYYY-MM-DD')
+    const dp = dayPlanByKey.get(key)
+    if (dp) {
+      sum += dp.minutes
+    } else {
+      const recurringForDay = getPlansIntersectingDay(
+        cursor.toDate(),
+        recurringPlans
+      )
+      const highest = recurringForDay.reduce(
+        (max, plan) =>
+          Math.max(
+            max,
+            getEffectiveMinutesForRecurringPlan(plan, cursor.toDate())
+          ),
+        0
+      )
+      sum += highest
+    }
+    cursor.add(1, 'day')
+  }
+  return sum
+}
+
+const eligibleDays = (
+  year: number,
+  month: number,
+  today: Date,
+  excludedWeekdays: number[],
+  dayPlans: DayPlan[],
+  recurringPlans: RecurringPlan[]
+): moment.Moment[] => {
+  const start = moment.utc({ year, month, day: 1 })
+  const end = start.clone().endOf('month')
+  const todayDay = momentStoredDate(normalizeDateForStorage(today))
+  const cursor = (todayDay.isAfter(start, 'day') ? todayDay : start).clone()
+
+  const dayPlanKeys = new Set(
+    dayPlans.map((p) => momentStoredDate(p.date).format('YYYY-MM-DD'))
+  )
+
+  const days: moment.Moment[] = []
+  while (cursor.isSameOrBefore(end, 'day')) {
+    const isExcluded = excludedWeekdays.includes(cursor.day())
+    const key = cursor.format('YYYY-MM-DD')
+    const hasDayPlan = dayPlanKeys.has(key)
+    const hasRecurring =
+      getPlansIntersectingDay(cursor.toDate(), recurringPlans).length > 0
+    if (!isExcluded && !hasDayPlan && !hasRecurring) {
+      days.push(cursor.clone())
+    }
+    cursor.add(1, 'day')
+  }
+  return days
+}
+
+type BuildContext = {
+  gapMinutes: number
+  eligible: moment.Moment[]
+  params: EngineParams
+  conversationDayKeys: Set<string>
+  tirednessTriggered: boolean
+}
+
+const buildConcentrated = (ctx: BuildContext): Recommendation | null => {
+  const { gapMinutes, eligible, params, tirednessTriggered } = ctx
+  const absoluteCapMinutes = params.absoluteMaxHoursPerDay * 60
+  if (gapMinutes > absoluteCapMinutes) return null
+  const pool = tirednessTriggered ? eligible.slice(1) : eligible
+  if (pool.length === 0) return null
+  const day = pool[0]
+  const hours = Math.ceil(gapMinutes / 60)
+  return {
+    shape: 'concentrated',
+    plans: [{ date: day.toDate(), minutes: gapMinutes }],
+    headline: {
+      code: 'shape.concentrated',
+      values: { hours, day: day.format('YYYY-MM-DD') },
+    },
+    rationale: {
+      code: tirednessTriggered
+        ? 'rest_recommended_then_resume'
+        : 'small_gap_one_focused_plan',
+      values: { hours },
+    },
+  }
+}
+
+const buildDistributed = (ctx: BuildContext): Recommendation | null => {
+  const { gapMinutes, eligible, params, conversationDayKeys } = ctx
+  const softCapMinutes = params.softMaxHoursPerDay * 60
+  const stretchCapMinutes = params.stretchMaxHoursPerDay * 60
+  const fitsAtSoftCap = gapMinutes <= eligible.length * softCapMinutes
+
+  const slotMinutes = fitsAtSoftCap ? softCapMinutes : stretchCapMinutes
+  const hoursPerSlot = fitsAtSoftCap
+    ? params.softMaxHoursPerDay
+    : params.stretchMaxHoursPerDay
+  const nSlots = fitsAtSoftCap
+    ? Math.ceil(gapMinutes / slotMinutes)
+    : eligible.length
+
+  const conversationDays = eligible.filter((d) =>
+    conversationDayKeys.has(d.format('YYYY-MM-DD'))
+  )
+  const nonConversationDays = eligible.filter(
+    (d) => !conversationDayKeys.has(d.format('YYYY-MM-DD'))
+  )
+
+  const layered =
+    fitsAtSoftCap &&
+    conversationDays.length > 0 &&
+    conversationDays.length < nSlots
+      ? [
+          ...conversationDays.slice(0, nSlots),
+          ...pickEvenlySpacedDays(
+            nonConversationDays,
+            nSlots - Math.min(conversationDays.length, nSlots)
+          ),
+        ]
+      : fitsAtSoftCap && conversationDays.length >= nSlots
+        ? conversationDays.slice(0, nSlots)
+        : pickEvenlySpacedDays(eligible, nSlots)
+  const chosen = layered.slice().sort((a, b) => (a.isBefore(b) ? -1 : 1))
+
+  const layeredOnConversation =
+    fitsAtSoftCap &&
+    chosen.some((d) => conversationDayKeys.has(d.format('YYYY-MM-DD')))
+
+  const plans = chosen.map((d, i) => ({
+    date: d.toDate(),
+    minutes:
+      !fitsAtSoftCap || i < nSlots - 1
+        ? slotMinutes
+        : Math.max(slotMinutes, gapMinutes - slotMinutes * (nSlots - 1)),
+  }))
+
+  const rationaleCode: ReasonCode = !fitsAtSoftCap
+    ? 'best_effort_unreachable_goal'
+    : layeredOnConversation
+      ? 'layered_on_conversation_days'
+      : 'spread_to_sustainable_pace'
+
+  return {
+    shape: 'distributed',
+    plans,
+    headline: {
+      code: 'shape.distributed',
+      values: { hours: hoursPerSlot, days: nSlots },
+    },
+    rationale: {
+      code: rationaleCode,
+      values: { hours: hoursPerSlot, days: nSlots },
+    },
+  }
+}
+
+const buildRecurring = (ctx: BuildContext): Recommendation | null => {
+  const { gapMinutes, eligible, params } = ctx
+  const stretchCapMinutes = params.stretchMaxHoursPerDay * 60
+  const absoluteCapMinutes = params.absoluteMaxHoursPerDay * 60
+  if (eligible.length < params.recurringMinHorizonDays) return null
+  if (gapMinutes > eligible.length * stretchCapMinutes) return null
+
+  const weeks = Math.max(1, Math.ceil(eligible.length / 7))
+  const weekdaysPerWeek = Math.min(
+    7,
+    Math.max(2, Math.ceil(gapMinutes / (stretchCapMinutes * weeks)))
+  )
+  const perSessionHours = Math.ceil(gapMinutes / (weekdaysPerWeek * weeks) / 60)
+  const perSessionMinutes = perSessionHours * 60
+  if (perSessionMinutes > absoluteCapMinutes) return null
+
+  const seenWeekday = new Set<number>()
+  const patternWeekdays: number[] = []
+  for (const d of eligible) {
+    const wd = d.day()
+    if (seenWeekday.has(wd)) continue
+    seenWeekday.add(wd)
+    patternWeekdays.push(wd)
+    if (patternWeekdays.length >= weekdaysPerWeek) break
+  }
+
+  const plans: ProposedDayPlan[] = eligible
+    .filter((d) => patternWeekdays.includes(d.day()))
+    .map((d) => ({ date: d.toDate(), minutes: perSessionMinutes }))
+
+  const weekdayList = patternWeekdays
+    .slice()
+    .sort((a, b) => a - b)
+    .map((wd) => WEEKDAY_NAMES[wd])
+    .join(', ')
+
+  return {
+    shape: 'recurring',
+    plans,
+    headline: {
+      code: 'shape.recurring',
+      values: { hours: perSessionHours, weekdayList, weeks },
+    },
+    rationale: {
+      code: 'pattern_fits_over_horizon',
+      values: { hours: perSessionHours, weekdayList, weeks },
+    },
+  }
+}
+
+const HISTORY_LOOKBACK = 10
+const MIN_EVENTS_TO_TRUST = 3
+
+const hasNegativeHistory = (
+  history: AssistantEvent[],
+  shape: RecommendationShape
+): boolean => {
+  const events = history
+    .filter((e) => e.shape === shape)
+    .slice(-HISTORY_LOOKBACK)
+  if (events.length < MIN_EVENTS_TO_TRUST) return false
+  const accepted = events.filter((e) => e.action === 'accepted').length
+  const dismissed = events.filter((e) => e.action === 'dismissed').length
+  return dismissed > accepted
+}
+
+const decisionTreeShape = (
+  gapMinutes: number,
+  eligibleLen: number,
+  params: EngineParams
+): RecommendationShape => {
+  const softCapMinutes = params.softMaxHoursPerDay * 60
+  const stretchCapMinutes = params.stretchMaxHoursPerDay * 60
+  if (gapMinutes <= softCapMinutes * 2) return 'concentrated'
+  if (gapMinutes <= eligibleLen * softCapMinutes) return 'distributed'
+  if (
+    gapMinutes <= eligibleLen * stretchCapMinutes &&
+    eligibleLen >= params.recurringMinHorizonDays
+  )
+    return 'recurring'
+  return 'distributed'
+}
+
+export const generateRecommendation = (
+  input: EngineInput
+): Recommendation | null => {
+  const goalMinutes = input.monthlyGoalHours * 60
+  if (goalMinutes <= 0) return null
+
+  const logged = input.loggedAdjustedMinutes
+  if (logged >= goalMinutes) return null
+
+  const planned = futurePlannedMinutes(
+    input.year,
+    input.month,
+    input.today,
+    input.dayPlans,
+    input.recurringPlans
+  )
+  const projected = logged + planned
+  if (projected >= goalMinutes) return null
+
+  const params = { ...DEFAULT_ENGINE_PARAMS, ...(input.params ?? {}) }
+  const eligible = eligibleDays(
+    input.year,
+    input.month,
+    input.today,
+    input.excludedWeekdays,
+    input.dayPlans,
+    input.recurringPlans
+  )
+  if (eligible.length === 0) return null
+
+  const ctx: BuildContext = {
+    gapMinutes: goalMinutes - projected,
+    eligible,
+    params,
+    conversationDayKeys: collectConversationDayKeys(
+      input.conversations,
+      input.today
+    ),
+    tirednessTriggered:
+      (input.minutesLoggedInPriorDays ?? 0) >=
+      params.tirednessThresholdHours * 60,
+  }
+
+  const builders: Record<
+    RecommendationShape,
+    (c: BuildContext) => Recommendation | null
+  > = {
+    concentrated: buildConcentrated,
+    distributed: buildDistributed,
+    recurring: buildRecurring,
+  }
+
+  const primary = decisionTreeShape(ctx.gapMinutes, eligible.length, params)
+  const primaryRec = builders[primary](ctx)
+
+  const fallbacks: Recommendation[] = (
+    ['concentrated', 'distributed', 'recurring'] as RecommendationShape[]
+  )
+    .filter((s) => s !== primary)
+    .map((s) => builders[s](ctx))
+    .filter((r): r is Recommendation => r !== null)
+
+  if (
+    primaryRec &&
+    fallbacks.length > 0 &&
+    hasNegativeHistory(input.assistantHistory, primary)
+  ) {
+    return fallbacks[0]
+  }
+
+  return primaryRec ?? fallbacks[0] ?? null
+}
+
+const WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+const collectConversationDayKeys = (
+  conversations: Conversation[],
+  today: Date
+): Set<string> => {
+  const todayDay = momentStoredDate(normalizeDateForStorage(today))
+  const keys = new Set<string>()
+  for (const c of conversations) {
+    if (c.date) {
+      const d = momentStoredDate(c.date)
+      if (d.isSameOrAfter(todayDay, 'day')) keys.add(d.format('YYYY-MM-DD'))
+    }
+    const fu = c.followUp
+    if (fu && fu.date && fu.dismissed !== true) {
+      const d = momentStoredDate(fu.date)
+      if (d.isSameOrAfter(todayDay, 'day')) keys.add(d.format('YYYY-MM-DD'))
+    }
+  }
+  return keys
+}
+
+const pickEvenlySpacedDays = (
+  days: moment.Moment[],
+  n: number
+): moment.Moment[] => {
+  if (n >= days.length) return days.slice(0, n)
+  const step = days.length / n
+  const result: moment.Moment[] = []
+  for (let i = 0; i < n; i++) {
+    result.push(days[Math.floor(i * step)])
+  }
+  return result
+}

--- a/src/lib/projectedTotal.ts
+++ b/src/lib/projectedTotal.ts
@@ -1,0 +1,164 @@
+import type { DayPlan, RecurringPlan } from '../types/serviceReport'
+import { momentStoredDate, normalizeDateForStorage } from './normalizeDate'
+import {
+  getEffectiveMinutesForRecurringPlan,
+  getPlansIntersectingDay,
+} from './serviceReport'
+import moment from 'moment'
+
+export type ProjectedTotalScope =
+  | { kind: 'month'; year: number; month: number }
+  | { kind: 'serviceYear'; serviceYear: number }
+
+export type ProjectedTotalState =
+  | 'empty'
+  | 'logged_over_goal'
+  | 'projected_over_goal'
+  | 'reachable_gap'
+  | 'unreachable_gap'
+
+export type ProjectedTotalInput = {
+  scope: ProjectedTotalScope
+  today: Date
+  goalMinutes: number
+  loggedAdjustedMinutes: number
+  dayPlans: DayPlan[]
+  recurringPlans: RecurringPlan[]
+  /** Resolved credit cap in minutes, or null for unlimited. */
+  creditCapMinutes: number | null
+  excludedWeekdays?: number[]
+  params?: {
+    stretchMaxHoursPerDay?: number
+  }
+}
+
+export type ProjectedTotalResult = {
+  loggedMinutes: number
+  plannedMinutes: number
+  projectedMinutes: number
+  goalMinutes: number
+  state: ProjectedTotalState
+  gapMinutes: number
+  overMinutes: number
+}
+
+const periodBounds = (
+  scope: ProjectedTotalScope
+): { start: moment.Moment; end: moment.Moment } => {
+  if (scope.kind === 'month') {
+    const m = moment.utc({ year: scope.year, month: scope.month, day: 1 })
+    return { start: m.clone().startOf('month'), end: m.clone().endOf('month') }
+  }
+  const start = moment.utc({ year: scope.serviceYear, month: 8, day: 1 })
+  const end = moment
+    .utc({ year: scope.serviceYear + 1, month: 7, day: 1 })
+    .endOf('month')
+  return { start, end }
+}
+
+const futurePlannedMinutes = (
+  scope: ProjectedTotalScope,
+  today: Date,
+  dayPlans: DayPlan[],
+  recurringPlans: RecurringPlan[]
+): number => {
+  const { start, end } = periodBounds(scope)
+  const todayDay = momentStoredDate(normalizeDateForStorage(today))
+  const cursor = (todayDay.isAfter(start, 'day') ? todayDay : start).clone()
+
+  const dayPlanByKey = new Map(
+    dayPlans.map((p) => [momentStoredDate(p.date).format('YYYY-MM-DD'), p])
+  )
+
+  let sum = 0
+  while (cursor.isSameOrBefore(end, 'day')) {
+    const key = cursor.format('YYYY-MM-DD')
+    const dp = dayPlanByKey.get(key)
+    if (dp) {
+      sum += dp.minutes
+    } else {
+      const recurringForDay = getPlansIntersectingDay(
+        cursor.toDate(),
+        recurringPlans
+      )
+      const highest = recurringForDay.reduce(
+        (max, plan) =>
+          Math.max(
+            max,
+            getEffectiveMinutesForRecurringPlan(plan, cursor.toDate())
+          ),
+        0
+      )
+      sum += highest
+    }
+    cursor.add(1, 'day')
+  }
+  return sum
+}
+
+/** Stretch cap from the recommendation engine — used to decide reachability. */
+const DEFAULT_STRETCH_MAX_HOURS_PER_DAY = 6
+
+const eligibleRemainingDays = (
+  scope: ProjectedTotalScope,
+  today: Date,
+  excludedWeekdays: number[] = []
+): number => {
+  const { start, end } = periodBounds(scope)
+  const todayDay = momentStoredDate(normalizeDateForStorage(today))
+  const cursor = (todayDay.isAfter(start, 'day') ? todayDay : start).clone()
+
+  let count = 0
+  while (cursor.isSameOrBefore(end, 'day')) {
+    if (!excludedWeekdays.includes(cursor.day())) count++
+    cursor.add(1, 'day')
+  }
+  return count
+}
+
+export const computeProjectedTotal = (
+  input: ProjectedTotalInput
+): ProjectedTotalResult => {
+  const rawPlanned = futurePlannedMinutes(
+    input.scope,
+    input.today,
+    input.dayPlans,
+    input.recurringPlans
+  )
+
+  const logged = input.loggedAdjustedMinutes
+  const cap = input.creditCapMinutes
+  const planned =
+    cap !== null ? Math.max(0, Math.min(rawPlanned, cap - logged)) : rawPlanned
+  const projected = logged + planned
+  const goal = input.goalMinutes
+  const gap = Math.max(0, goal - projected)
+  const over = Math.max(0, projected - goal)
+
+  const state: ProjectedTotalState = (() => {
+    if (logged >= goal) return 'logged_over_goal'
+    if (projected >= goal) return 'projected_over_goal'
+    if (logged === 0 && planned === 0) return 'empty'
+    const stretchMinutesPerDay =
+      (input.params?.stretchMaxHoursPerDay ??
+        DEFAULT_STRETCH_MAX_HOURS_PER_DAY) * 60
+    const daysRemaining = eligibleRemainingDays(
+      input.scope,
+      input.today,
+      input.excludedWeekdays
+    )
+    const fillable =
+      daysRemaining > 0 && gap <= daysRemaining * stretchMinutesPerDay
+    return fillable ? 'reachable_gap' : 'unreachable_gap'
+  })()
+
+  return {
+    loggedMinutes: logged,
+    plannedMinutes: planned,
+    projectedMinutes: projected,
+    goalMinutes: goal,
+    state,
+    gapMinutes: gap,
+    overMinutes: over,
+  }
+}


### PR DESCRIPTION
## Summary

Step 1 of the [Projected Total + Assistant plan](../blob/development/docs/projected-total-plan.md) — drops the two pure modules the upcoming `ProjectedTotalCard` and `AssistantSection` will consume. No UI, no zustand, no i18n; all translation and state live in the UI layer per the plan.

- **`src/lib/projectedTotal.ts`** — `computeProjectedTotal()` returns `{ loggedMinutes, plannedMinutes, projectedMinutes, goalMinutes, state, gapMinutes, overMinutes }` with the 5-state classification (`empty` / `logged_over_goal` / `projected_over_goal` / `reachable_gap` / `unreachable_gap`). Supports `{ kind: 'month' }` and `{ kind: 'serviceYear' }` scopes, applies the credit cap to future planned minutes, and respects `excludedWeekdays` in the reachability heuristic.
- **`src/lib/assistantRecommendation.ts`** — `generateRecommendation()` returns the primary shape (`concentrated` / `distributed` / `recurring`) per the decision tree, plus:
  - Conversation-day preference (`layered_on_conversation_days` rationale when a conversation day receives a proposed plan)
  - Tiredness lookback (`minutesLoggedInPriorDays ≥ 12h` ⇒ first day pushed back, `rest_recommended_then_resume`)
  - History-aware fallback (primary's `dismissed > accepted` over last 10 events with ≥3 samples ⇒ swap to viable fallback; never suppresses the only viable option)
  - Best-effort distributed at stretch cap when the goal is unreachable (`best_effort_unreachable_goal`)
  - Tunable via `params?: Partial<EngineParams>`

## Notes for reviewers

- **Credit-cap math on projection** is the literal reading of the plan: when `creditCapMinutes` is non-null, planned is truncated so `projected ≤ cap`. If the real intent is "cap only the credit-tagged portion," the math here is over-aggressive — callers can pass `creditCapMinutes: null` to opt out per-call.
- **`empty` precedence** over `reachable_gap`/`unreachable_gap` per the spec — even mid-month with a mathematically unreachable goal, if `logged + planned === 0` the state is `empty`. The Assistant section is still gated on `empty`-as-reachable-math per the plan's note.
- **`minutesLoggedInPriorDays`** is an optional input field I added — the original `EngineInput` shape gave only an aggregate `loggedAdjustedMinutes`, with no way to evaluate tiredness. Callers compute the prior-`tirednessLookbackDays`-day sum and pass it in.

## Test plan

- [x] 23 unit tests across two suites (`projectedTotal.test.ts`, `assistantRecommendation.test.ts`), built TDD-style — 16 red-green cycles, one behavior per cycle
- [x] `pnpm run testFinal` — 471 tests green
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean

## Deferred (the other 6 steps in the plan)

These are mostly mechanical UI work and benefit more from running the app than from unit tests — left for follow-up sessions:

- Data model (`DayPlan.source`, new preference fields)
- `ProjectedTotalCard` + Year list tweak + `MonthSummary` → `MonthReport` rename
- `AssistantSection` + `AssistantPreviewSheet` + history wiring
- `AvailabilityOnboardingSheet` + `CalendarDay` dim
- i18n keys