### PR TITLE
refactor: rename isPioneer to isInFullTimeService

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -76,11 +76,11 @@ Sources: `src/constants/publisher.ts`, `src/stores/preferences.ts`, `src/lib/pub
 
 ### Single seam: `derivePublisherCapabilities`
 
-`src/lib/publisherCapabilities.ts` = **only** place role behavior encoded. React code reads via `usePublisher()` hook; pure callers use `derivePublisherCapabilities` or helpers (`getEntryMode`, `isPioneer`, `tracksPioneerStartDate`, `effectiveHasAnnualGoal`, `creditCapMinutesFor`).
+`src/lib/publisherCapabilities.ts` = **only** place role behavior encoded. React code reads via `usePublisher()` hook; pure callers use `derivePublisherCapabilities` or helpers (`getEntryMode`, `isInFullTimeService`, `tracksPioneerStartDate`, `effectiveHasAnnualGoal`, `creditCapMinutesFor`).
 
 ### Rules
 
-1. **Never branch on publisher string.** `if (publisher === 'specialPioneer')` wrong — add/use capability flag (`entryMode`, `hasAnnualGoal`, `isPioneer`, `tracksPioneerStartDate`, `showsTimer`, `showsYearTabs`, `creditCapMinutes`, `hasUnlimitedCreditDefault`).
+1. **Never branch on publisher string.** `if (publisher === 'specialPioneer')` wrong — add/use capability flag (`entryMode`, `hasAnnualGoal`, `isInFullTimeService`, `tracksPioneerStartDate`, `showsTimer`, `showsYearTabs`, `creditCapMinutes`, `hasUnlimitedCreditDefault`).
 2. **Capabilities fold in user overrides** (`userSpecifiedHasAnnualGoal`, `overrideCreditLimit`, `milestoneOverrides`). Read resolved value; don't re-derive.
 3. **Gate UI on capabilities, not role.** E.g. timer on `showsTimer`, year tab on `showsYearTabs`, start-date row on `tracksPioneerStartDate`, entry mode on `entryMode`.
 4. **`publisher` role = checkbox mode** — anything assuming hours breaks. Check `entryMode` / `hasAnnualGoal` / `showsTimer` first.

--- a/src/__tests__/publisherCapabilities.test.ts
+++ b/src/__tests__/publisherCapabilities.test.ts
@@ -133,17 +133,17 @@ describe('derivePublisherCapabilities', () => {
     })
   })
 
-  describe('isPioneer', () => {
-    it('is true for regular, special, and circuit-overseer pioneers', () => {
-      expect(derive('regularPioneer').isPioneer).toBe(true)
-      expect(derive('specialPioneer').isPioneer).toBe(true)
-      expect(derive('circuitOverseer').isPioneer).toBe(true)
+  describe('isInFullTimeService', () => {
+    it('is true for regular pioneer, special pioneer, and circuit overseer', () => {
+      expect(derive('regularPioneer').isInFullTimeService).toBe(true)
+      expect(derive('specialPioneer').isInFullTimeService).toBe(true)
+      expect(derive('circuitOverseer').isInFullTimeService).toBe(true)
     })
 
-    it('is false for non-pioneer roles', () => {
-      expect(derive('publisher').isPioneer).toBe(false)
-      expect(derive('regularAuxiliary').isPioneer).toBe(false)
-      expect(derive('custom').isPioneer).toBe(false)
+    it('is false for roles outside full-time service', () => {
+      expect(derive('publisher').isInFullTimeService).toBe(false)
+      expect(derive('regularAuxiliary').isInFullTimeService).toBe(false)
+      expect(derive('custom').isInFullTimeService).toBe(false)
     })
   })
 

--- a/src/features/onboarding/components/steps/YourPlanPreview.tsx
+++ b/src/features/onboarding/components/steps/YourPlanPreview.tsx
@@ -38,7 +38,7 @@ import useTheme from '@/contexts/theme'
 import i18n, { TranslationKey } from '@/lib/locales'
 import { OnboardingIntent, usePreferences } from '@/stores/preferences'
 import usePublisher from '@/hooks/usePublisher'
-import { getEntryMode, isPioneer } from '@/lib/publisherCapabilities'
+import { getEntryMode, isInFullTimeService } from '@/lib/publisherCapabilities'
 import { useMarkerColors } from '@/hooks/useMarkerColors'
 import { Theme } from '@/types/theme'
 import type { DayPlan, ServiceReport } from '@/types/serviceReport'
@@ -1144,7 +1144,7 @@ const YourPlanPreview = ({ goBack, goNext }: Props) => {
   const publisherLabel = i18n.t(publisher)
   const entryMode = getEntryMode(publisher)
 
-  const pioneering = isPioneer(publisher) && pioneerStartDate
+  const pioneering = isInFullTimeService(publisher) && pioneerStartDate
   const pioneeringLine = pioneering
     ? i18n.t('yourPlanPioneeringSince', {
         date: moment(pioneerStartDate).format('MMM YYYY'),

--- a/src/features/profile/components/ProfileCard.tsx
+++ b/src/features/profile/components/ProfileCard.tsx
@@ -106,7 +106,7 @@ const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
   } = usePreferences()
   const {
     type: publisher,
-    isPioneer,
+    isInFullTimeService,
     name: trimmedName,
     hasName,
   } = usePublisher()
@@ -185,7 +185,7 @@ const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
     : i18n.t('profileGreetingNoName')
 
   const tenure: Tenure = (() => {
-    if (isPioneer && pioneerStartDate) {
+    if (isInFullTimeService && pioneerStartDate) {
       const tone: TenureTone =
         publisher === 'specialPioneer'
           ? 'specialPioneer'

--- a/src/lib/publisherCapabilities.ts
+++ b/src/lib/publisherCapabilities.ts
@@ -21,7 +21,13 @@ export type PublisherCapabilities = {
   monthlyGoalHours: number
   annualGoalHours: number
   hasAnnualGoal: boolean
-  isPioneer: boolean
+  /**
+   * Whether this role is part of **Full-Time Service** — the umbrella covering
+   * regular pioneer, special pioneer, and circuit overseer. These three roles
+   * share a single tenure clock. A circuit overseer is not called a "pioneer"
+   * in JW vernacular, so prefer this flag over any "isPioneer"-style naming.
+   */
+  isInFullTimeService: boolean
   /**
    * Whether this role has a pioneering/auxiliary tenure start date the app
    * displays (e.g. "regular pioneer since 2018"). False for plain publishers
@@ -33,17 +39,17 @@ export type PublisherCapabilities = {
   milestones: number[]
 }
 
-const PIONEER_PUBLISHERS: ReadonlyArray<Publisher> = [
+const FULL_TIME_SERVICE_PUBLISHERS: ReadonlyArray<Publisher> = [
   'regularPioneer',
   'specialPioneer',
   'circuitOverseer',
 ]
 
-export const isPioneer = (publisher: Publisher): boolean =>
-  PIONEER_PUBLISHERS.includes(publisher)
+export const isInFullTimeService = (publisher: Publisher): boolean =>
+  FULL_TIME_SERVICE_PUBLISHERS.includes(publisher)
 
 export const tracksPioneerStartDate = (publisher: Publisher): boolean =>
-  isPioneer(publisher) || publisher === 'regularAuxiliary'
+  isInFullTimeService(publisher) || publisher === 'regularAuxiliary'
 
 /**
  * Whether this role enters service time as a "did I go out?" checkbox (the
@@ -153,7 +159,7 @@ export const derivePublisherCapabilities = (
       publisher,
       userSpecifiedHasAnnualGoal
     ),
-    isPioneer: isPioneer(publisher),
+    isInFullTimeService: isInFullTimeService(publisher),
     tracksPioneerStartDate: tracksPioneerStartDate(publisher),
     showsTimer: hoursMode,
     showsYearTabs: hoursMode,


### PR DESCRIPTION
## Why

The `isPioneer` capability flag was `true` for `regularPioneer`, `specialPioneer`, and `circuitOverseer` — but a circuit overseer is not called a pioneer in JW vernacular. The canonical glossary umbrella for that grouping is **Full-Time Service** (see `CONTEXT.md`), which exactly matches the predicate. No call site needed the strict pioneer-but-not-CO semantic, so this is a mechanical rename: `PublisherCapabilities.isPioneer` → `isInFullTimeService`, the helper export, and `PIONEER_PUBLISHERS` → `FULL_TIME_SERVICE_PUBLISHERS`. Publisher role values themselves are unchanged.