### PR TITLE
refactor: rename excludedWeekdays/meetingWeekdays → offDays/meetingDays

### DIFF
--- a/src/__tests__/assistantDataModel.test.ts
+++ b/src/__tests__/assistantDataModel.test.ts
@@ -65,16 +65,16 @@ describe('DayPlan.source field', () => {
 describe('Assistant preference defaults', () => {
   it('exposes the new assistant-related defaults so consumer code reads safe starting values without optional-chaining', () => {
     const state = usePreferences.getState()
-    expect(state.excludedWeekdays).toEqual([])
-    expect(state.meetingWeekdays).toEqual([])
+    expect(state.offDays).toEqual([])
+    expect(state.meetingDays).toEqual([])
     expect(state.hasSeenAvailabilityOnboarding).toBe(false)
     expect(state.assistantHistory).toEqual([])
     expect(state.hasDismissedRecommendationHash).toBeUndefined()
   })
 
   it('keeps the new assistant preferences syncable — they describe user intent and should follow the user across devices', () => {
-    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('excludedWeekdays')).toBe(false)
-    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('meetingWeekdays')).toBe(false)
+    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('offDays')).toBe(false)
+    expect(NON_SYNCABLE_PREFERENCE_KEYS.has('meetingDays')).toBe(false)
     expect(
       NON_SYNCABLE_PREFERENCE_KEYS.has('hasSeenAvailabilityOnboarding')
     ).toBe(false)

--- a/src/__tests__/assistantRecommendation.test.ts
+++ b/src/__tests__/assistantRecommendation.test.ts
@@ -16,8 +16,8 @@ const baseInput = {
   dayPlans: [] as DayPlan[],
   recurringPlans: [] as RecurringPlan[],
   conversations: [] as Conversation[],
-  excludedWeekdays: [] as number[],
-  meetingWeekdays: [] as number[],
+  offDays: [] as number[],
+  meetingDays: [] as number[],
   assistantHistory: [],
 }
 
@@ -152,14 +152,14 @@ describe('generateRecommendation', () => {
       expect(rec!.plans.every((p) => p.minutes % 60 === 0)).toBe(true)
     })
 
-    it('excludes weekdays in excludedWeekdays from the eligible pool', () => {
-      // May 22, 2026 is a Friday. Excluding Fridays means the first eligible
-      // day must not be a Friday.
+    it('excludes weekdays in offDays from the eligible pool', () => {
+      // May 22, 2026 is a Friday. Marking Friday as an Off Day means the first
+      // eligible day must not be a Friday.
       const rec = generateRecommendation({
         ...baseInput,
         today: normalizeDateForStorage('2026-05-22'),
         loggedAdjustedMinutes: 44 * 60,
-        excludedWeekdays: [5],
+        offDays: [5],
       })
 
       expect(rec).not.toBeNull()
@@ -303,7 +303,7 @@ describe('generateRecommendation', () => {
         ...baseInput,
         today: normalizeDateForStorage('2026-05-22'),
         loggedAdjustedMinutes: 44 * 60,
-        meetingWeekdays: [5],
+        meetingDays: [5],
       })
 
       expect(rec).not.toBeNull()
@@ -312,14 +312,14 @@ describe('generateRecommendation', () => {
       expect(momentStoredDate(rec!.plans[0].date).day()).not.toBe(5)
     })
 
-    it('keeps distributed picks off meeting weekdays when non-meeting capacity is sufficient', () => {
+    it('keeps distributed picks off meeting days when non-meeting capacity is sufficient', () => {
       // 20h gap, lots of eligible days, mark Wed (3) + Sun (0) as meeting
       // days. Engine should pick only non-meeting days.
       const rec = generateRecommendation({
         ...baseInput,
         today: normalizeDateForStorage('2026-05-10'),
         loggedAdjustedMinutes: 30 * 60,
-        meetingWeekdays: [0, 3],
+        meetingDays: [0, 3],
       })
 
       expect(rec).not.toBeNull()
@@ -330,15 +330,15 @@ describe('generateRecommendation', () => {
       }
     })
 
-    it('treats excluded as winning over meeting when both flags overlap', () => {
-      // Friday (5) is both excluded and a meeting day. The engine should
+    it('treats Off Day as winning over Meeting Day when both flags overlap', () => {
+      // Friday (5) is both an Off Day and a Meeting Day. The engine should
       // exclude Friday entirely (no proposal on a Friday at any cap).
       const rec = generateRecommendation({
         ...baseInput,
         today: normalizeDateForStorage('2026-05-22'),
         loggedAdjustedMinutes: 44 * 60,
-        excludedWeekdays: [5],
-        meetingWeekdays: [5],
+        offDays: [5],
+        meetingDays: [5],
       })
 
       expect(rec).not.toBeNull()
@@ -356,7 +356,7 @@ describe('generateRecommendation', () => {
         ...baseInput,
         today: normalizeDateForStorage('2026-05-28'),
         loggedAdjustedMinutes: 47 * 60,
-        meetingWeekdays: [0, 4, 5, 6],
+        meetingDays: [0, 4, 5, 6],
       })
 
       expect(rec).not.toBeNull()
@@ -375,7 +375,7 @@ describe('generateRecommendation', () => {
         ...baseInput,
         today: normalizeDateForStorage('2026-05-28'),
         loggedAdjustedMinutes: 44 * 60,
-        meetingWeekdays: [0, 4, 5, 6],
+        meetingDays: [0, 4, 5, 6],
       })
 
       expect(rec).not.toBeNull()
@@ -386,7 +386,7 @@ describe('generateRecommendation', () => {
       }
     })
 
-    it('does not pick a recurring pattern that lands on meeting weekdays', () => {
+    it('does not pick a recurring pattern that lands on meeting days', () => {
       // Recurring scenario from the existing test (May 18, gap 60h ≥ 14d
       // horizon). Mark Mon (1) as a meeting day. The pattern should skip Mon.
       const rec = generateRecommendation({
@@ -394,7 +394,7 @@ describe('generateRecommendation', () => {
         today: normalizeDateForStorage('2026-05-18'),
         monthlyGoalHours: 60,
         loggedAdjustedMinutes: 0,
-        meetingWeekdays: [1],
+        meetingDays: [1],
       })
 
       expect(rec).not.toBeNull()

--- a/src/__tests__/assistantState.test.ts
+++ b/src/__tests__/assistantState.test.ts
@@ -16,8 +16,8 @@ describe('computeRecommendationInputsHash', () => {
     dayPlanFingerprints: ['2026-05-15:120', '2026-05-20:120'],
     recurringPlanFingerprints: ['rp-1:weekly'],
     conversationDayKeys: ['2026-05-18'],
-    excludedWeekdays: [0, 6] as number[],
-    meetingWeekdays: [3] as number[],
+    offDays: [0, 6] as number[],
+    meetingDays: [3] as number[],
   }
 
   it('is stable for the same inputs', () => {
@@ -41,24 +41,24 @@ describe('computeRecommendationInputsHash', () => {
     )
   })
 
-  it('changes when excluded weekdays change', () => {
+  it('changes when off days change', () => {
     expect(computeRecommendationInputsHash(base)).not.toBe(
-      computeRecommendationInputsHash({ ...base, excludedWeekdays: [0] })
+      computeRecommendationInputsHash({ ...base, offDays: [0] })
     )
   })
 
-  it('changes when meeting weekdays change', () => {
+  it('changes when meeting days change', () => {
     expect(computeRecommendationInputsHash(base)).not.toBe(
-      computeRecommendationInputsHash({ ...base, meetingWeekdays: [2] })
+      computeRecommendationInputsHash({ ...base, meetingDays: [2] })
     )
   })
 
-  it('hashes the same when meetingWeekdays is omitted vs set to []', () => {
-    const { meetingWeekdays: _omit, ...withoutMeeting } = base
+  it('hashes the same when meetingDays is omitted vs set to []', () => {
+    const { meetingDays: _omit, ...withoutMeeting } = base
     expect(computeRecommendationInputsHash(withoutMeeting)).toBe(
       computeRecommendationInputsHash({
         ...withoutMeeting,
-        meetingWeekdays: [],
+        meetingDays: [],
       })
     )
   })

--- a/src/__tests__/preferencesPersistMigration.test.ts
+++ b/src/__tests__/preferencesPersistMigration.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { version: '1.0.0' } },
+}))
+vi.mock('expo-device', () => ({ DeviceType: { TABLET: 2 }, deviceType: 1 }))
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'en-US' }],
+}))
+vi.mock('@/lib/locales', () => ({
+  default: { t: (k: string) => k },
+}))
+vi.mock('@/shaders/registry', () => ({
+  DEFAULT_SHADER_ID: 'holographic',
+}))
+
+import { migratePreferencesPersistedState } from '@/stores/preferences'
+
+describe('preferences persist migrate v0 → v1 (excluded/meeting weekdays → offDays/meetingDays)', () => {
+  it('renames excludedWeekdays → offDays preserving the array', () => {
+    const v0State = {
+      excludedWeekdays: [0, 6],
+      meetingWeekdays: [3],
+    }
+
+    const migrated = migratePreferencesPersistedState(v0State, 0)
+
+    expect(migrated.offDays).toEqual([0, 6])
+    expect(migrated.meetingDays).toEqual([3])
+    expect(migrated).not.toHaveProperty('excludedWeekdays')
+    expect(migrated).not.toHaveProperty('meetingWeekdays')
+  })
+
+  it('also migrates the preferenceUpdatedAt timestamp map so iCloud LWW still works after rename', () => {
+    const v0State = {
+      excludedWeekdays: [1],
+      meetingWeekdays: [3],
+      preferenceUpdatedAt: {
+        excludedWeekdays: 1700000000000,
+        meetingWeekdays: 1700000001000,
+        otherKey: 1700000002000,
+      },
+    }
+
+    const migrated = migratePreferencesPersistedState(v0State, 0)
+
+    expect(migrated.preferenceUpdatedAt.offDays).toBe(1700000000000)
+    expect(migrated.preferenceUpdatedAt.meetingDays).toBe(1700000001000)
+    expect(migrated.preferenceUpdatedAt.otherKey).toBe(1700000002000)
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('excludedWeekdays')
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('meetingWeekdays')
+  })
+
+  it('fills sensible defaults when the old fields were missing entirely', () => {
+    const migrated = migratePreferencesPersistedState({}, 0)
+
+    expect(migrated).not.toHaveProperty('excludedWeekdays')
+    expect(migrated).not.toHaveProperty('meetingWeekdays')
+    // Defaults are filled at hydration time by combine(), so absence here is
+    // fine — the migration just shouldn't *introduce* the legacy fields.
+  })
+
+  it('is idempotent — re-running on an already-v1 state is a no-op', () => {
+    const v0State = {
+      excludedWeekdays: [0, 6],
+      meetingWeekdays: [3],
+    }
+    const v1State = migratePreferencesPersistedState(v0State, 0)
+    const v1Again = migratePreferencesPersistedState(v1State, 1)
+
+    expect(JSON.stringify(v1Again)).toEqual(JSON.stringify(v1State))
+  })
+
+  it('does not overwrite an existing offDays value if both old and new exist (new wins)', () => {
+    // Defensive: if a downgrade-then-upgrade somehow leaves both keys present,
+    // the migrated/new name should win. Old gets dropped.
+    const mixedState = {
+      excludedWeekdays: [1, 2],
+      offDays: [4, 5],
+      meetingWeekdays: [3],
+      meetingDays: [6],
+    }
+
+    const migrated = migratePreferencesPersistedState(mixedState, 0)
+
+    expect(migrated.offDays).toEqual([4, 5])
+    expect(migrated.meetingDays).toEqual([6])
+    expect(migrated).not.toHaveProperty('excludedWeekdays')
+    expect(migrated).not.toHaveProperty('meetingWeekdays')
+  })
+})

--- a/src/app/sync/__tests__/payloadFieldRenames.test.ts
+++ b/src/app/sync/__tests__/payloadFieldRenames.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeLegacyPayloadFieldNames } from '@/app/sync/payloadFieldRenames'
+
+const makePayload = (
+  values: Record<string, unknown>,
+  updatedAt: Record<string, number>
+) => ({
+  version: 1,
+  preferencesStore: { values, updatedAt },
+})
+
+describe('normalizeLegacyPayloadFieldNames', () => {
+  it('renames excludedWeekdays → offDays and meetingWeekdays → meetingDays', () => {
+    const d = makePayload(
+      { excludedWeekdays: [0, 6], meetingWeekdays: [3] },
+      { excludedWeekdays: 1700000001000, meetingWeekdays: 1700000002000 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.offDays).toEqual([0, 6])
+    expect(d.preferencesStore.values.meetingDays).toEqual([3])
+    expect(d.preferencesStore.values).not.toHaveProperty('excludedWeekdays')
+    expect(d.preferencesStore.values).not.toHaveProperty('meetingWeekdays')
+    expect(d.preferencesStore.updatedAt.offDays).toBe(1700000001000)
+    expect(d.preferencesStore.updatedAt.meetingDays).toBe(1700000002000)
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('excludedWeekdays')
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('meetingWeekdays')
+  })
+
+  it('leaves a payload without the legacy keys untouched', () => {
+    const d = makePayload(
+      { offDays: [1], meetingDays: [2] },
+      { offDays: 1700000005000, meetingDays: 1700000006000 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.offDays).toEqual([1])
+    expect(d.preferencesStore.values.meetingDays).toEqual([2])
+    expect(d.preferencesStore.updatedAt.offDays).toBe(1700000005000)
+    expect(d.preferencesStore.updatedAt.meetingDays).toBe(1700000006000)
+  })
+
+  it('prefers the new key when a payload somehow carries both', () => {
+    const d = makePayload(
+      { excludedWeekdays: [9], offDays: [4, 5] },
+      { excludedWeekdays: 1, offDays: 2 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.offDays).toEqual([4, 5])
+    expect(d.preferencesStore.values).not.toHaveProperty('excludedWeekdays')
+    expect(d.preferencesStore.updatedAt.offDays).toBe(2)
+  })
+
+  it('is idempotent', () => {
+    const d = makePayload(
+      { excludedWeekdays: [0], meetingWeekdays: [3] },
+      { excludedWeekdays: 1, meetingWeekdays: 2 }
+    )
+    normalizeLegacyPayloadFieldNames(d)
+    const snapshot = JSON.stringify(d)
+    normalizeLegacyPayloadFieldNames(d)
+    expect(JSON.stringify(d)).toBe(snapshot)
+  })
+
+  it('no-ops when preferencesStore is missing or malformed', () => {
+    const d1 = {} as Record<string, unknown>
+    const d2 = { preferencesStore: null } as Record<string, unknown>
+    const d3 = {
+      preferencesStore: { values: null, updatedAt: null },
+    } as Record<string, unknown>
+    expect(() => normalizeLegacyPayloadFieldNames(d1)).not.toThrow()
+    expect(() => normalizeLegacyPayloadFieldNames(d2)).not.toThrow()
+    expect(() => normalizeLegacyPayloadFieldNames(d3)).not.toThrow()
+  })
+})

--- a/src/app/sync/payload.ts
+++ b/src/app/sync/payload.ts
@@ -127,10 +127,17 @@ export function buildPayload(args: {
   }
 }
 
+import { normalizeLegacyPayloadFieldNames } from '@/app/sync/payloadFieldRenames'
+
 /**
  * Parses and validates a JSON-encoded payload. Returns null if the JSON is
  * malformed or the shape is unrecognizable — the caller should treat that as
  * "leave local state alone, surface a sync error in settings."
+ *
+ * Also translates legacy preference field names from older app versions so the
+ * merge step sees the canonical schema. The wire payload version
+ * (`PAYLOAD_VERSION`) is intentionally NOT bumped for pure renames — receivers
+ * normalize on read. See `payloadFieldRenames.ts` for the rename table.
  */
 export function parsePayload(json: string): SyncPayload | null {
   let data: unknown
@@ -147,5 +154,6 @@ export function parsePayload(json: string): SyncPayload | null {
   if (!d.contactStore || !d.conversationStore || !d.serviceReportStore) {
     return null
   }
+  normalizeLegacyPayloadFieldNames(d)
   return d as SyncPayload
 }

--- a/src/app/sync/payloadFieldRenames.ts
+++ b/src/app/sync/payloadFieldRenames.ts
@@ -1,0 +1,39 @@
+/**
+ * Wire-payload field-name normalisations applied on read so receivers see the
+ * canonical schema regardless of which app version wrote the payload. Used by
+ * `parsePayload` immediately after JSON validation and before any merge step.
+ *
+ * Why this lives outside `payload.ts`: keeping it as a tiny pure module (no
+ * store / RN / Expo imports) makes it cheap to unit-test in isolation — the
+ * full `parsePayload` module pulls in every zustand store which transitively
+ * pulls native modules vitest can't load.
+ *
+ * Rename table (legacy → canonical):
+ *
+ * - `preferencesStore.values.excludedWeekdays` → `offDays`
+ * - `preferencesStore.values.meetingWeekdays` → `meetingDays`
+ * - The matching keys inside `preferencesStore.updatedAt`
+ *
+ * New name wins if both keys somehow coexist on the wire (defensive); the
+ * legacy key is always dropped.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normalizeLegacyPayloadFieldNames(d: any): void {
+  const prefs = d?.preferencesStore
+  if (!prefs || typeof prefs !== 'object') return
+  renameKey(prefs.values, 'excludedWeekdays', 'offDays')
+  renameKey(prefs.values, 'meetingWeekdays', 'meetingDays')
+  renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
+  renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
+}
+
+function renameKey(
+  obj: Record<string, unknown> | undefined,
+  from: string,
+  to: string
+): void {
+  if (!obj || typeof obj !== 'object') return
+  if (!(from in obj)) return
+  if (!(to in obj)) obj[to] = obj[from]
+  delete obj[from]
+}

--- a/src/components/AssistantSection.tsx
+++ b/src/components/AssistantSection.tsx
@@ -68,8 +68,8 @@ const AssistantSection = ({
   const theme = useTheme()
   const navigation = useNavigation<RootStackNavigation>()
   const {
-    excludedWeekdays,
-    meetingWeekdays,
+    offDays,
+    meetingDays,
     assistantHistory,
     hasDismissedRecommendationHash,
     hasSeenAvailabilityOnboarding,
@@ -110,8 +110,8 @@ const AssistantSection = ({
       dayPlans,
       recurringPlans,
       conversations,
-      excludedWeekdays,
-      meetingWeekdays,
+      offDays,
+      meetingDays,
       assistantHistory,
       minutesLoggedInPriorDays,
     })
@@ -125,8 +125,8 @@ const AssistantSection = ({
     dayPlans,
     recurringPlans,
     conversations,
-    excludedWeekdays,
-    meetingWeekdays,
+    offDays,
+    meetingDays,
     assistantHistory,
     minutesLoggedInPriorDays,
   ])
@@ -153,16 +153,16 @@ const AssistantSection = ({
               : null,
           ])
           .filter((s): s is string => s !== null),
-        excludedWeekdays,
-        meetingWeekdays,
+        offDays,
+        meetingDays,
       }),
     [
       loggedAdjustedMinutes,
       dayPlans,
       recurringPlans,
       conversations,
-      excludedWeekdays,
-      meetingWeekdays,
+      offDays,
+      meetingDays,
     ]
   )
 

--- a/src/components/AvailabilityOnboardingSheet.tsx
+++ b/src/components/AvailabilityOnboardingSheet.tsx
@@ -43,22 +43,22 @@ const AvailabilityOnboardingSheet = ({
 }: Props) => {
   const theme = useTheme()
   const {
-    excludedWeekdays,
-    meetingWeekdays,
-    setExcludedWeekdays,
-    setMeetingWeekdays,
+    offDays,
+    meetingDays,
+    setOffDays,
+    setMeetingDays,
     setHasSeenAvailabilityOnboarding,
   } = usePreferences()
 
-  const [selected, setSelected] = useState<number[]>(excludedWeekdays)
-  const [meetings, setMeetings] = useState<number[]>(meetingWeekdays)
+  const [selected, setSelected] = useState<number[]>(offDays)
+  const [meetings, setMeetings] = useState<number[]>(meetingDays)
 
   useEffect(() => {
     if (open) {
-      setSelected(excludedWeekdays)
-      setMeetings(meetingWeekdays)
+      setSelected(offDays)
+      setMeetings(meetingDays)
     }
-  }, [open, excludedWeekdays, meetingWeekdays])
+  }, [open, offDays, meetingDays])
 
   const toggle = useCallback((index: number) => {
     setSelected((prev) =>
@@ -67,23 +67,23 @@ const AvailabilityOnboardingSheet = ({
   }, [])
 
   const toggleMeeting = useCallback((index: number) => {
-    // A weekday can be both a work day and a meeting day — the engine resolves
-    // overlap (excluded wins) so the UI doesn't need to enforce it.
+    // A day can be both an Off Day and a Meeting Day — the engine resolves
+    // overlap (Off Day wins) so the UI doesn't need to enforce it.
     setMeetings((prev) =>
       prev.includes(index) ? prev.filter((d) => d !== index) : [...prev, index]
     )
   }, [])
 
   const handleSave = useCallback(() => {
-    setExcludedWeekdays(selected.slice().sort((a, b) => a - b))
-    setMeetingWeekdays(meetings.slice().sort((a, b) => a - b))
+    setOffDays(selected.slice().sort((a, b) => a - b))
+    setMeetingDays(meetings.slice().sort((a, b) => a - b))
     if (markSeenOnDismiss) setHasSeenAvailabilityOnboarding(true)
     onOpenChange(false)
   }, [
     selected,
     meetings,
-    setExcludedWeekdays,
-    setMeetingWeekdays,
+    setOffDays,
+    setMeetingDays,
     markSeenOnDismiss,
     setHasSeenAvailabilityOnboarding,
     onOpenChange,

--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -334,11 +334,11 @@ const CalendarDay = (
   const recurringPlans = props.recurringPlansOverride ?? store.recurringPlans
   const translateY = useSharedValue(0)
   const theme = useTheme()
-  const { howToAddPlan, removeHint, excludedWeekdays } = usePreferences()
+  const { howToAddPlan, removeHint, offDays } = usePreferences()
 
   const isToday = moment().isSame(props.date?.dateString, 'day')
-  const isExcludedWeekday = props.date?.dateString
-    ? excludedWeekdays.includes(moment(props.date.dateString).day())
+  const isOffDay = props.date?.dateString
+    ? offDays.includes(moment(props.date.dateString).day())
     : false
 
   const startAnimation = useCallback(() => {
@@ -399,8 +399,7 @@ const CalendarDay = (
           }
         }}
         style={{
-          opacity:
-            props.state === 'disabled' ? 0.4 : isExcludedWeekday ? 0.55 : 1,
+          opacity: props.state === 'disabled' ? 0.4 : isOffDay ? 0.55 : 1,
         }}
       >
         {(dayPlan ?? !!recurringPlansForDay?.length) ? (

--- a/src/features/settings/components/preferences-sections/PlansPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/PlansPreferencesSection.tsx
@@ -20,25 +20,25 @@ const PlansPreferencesSection = () => {
   const {
     planNotificationOffset,
     planAlwaysNotify,
-    excludedWeekdays,
-    meetingWeekdays,
+    offDays,
+    meetingDays,
     set,
   } = usePreferences()
   const [availabilityOpen, setAvailabilityOpen] = useState(false)
   const availabilitySummary =
-    excludedWeekdays.length === 0 && meetingWeekdays.length === 0
+    offDays.length === 0 && meetingDays.length === 0
       ? i18n.t('availability.settingsValueAllAvailable')
-      : meetingWeekdays.length === 0
-        ? i18n.t('availability.settingsValueNExcluded', {
-            count: excludedWeekdays.length,
+      : meetingDays.length === 0
+        ? i18n.t('availability.settingsValueNOff', {
+            count: offDays.length,
           })
-        : excludedWeekdays.length === 0
+        : offDays.length === 0
           ? i18n.t('availability.settingsValueNMeeting', {
-              count: meetingWeekdays.length,
+              count: meetingDays.length,
             })
-          : i18n.t('availability.settingsValueNExcludedNMeeting', {
-              excluded: excludedWeekdays.length,
-              meeting: meetingWeekdays.length,
+          : i18n.t('availability.settingsValueNOffNMeeting', {
+              off: offDays.length,
+              meeting: meetingDays.length,
             })
 
   const currentAmount =

--- a/src/lib/assistantRecommendation.ts
+++ b/src/lib/assistantRecommendation.ts
@@ -93,15 +93,20 @@ export type EngineInput = {
   dayPlans: DayPlan[]
   recurringPlans: RecurringPlan[]
   conversations: Conversation[]
-  excludedWeekdays: number[]
   /**
-   * Weekdays the user has Kingdom Hall meetings on. The engine prefers
-   * non-meeting days, and when it has to use a meeting day it caps the proposed
-   * session at the meeting-day cap. A weekday present in both
-   * `excludedWeekdays` and `meetingWeekdays` is treated as excluded (stricter
-   * wins).
+   * Off Days the user wants the engine to treat as a hard exclusion when
+   * generating a recommendation. Today stored as weekday numbers (0–6); the
+   * concept covers any day.
    */
-  meetingWeekdays?: number[]
+  offDays: number[]
+  /**
+   * Meeting Days — days the user attends a Kingdom Hall meeting. The engine
+   * prefers non-meeting days, and when it has to use a meeting day it caps the
+   * proposed session at the meeting-day cap. A day present in both `offDays`
+   * and `meetingDays` is treated as an Off Day (stricter wins). Today stored as
+   * weekday numbers (0–6).
+   */
+  meetingDays?: number[]
   assistantHistory: AssistantEvent[]
   /**
    * Total minutes logged within `tirednessLookbackDays` of `today` (not
@@ -169,8 +174,8 @@ const eligibleDays = (
   year: number,
   month: number,
   today: Date,
-  excludedWeekdays: number[],
-  meetingWeekdays: number[],
+  offDays: number[],
+  meetingDays: number[],
   dayPlans: DayPlan[],
   recurringPlans: RecurringPlan[]
 ): EligibleDay[] => {
@@ -186,18 +191,18 @@ const eligibleDays = (
   const days: EligibleDay[] = []
   while (cursor.isSameOrBefore(end, 'day')) {
     const weekday = cursor.day()
-    const isExcluded = excludedWeekdays.includes(weekday)
+    const isOffDay = offDays.includes(weekday)
     const key = cursor.format('YYYY-MM-DD')
     const hasDayPlan = dayPlanKeys.has(key)
     const hasRecurring =
       getPlansIntersectingDay(cursor.toDate(), recurringPlans).length > 0
-    if (!isExcluded && !hasDayPlan && !hasRecurring) {
+    if (!isOffDay && !hasDayPlan && !hasRecurring) {
       days.push({
         m: cursor.clone(),
-        // Excluded already filtered out — meeting flag only matters for the
-        // days that survived. This is also why `meetingWeekdays ∩ excludedWeekdays`
-        // never reaches the engine: excluded wins by virtue of filtering first.
-        isMeetingDay: meetingWeekdays.includes(weekday),
+        // Off Days already filtered out — meeting flag only matters for the
+        // days that survived. This is also why `meetingDays ∩ offDays` never
+        // reaches the engine: Off Day wins by virtue of filtering first.
+        isMeetingDay: meetingDays.includes(weekday),
       })
     }
     cursor.add(1, 'day')
@@ -587,8 +592,8 @@ export const generateRecommendation = (
     input.year,
     input.month,
     input.today,
-    input.excludedWeekdays,
-    input.meetingWeekdays ?? [],
+    input.offDays,
+    input.meetingDays ?? [],
     input.dayPlans,
     input.recurringPlans
   )

--- a/src/lib/assistantState.ts
+++ b/src/lib/assistantState.ts
@@ -5,8 +5,8 @@ export type RecommendationInputsHashInput = {
   dayPlanFingerprints: string[]
   recurringPlanFingerprints: string[]
   conversationDayKeys: string[]
-  excludedWeekdays: number[]
-  meetingWeekdays?: number[]
+  offDays: number[]
+  meetingDays?: number[]
 }
 
 /**
@@ -24,11 +24,11 @@ export const computeRecommendationInputsHash = (
     input.dayPlanFingerprints.slice().sort().join('|'),
     input.recurringPlanFingerprints.slice().sort().join('|'),
     input.conversationDayKeys.slice().sort().join('|'),
-    input.excludedWeekdays
+    input.offDays
       .slice()
       .sort((a, b) => a - b)
       .join(','),
-    (input.meetingWeekdays ?? [])
+    (input.meetingDays ?? [])
       .slice()
       .sort((a, b) => a - b)
       .join(','),

--- a/src/lib/projectedTotal.ts
+++ b/src/lib/projectedTotal.ts
@@ -26,7 +26,11 @@ export type ProjectedTotalInput = {
   recurringPlans: RecurringPlan[]
   /** Resolved credit cap in minutes, or null for unlimited. */
   creditCapMinutes: number | null
-  excludedWeekdays?: number[]
+  /**
+   * Off Days the user marked — passed through so the "is the gap reachable?"
+   * heuristic only counts days the user is actually willing to go out.
+   */
+  offDays?: number[]
   params?: {
     stretchMaxHoursPerDay?: number
   }
@@ -102,7 +106,7 @@ const DEFAULT_STRETCH_MAX_HOURS_PER_DAY = 6
 const eligibleRemainingDays = (
   scope: ProjectedTotalScope,
   today: Date,
-  excludedWeekdays: number[] = []
+  offDays: number[] = []
 ): number => {
   const { start, end } = periodBounds(scope)
   const todayDay = momentStoredDate(normalizeDateForStorage(today))
@@ -110,7 +114,7 @@ const eligibleRemainingDays = (
 
   let count = 0
   while (cursor.isSameOrBefore(end, 'day')) {
-    if (!excludedWeekdays.includes(cursor.day())) count++
+    if (!offDays.includes(cursor.day())) count++
     cursor.add(1, 'day')
   }
   return count
@@ -145,7 +149,7 @@ export const computeProjectedTotal = (
     const daysRemaining = eligibleRemainingDays(
       input.scope,
       input.today,
-      input.excludedWeekdays
+      input.offDays
     )
     const fillable =
       daysRemaining > 0 && gap <= daysRemaining * stretchMinutesPerDay

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1768,16 +1768,16 @@
   "faq_whatsNew_a": "Settings → What's New shows a summary of recent changes. Major updates also pop up a one-time \"What's new\" sheet the first time you open the app after updating.",
   "availability": {
     "settingsRow": "Availability",
-    "settingsRowDescription": "Tell the Assistant which weekdays are your work days and which are Kingdom Hall meeting days. It uses both to shape its recommendations.",
+    "settingsRowDescription": "Tell the Assistant which days are your off days and which are Kingdom Hall meeting days. It uses both to shape its recommendations.",
     "settingsValueAllAvailable": "All days available",
-    "settingsValueNExcluded": "{{count}} work days",
+    "settingsValueNOff": "{{count}} off days",
     "settingsValueNMeeting": "{{count}} meeting days",
-    "settingsValueNExcludedNMeeting": "{{excluded}} work · {{meeting}} meeting",
+    "settingsValueNOffNMeeting": "{{off}} off · {{meeting}} meeting",
     "onboarding": {
-      "title": "Which days are your work days?",
-      "body": "Tap the weekdays you work — or any weekdays the Assistant should skip entirely. We won't propose service on these days. You can change this anytime in Settings.",
+      "title": "Which days are your off days?",
+      "body": "Tap the days the Assistant should skip entirely. We won't propose service on these days. You can change this anytime in Settings.",
       "meetingDaysTitle": "Kingdom Hall meeting days",
-      "meetingDaysBody": "Tap the weekdays you have meetings. The Assistant will keep those days lighter so you have time to attend and prepare.",
+      "meetingDaysBody": "Tap the days you have meetings. The Assistant will keep those days lighter so you have time to attend and prepare.",
       "save": "Save",
       "skip": "Skip"
     },
@@ -1796,7 +1796,7 @@
     "settingsA11y": "Plan preferences",
     "intro": {
       "title": "Get a recommended plan",
-      "body": "Tell the Assistant your work days and meeting days, and it'll suggest the strongest plan to reach your goal.",
+      "body": "Tell the Assistant your off days and meeting days, and it'll suggest the strongest plan to reach your goal.",
       "cta": "Set up Assistant"
     },
     "headline": {

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -660,21 +660,23 @@ export const PREFERENCE_DEFAULTS = {
    */
   seenTipIds: [] as string[],
   /**
-   * Weekdays (0 = Sunday … 6 = Saturday) that the Projected Total Assistant
-   * should treat as unavailable when generating recommended day plans. Empty by
-   * default — no exclusion. The user can override per-day even when a weekday
-   * is excluded; the calendar dims excluded weekdays as a hint.
+   * Off Days the user wants the Assistant to treat as a hard exclusion when
+   * generating recommended day plans. Empty by default — no exclusion. Today
+   * stored as weekday numbers (0 = Sunday … 6 = Saturday); the concept covers
+   * any day. The user can override per-day even when a weekday is in this set;
+   * the calendar dims Off Days as a hint.
    */
-  excludedWeekdays: [] as number[],
+  offDays: [] as number[],
   /**
-   * Weekdays (0 = Sunday … 6 = Saturday) the user has Kingdom Hall meetings on.
-   * The Assistant treats these as "busier" days: it prefers other days first
-   * and, when a meeting day is used, caps the proposed session at a lower
-   * number of hours so the user still has time to study and attend. A weekday
-   * listed in both `excludedWeekdays` and `meetingWeekdays` is treated as
-   * excluded — the stricter rule wins.
+   * Meeting Days — days the user attends a Kingdom Hall meeting. The Assistant
+   * treats these as "busier" days: it prefers other days first and, when a
+   * meeting day is used, caps the proposed session at a lower number of hours
+   * so the user still has time to study and attend. A day listed in both
+   * `offDays` and `meetingDays` is treated as an Off Day — the stricter rule
+   * wins. Today stored as weekday numbers (0 = Sunday … 6 = Saturday); the
+   * concept covers any day.
    */
-  meetingWeekdays: [] as number[],
+  meetingDays: [] as number[],
   /**
    * One-shot flag for the Availability Onboarding sheet, which surfaces just in
    * time the first time a recommendation would render. Flipped true when the
@@ -690,9 +692,9 @@ export const PREFERENCE_DEFAULTS = {
    */
   assistantHistory: [] as AssistantEvent[],
   /**
-   * Hash of the engine inputs (logged, plans, conversations, excluded weekdays)
-   * at the time the user last dismissed the Assistant card. While this hash
-   * matches the current inputs, the Assistant section stays hidden —
+   * Hash of the engine inputs (logged, plans, conversations, off days, meeting
+   * days) at the time the user last dismissed the Assistant card. While this
+   * hash matches the current inputs, the Assistant section stays hidden —
    * re-emerging once any input changes.
    */
   hasDismissedRecommendationHash: undefined as string | undefined,
@@ -746,6 +748,67 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
   'dismissedMilestoneRevealOnce',
   'seenFoundingSupporterReveal',
 ])
+
+/**
+ * Persisted-shape migrations for the preferences store.
+ *
+ * Versioning history:
+ *
+ * - V0 → v1: rename `excludedWeekdays` → `offDays`, `meetingWeekdays` →
+ *   `meetingDays`. The underlying data (a set of weekday numbers 0–6) is
+ *   identical; only the field names change. We also migrate the
+ *   `preferenceUpdatedAt` timestamp map so iCloud last-writer-wins continues to
+ *   work across the rename. The legacy fields are dropped from disk.
+ *
+ * Exported for unit testing. Idempotent — re-running on an already-migrated
+ * blob is a no-op.
+ */
+export const migratePreferencesPersistedState = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  persistedState: any,
+  version: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => {
+  let next = persistedState
+  if (version < 1) {
+    next = migrateExcludedMeetingWeekdaysToOffMeetingDays(next)
+  }
+  return next
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const migrateExcludedMeetingWeekdaysToOffMeetingDays = (state: any): any => {
+  if (!state || typeof state !== 'object') return state
+  const { excludedWeekdays, meetingWeekdays, ...rest } = state
+  const next = { ...rest }
+  // If the new key already carries a value, it wins (defensive — a
+  // downgrade-then-upgrade could leave both keys present).
+  if (excludedWeekdays !== undefined && next.offDays === undefined) {
+    next.offDays = excludedWeekdays
+  }
+  if (meetingWeekdays !== undefined && next.meetingDays === undefined) {
+    next.meetingDays = meetingWeekdays
+  }
+  if (
+    next.preferenceUpdatedAt &&
+    typeof next.preferenceUpdatedAt === 'object'
+  ) {
+    const {
+      excludedWeekdays: excludedTs,
+      meetingWeekdays: meetingTs,
+      ...restTs
+    } = next.preferenceUpdatedAt
+    const nextTs: Record<string, number> = { ...restTs }
+    if (excludedTs !== undefined && nextTs.offDays === undefined) {
+      nextTs.offDays = excludedTs
+    }
+    if (meetingTs !== undefined && nextTs.meetingDays === undefined) {
+      nextTs.meetingDays = meetingTs
+    }
+    next.preferenceUpdatedAt = nextTs
+  }
+  return next
+}
 
 export const usePreferences = create(
   persist(
@@ -865,10 +928,8 @@ export const usePreferences = create(
             next[next.length - 1] = event
             return { assistantHistory: next }
           }),
-        setExcludedWeekdays: (excludedWeekdays: number[]) =>
-          set({ excludedWeekdays }),
-        setMeetingWeekdays: (meetingWeekdays: number[]) =>
-          set({ meetingWeekdays }),
+        setOffDays: (offDays: number[]) => set({ offDays }),
+        setMeetingDays: (meetingDays: number[]) => set({ meetingDays }),
         setHasSeenAvailabilityOnboarding: (value: boolean) =>
           set({ hasSeenAvailabilityOnboarding: value }),
         setHasDismissedRecommendationHash: (value: string | undefined) =>
@@ -880,6 +941,9 @@ export const usePreferences = create(
       storage: createJSONStorage(() =>
         hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
       ),
+      version: 1,
+      migrate: (persistedState, version) =>
+        migratePreferencesPersistedState(persistedState, version),
     }
   )
 )


### PR DESCRIPTION
## Why

Align preferences + assistant input shape with the canonical glossary terms (**Off Day**, **Meeting Day**) so storage can later broaden beyond weekday numbers without another rename. Field semantics are unchanged: an Off Day is a hard exclusion the Assistant will not propose Plans for; a Meeting Day applies a tighter per-day cap; when a day is both, Off Day wins.

## How

- Renames at every layer: preferences store (`offDays`, `meetingDays`), Zustand actions (`setOffDays`, `setMeetingDays`), assistant `EngineInput` + fingerprint, settings UI, calendar dimming hint, en-US i18n keys (`settingsValueNOff`, `settingsValueNOffNMeeting`).
- New file: `src/app/sync/payloadFieldRenames.ts` — tiny pure helper invoked by `parsePayload` to translate legacy keys from older devices on read. Lives outside `payload.ts` so it can be unit-tested without the full store/RN chain. `PAYLOAD_VERSION` intentionally stays at 1; pure renames don't need a wire bump when receivers normalise.
- MMKV-persisted shape gets a versioned migration: store `version: 0 → 1`, exported `migratePreferencesPersistedState` renames both the field values and the matching `preferenceUpdatedAt` timestamp entries (so iCloud LWW keeps working across the rename), then drops the legacy keys. Idempotent.
- `EngineParams.meetingDay*` cap names left as-is — they already use the canonical "Meeting Day" prefix and just describe the caps applied to meeting days.

Key files: `src/stores/preferences.ts:752` (migration), `src/lib/assistantRecommendation.ts:96` (engine input), `src/lib/assistantState.ts:7` (fingerprint), `src/app/sync/payloadFieldRenames.ts` (sync legacy translation).

## Risks

- **Persisted-shape change.** Existing installs upgrade from v0 → v1; the migration is exercised by `src/__tests__/preferencesPersistMigration.test.ts` (5 cases including idempotency + both-keys-present). If the migrate callback ever fails to run, the user's off-days + meeting-days defaults silently reset to `[]` because the v0 keys no longer match defaults — but the new fields' defaults still come from `PREFERENCE_DEFAULTS`, so the worst case is a forgotten Off Day list, not a corrupt state.
- **iCloud sync compat.** A v0 device pushing a payload would carry `excludedWeekdays`/`meetingWeekdays`. v1 devices translate those on read via `normalizeLegacyPayloadFieldNames` so the merge sees canonical names. A v0 device pulling a v1 payload would see `offDays`/`meetingDays` it doesn't recognise and ignore them (it can't accept what it can't merge) — same outcome as today when a newer schema field reaches an older device.
- **Re-arm hash.** The recommendation-input fingerprint changes shape, so users who had a dismissed recommendation will see the Assistant re-emerge once. Expected, matches the refactor-log note.

## Tests required

- Manually verify on a device upgraded from the prior version that Off Days + Meeting Days survive the migration (Settings → Plans → Availability summary still shows the previously-saved selection).
- Manually verify iCloud sync still mirrors the renamed fields cross-device: edit Off Days on Device A with iCloud sync on, confirm Device B reflects the change. Optionally, in a controlled test, push a payload with the legacy `excludedWeekdays` field from a stub and confirm a v1 device pulls it as `offDays`.