### PR TITLE
feat(assistant): data model for projected-total Assistant

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "browser": true,
     "es2021": true,

--- a/src/__tests__/assistantDataModel.test.ts
+++ b/src/__tests__/assistantDataModel.test.ts
@@ -1,0 +1,84 @@
+import moment from 'moment'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/logger', () => import('./mocks/logger'))
+vi.mock('../stores/mmkv', () => import('./mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('./mocks/asyncStorage')
+)
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { version: '1.0.0' } },
+}))
+vi.mock('expo-device', () => ({ DeviceType: { TABLET: 2 }, deviceType: 1 }))
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'en-US' }],
+}))
+vi.mock('../lib/locales', () => ({
+  default: { t: (k: string) => k },
+}))
+vi.mock('../shaders/registry', () => ({
+  DEFAULT_SHADER_ID: 'holographic',
+}))
+
+import useServiceReport from '../stores/serviceReport'
+import {
+  NON_SYNCABLE_PREFERENCE_KEYS,
+  usePreferences,
+} from '../stores/preferences'
+
+describe('DayPlan.source field', () => {
+  beforeEach(() => {
+    useServiceReport.setState({ dayPlans: [] })
+  })
+
+  it('addDayPlan persists source="recommendation" so the engine-inserted plans are distinguishable from manual ones', () => {
+    const { addDayPlan } = useServiceReport.getState()
+    addDayPlan({
+      id: 'rec-1',
+      date: moment('2026-05-15').toDate(),
+      minutes: 120,
+      source: 'recommendation',
+    })
+    const stored = useServiceReport
+      .getState()
+      .dayPlans.find((p) => p.id === 'rec-1')
+    expect(stored?.source).toBe('recommendation')
+  })
+
+  it("updateDayPlan can flip an existing plan's source — e.g. user edits a recommended plan and it becomes manual", () => {
+    const { addDayPlan, updateDayPlan } = useServiceReport.getState()
+    addDayPlan({
+      id: 'rec-2',
+      date: moment('2026-05-16').toDate(),
+      minutes: 60,
+      source: 'recommendation',
+    })
+    updateDayPlan({ id: 'rec-2', source: 'manual' })
+    const stored = useServiceReport
+      .getState()
+      .dayPlans.find((p) => p.id === 'rec-2')
+    expect(stored?.source).toBe('manual')
+  })
+})
+
+describe('Assistant preference defaults', () => {
+  it('exposes the new assistant-related defaults so consumer code reads safe starting values without optional-chaining', () => {
+    const state = usePreferences.getState()
+    expect(state.excludedWeekdays).toEqual([])
+    expect(state.hasSeenAvailabilityOnboarding).toBe(false)
+    expect(state.assistantHistory).toEqual([])
+    expect(state.hasDismissedRecommendationHash).toBeUndefined()
+  })
+
+  it('keeps the new assistant preferences syncable — they describe user intent and should follow the user across devices', () => {
+    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('excludedWeekdays')).toBe(false)
+    expect(
+      NON_SYNCABLE_PREFERENCE_KEYS.has('hasSeenAvailabilityOnboarding')
+    ).toBe(false)
+    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('assistantHistory')).toBe(false)
+    expect(
+      NON_SYNCABLE_PREFERENCE_KEYS.has('hasDismissedRecommendationHash')
+    ).toBe(false)
+  })
+})

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -108,6 +108,19 @@ export type ServiceReportTag = {
   credit: boolean
 }
 
+/**
+ * A single record in `assistantHistory` — written when the user accepts or
+ * dismisses a recommendation from the Projected Total card's Assistant. The
+ * engine reads this list to back off from shapes the user has rejected
+ * repeatedly (see `docs/projected-total-plan.md` → "Assistant history
+ * weighting").
+ */
+export type AssistantEvent = {
+  shape: 'concentrated' | 'distributed' | 'recurring'
+  action: 'accepted' | 'dismissed'
+  at: number
+}
+
 export const widgetContactSortOptions = [
   'longestContacted',
   'recentConversation',
@@ -646,6 +659,34 @@ export const PREFERENCE_DEFAULTS = {
    * the same tip on another.
    */
   seenTipIds: [] as string[],
+  /**
+   * Weekdays (0 = Sunday … 6 = Saturday) that the Projected Total Assistant
+   * should treat as unavailable when generating recommended day plans. Empty by
+   * default — no exclusion. The user can override per-day even when a weekday
+   * is excluded; the calendar dims excluded weekdays as a hint.
+   */
+  excludedWeekdays: [] as number[],
+  /**
+   * One-shot flag for the Availability Onboarding sheet, which surfaces just in
+   * time the first time a recommendation would render. Flipped true when the
+   * user saves OR skips the sheet, so we never re-prompt automatically — but
+   * Settings retains an entry point to revisit.
+   */
+  hasSeenAvailabilityOnboarding: false,
+  /**
+   * FIFO ring buffer (cap 10) of the user's accept/dismiss actions on Assistant
+   * recommendations. The engine reads this to back off from
+   * repeatedly-dismissed shapes. Insert/eviction happens in the action that
+   * records the event — this store only owns the default empty list.
+   */
+  assistantHistory: [] as AssistantEvent[],
+  /**
+   * Hash of the engine inputs (logged, plans, conversations, excluded weekdays)
+   * at the time the user last dismissed the Assistant card. While this hash
+   * matches the current inputs, the Assistant section stays hidden —
+   * re-emerging once any input changes.
+   */
+  hasDismissedRecommendationHash: undefined as string | undefined,
 }
 
 /**

--- a/src/types/serviceReport.ts
+++ b/src/types/serviceReport.ts
@@ -80,6 +80,12 @@ export type DayPlan = {
    * remote IDs as opaque (they cannot be cancelled from another device).
    */
   notifications?: import('./conversation').Notification[]
+  /**
+   * Origin of this plan. `'recommendation'` is stamped by the Assistant when
+   * the engine inserts plans on the user's behalf; treated as `'manual'` when
+   * unset, including for all plans that predate this field.
+   */
+  source?: 'manual' | 'recommendation'
   /** Epoch ms of the most recent change. Used for iCloud merge. */
   updatedAt?: number
 }


### PR DESCRIPTION
## Why

Step 2 of [docs/projected-total-plan.md](docs/projected-total-plan.md) — lay down the types and persisted preference defaults the recommendation engine + Assistant UI will read in later steps. No behavior changes ship in this PR; the field and prefs exist purely to be written/read by code that lands next.

## What changed

- `DayPlan.source?: 'manual' | 'recommendation'` — lets the engine tag plans it inserts so undo and history rules can target them without affecting user-authored plans. Unset = manual, covering all historical records ([src/types/serviceReport.ts:82](src/types/serviceReport.ts:82)).
- `AssistantEvent` type + 4 synced preferences in [src/stores/preferences.ts](src/stores/preferences.ts): `excludedWeekdays`, `hasSeenAvailabilityOnboarding`, `assistantHistory`, `hasDismissedRecommendationHash`.
- New unit tests in [src/__tests__/assistantDataModel.test.ts](src/__tests__/assistantDataModel.test.ts) — round-trip the `source` field through the store and verify the new preference defaults + sync-eligibility.

**Bundled tooling fix**: `chore(eslint): mark config as root` — adds `"root": true` to `.eslintrc.json` so ESLint stops climbing past it. Without this, `pnpm lint` (and therefore the pre-push hook) blows up in any worktree checked out under `.claude/worktrees/...` because two `@typescript-eslint` plugin installs are reachable from one config walk. Unrelated to the feature but blocking the push in nested worktrees — easier to land here than to spin up a separate one-line PR.

## How

No persist version bump. All new fields are optional with safe defaults (`[]`, `false`, `undefined`), so existing stored state hydrates cleanly. The alternative — a v3 migration — would only have inserted those same defaults, which Zustand's persist layer already does for missing keys.

`AssistantEvent` is co-located in `preferences.ts` rather than a new types file: it's only ever shaped data that the preferences store carries, and the engine reads it transitively from `usePreferences`. A standalone file felt premature for a 3-field type.

## Risks

- Touches a persisted Zustand shape (preferences + service report). Mitigated by additive-only fields with defaults — no migration needed and rollback is "remove the fields," no data loss.
- `source` participates in iCloud last-writer-wins merge by virtue of being a `DayPlan` field; existing `mergeById` spreads all fields so this works without changes to [src/lib/sync/merge.ts](src/lib/sync/merge.ts).