### PR TITLE
refactor: rename preferences.publisher → preferences.role

### DIFF
--- a/docs/refactor-log.md
+++ b/docs/refactor-log.md
@@ -6,11 +6,6 @@ Refactors flagged during glossary/domain clarifications. Each item is something 
 
 ### From CONTEXT.md alignment
 
-- **Preferences field rename: `publisher` → `role`**
-  Source: [`src/stores/preferences.ts:228`](src/stores/preferences.ts:228) (`publisher: 'publisher' as Publisher`).
-  Why: Glossary defines **Publisher** = the role. A field of type `Publisher` named `publisher` reads awkwardly. `role` matches the glossary directly.
-  Touches: preferences store, MMKV persisted shape (migration needed), every consumer of `usePreferences().publisher`, the `setPublisher` action, iCloud sync field mapping.
-
 - **Hook split: introduce `useUser()` for user-profile reads**
   Why: `usePublisher()` currently mixes role/capability data with user-profile data (name, displayName). Glossary now separates **User** (the human) from **Publisher** (their role). A `useUser()` hook for profile-only reads keeps the two concerns clean; `usePublisher()` stays as the role+capabilities accessor.
   Touches: `src/hooks/usePublisher.ts`, callers that only need name/avatar.
@@ -67,4 +62,4 @@ Refactors flagged during glossary/domain clarifications. Each item is something 
 
 ## Done
 
-_(none yet — move items here as they ship)_
+- **Preferences field rename: `publisher` → `role`** — shipped. MMKV v1 → v2 migration renames the `publisher` field to `role` (preserving the leaf enum value `'publisher'` for Regular Publisher), iCloud `payloadFieldRenames.ts` translates legacy peer payloads, `setPublisher` action renamed to `setRole`, all `usePreferences().publisher` consumers updated. `usePublisher()` hook name unchanged (returns role + capabilities). `Publisher` type unchanged.

--- a/src/__tests__/preferencesPersistMigration.test.ts
+++ b/src/__tests__/preferencesPersistMigration.test.ts
@@ -95,3 +95,103 @@ describe('preferences persist migrate v0 → v1 (excluded/meeting weekdays → o
     expect(migrated).not.toHaveProperty('meetingWeekdays')
   })
 })
+
+describe('preferences persist migrate v1 → v2 (publisher → role)', () => {
+  it('renames publisher → role preserving the value', () => {
+    const v1State = {
+      publisher: 'regularPioneer',
+      offDays: [0, 6],
+    }
+
+    const migrated = migratePreferencesPersistedState(v1State, 1)
+
+    expect(migrated.role).toBe('regularPioneer')
+    expect(migrated).not.toHaveProperty('publisher')
+  })
+
+  it('preserves the canonical leaf enum value `publisher` when stored under the publisher field', () => {
+    // The field name renames, but the *value* `'publisher'` (= Regular
+    // Publisher role) is canonical and unchanged.
+    const v1State = {
+      publisher: 'publisher',
+    }
+
+    const migrated = migratePreferencesPersistedState(v1State, 1)
+
+    expect(migrated.role).toBe('publisher')
+    expect(migrated).not.toHaveProperty('publisher')
+  })
+
+  it('also migrates the preferenceUpdatedAt timestamp map so iCloud LWW still works after rename', () => {
+    const v1State = {
+      publisher: 'circuitOverseer',
+      preferenceUpdatedAt: {
+        publisher: 1700000000000,
+        otherKey: 1700000002000,
+      },
+    }
+
+    const migrated = migratePreferencesPersistedState(v1State, 1)
+
+    expect(migrated.preferenceUpdatedAt.role).toBe(1700000000000)
+    expect(migrated.preferenceUpdatedAt.otherKey).toBe(1700000002000)
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('publisher')
+  })
+
+  it('is idempotent — re-running on an already-v2 state is a no-op', () => {
+    const v1State = {
+      publisher: 'specialPioneer',
+      preferenceUpdatedAt: { publisher: 1700000000000 },
+    }
+    const v2State = migratePreferencesPersistedState(v1State, 1)
+    const v2Again = migratePreferencesPersistedState(v2State, 2)
+
+    expect(JSON.stringify(v2Again)).toEqual(JSON.stringify(v2State))
+  })
+
+  it('does not overwrite an existing role value if both publisher and role exist (new wins)', () => {
+    // Defensive: if a downgrade-then-upgrade leaves both keys present, the
+    // new field wins and the legacy key is dropped.
+    const mixedState = {
+      publisher: 'publisher',
+      role: 'specialPioneer',
+      preferenceUpdatedAt: {
+        publisher: 1700000000000,
+        role: 1700000001000,
+      },
+    }
+
+    const migrated = migratePreferencesPersistedState(mixedState, 1)
+
+    expect(migrated.role).toBe('specialPioneer')
+    expect(migrated).not.toHaveProperty('publisher')
+    expect(migrated.preferenceUpdatedAt.role).toBe(1700000001000)
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('publisher')
+  })
+
+  it('chains cleanly through v0 → v2 when called with version 0', () => {
+    // A v0 blob being read on the v2 schema should get both renames applied.
+    const v0State = {
+      excludedWeekdays: [0, 6],
+      meetingWeekdays: [3],
+      publisher: 'regularPioneer',
+    }
+
+    const migrated = migratePreferencesPersistedState(v0State, 0)
+
+    expect(migrated.offDays).toEqual([0, 6])
+    expect(migrated.meetingDays).toEqual([3])
+    expect(migrated.role).toBe('regularPioneer')
+    expect(migrated).not.toHaveProperty('excludedWeekdays')
+    expect(migrated).not.toHaveProperty('meetingWeekdays')
+    expect(migrated).not.toHaveProperty('publisher')
+  })
+
+  it('fills sensible defaults when the publisher field was missing entirely', () => {
+    const migrated = migratePreferencesPersistedState({}, 1)
+
+    expect(migrated).not.toHaveProperty('publisher')
+    // The `role` default is filled at hydration time by combine(), so absence
+    // here is fine — the migration just shouldn't *introduce* the legacy field.
+  })
+})

--- a/src/app/sync/__tests__/payloadFieldRenames.test.ts
+++ b/src/app/sync/__tests__/payloadFieldRenames.test.ts
@@ -76,4 +76,43 @@ describe('normalizeLegacyPayloadFieldNames', () => {
     expect(() => normalizeLegacyPayloadFieldNames(d2)).not.toThrow()
     expect(() => normalizeLegacyPayloadFieldNames(d3)).not.toThrow()
   })
+
+  it('renames publisher → role on values and updatedAt (legacy peer payload)', () => {
+    const d = makePayload(
+      { publisher: 'regularPioneer' },
+      { publisher: 1700000010000 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.role).toBe('regularPioneer')
+    expect(d.preferencesStore.values).not.toHaveProperty('publisher')
+    expect(d.preferencesStore.updatedAt.role).toBe(1700000010000)
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('publisher')
+  })
+
+  it('preserves the canonical leaf value `publisher` when carried under the legacy publisher field', () => {
+    // The field name renames, but the *value* `'publisher'` (= Regular
+    // Publisher role) stays as-is.
+    const d = makePayload({ publisher: 'publisher' }, {})
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.role).toBe('publisher')
+    expect(d.preferencesStore.values).not.toHaveProperty('publisher')
+  })
+
+  it('prefers role when a payload carries both publisher and role', () => {
+    const d = makePayload(
+      { publisher: 'publisher', role: 'specialPioneer' },
+      { publisher: 1, role: 2 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.role).toBe('specialPioneer')
+    expect(d.preferencesStore.values).not.toHaveProperty('publisher')
+    expect(d.preferencesStore.updatedAt.role).toBe(2)
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('publisher')
+  })
 })

--- a/src/app/sync/payloadFieldRenames.ts
+++ b/src/app/sync/payloadFieldRenames.ts
@@ -12,6 +12,9 @@
  *
  * - `preferencesStore.values.excludedWeekdays` → `offDays`
  * - `preferencesStore.values.meetingWeekdays` → `meetingDays`
+ * - `preferencesStore.values.publisher` → `role` (the field stores a `Publisher`
+ *   enum value — only the field name renamed; the leaf enum value `'publisher'`
+ *   for Regular Publisher is canonical and unchanged)
  * - The matching keys inside `preferencesStore.updatedAt`
  *
  * New name wins if both keys somehow coexist on the wire (defensive); the
@@ -23,8 +26,10 @@ export function normalizeLegacyPayloadFieldNames(d: any): void {
   if (!prefs || typeof prefs !== 'object') return
   renameKey(prefs.values, 'excludedWeekdays', 'offDays')
   renameKey(prefs.values, 'meetingWeekdays', 'meetingDays')
+  renameKey(prefs.values, 'publisher', 'role')
   renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
   renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
+  renameKey(prefs.updatedAt, 'publisher', 'role')
 }
 
 function renameKey(

--- a/src/app/widgets/widgetSync.ts
+++ b/src/app/widgets/widgetSync.ts
@@ -44,7 +44,7 @@ function pushSnapshot(reason: string): void {
 
     const snapshot = buildWidgetSnapshot({
       serviceReports: sr.serviceReports,
-      publisher: prefs.publisher,
+      publisher: prefs.role,
       publisherHours: prefs.publisherHours,
       overrideCreditLimit: prefs.overrideCreditLimit,
       customCreditLimitHours: prefs.customCreditLimitHours,

--- a/src/components/PublisherTypeSelector.tsx
+++ b/src/components/PublisherTypeSelector.tsx
@@ -38,7 +38,7 @@ const PublisherTypeSelector = () => {
     },
   ]
 
-  const { publisherHours, publisher, setPublisher, set } = usePreferences()
+  const { publisherHours, role, setRole, set } = usePreferences()
   const [goalHours, setGoalHours] = useState(publisherHours.custom.toString())
   const customHoursInput = useRef<RNTextInput>(null)
 
@@ -46,12 +46,12 @@ const PublisherTypeSelector = () => {
     <View>
       <Select
         data={items}
-        onChange={({ value }) => setPublisher(value)}
-        value={publisher}
+        onChange={({ value }) => setRole(value)}
+        value={role}
         style={{ marginBottom: 10 }}
       />
 
-      {publisher === 'custom' ? (
+      {role === 'custom' ? (
         <View>
           <Pressable
             onPress={() => customHoursInput.current?.focus()}
@@ -99,10 +99,10 @@ const PublisherTypeSelector = () => {
         </View>
       ) : (
         <Text style={{ fontSize: 12, color: theme.colors.textAlt }}>
-          {publisher === publishers[0]
+          {role === publishers[0]
             ? i18n.t('noHourRequirement')
             : i18n.t('hourMonthlyRequirement', {
-                count: publisherHours[publisher],
+                count: publisherHours[role],
               })}
         </Text>
       )}

--- a/src/features/onboarding/components/FeatureShowcase.tsx
+++ b/src/features/onboarding/components/FeatureShowcase.tsx
@@ -460,11 +460,11 @@ interface FeatureShowcaseProps {
 
 const FeatureShowcase = ({ style }: FeatureShowcaseProps) => {
   const theme = useTheme()
-  const { publisher } = usePreferences()
+  const { role } = usePreferences()
 
   const highlights = useMemo(
-    () => highlightsForPublisher(publisher).map((id) => HIGHLIGHTS[id]),
-    [publisher]
+    () => highlightsForPublisher(role).map((id) => HIGHLIGHTS[id]),
+    [role]
   )
 
   return (

--- a/src/features/onboarding/components/Onboarding.tsx
+++ b/src/features/onboarding/components/Onboarding.tsx
@@ -126,7 +126,7 @@ const allSteps: StepDef[] = [
 const OnBoarding = () => {
   const {
     set,
-    publisher,
+    role,
     onboardingStepId,
     installedOn,
     userSpecifiedHasAnnualGoal,
@@ -135,12 +135,12 @@ const OnBoarding = () => {
 
   const showIfCtx: StepShowIfContext = useMemo(
     () => ({
-      publisher,
+      publisher: role,
       installedOn,
       userSpecifiedHasAnnualGoal,
       serviceReports,
     }),
-    [publisher, installedOn, userSpecifiedHasAnnualGoal, serviceReports]
+    [role, installedOn, userSpecifiedHasAnnualGoal, serviceReports]
   )
 
   const visibleSteps = useMemo(

--- a/src/features/onboarding/components/steps/IntentPicker.tsx
+++ b/src/features/onboarding/components/steps/IntentPicker.tsx
@@ -37,8 +37,8 @@ interface IntentOption {
 
 const IntentPicker = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
-  const { onboardingIntents, set, publisher } = usePreferences()
-  const isCheckbox = getEntryMode(publisher) === 'checkbox'
+  const { onboardingIntents, set, role } = usePreferences()
+  const isCheckbox = getEntryMode(role) === 'checkbox'
 
   const options: IntentOption[] = [
     {

--- a/src/features/onboarding/components/steps/ProfileSetupPioneerDate.tsx
+++ b/src/features/onboarding/components/steps/ProfileSetupPioneerDate.tsx
@@ -18,8 +18,8 @@ interface Props {
 
 const ProfileSetupPioneerDate = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
-  const { publisher, pioneerStartDate, set } = usePreferences()
-  const labels = getStartDateLabels(publisher)
+  const { role, pioneerStartDate, set } = usePreferences()
+  const labels = getStartDateLabels(role)
 
   const handleContinue = () => {
     goNext()

--- a/src/features/onboarding/components/steps/Supporter.tsx
+++ b/src/features/onboarding/components/steps/Supporter.tsx
@@ -42,7 +42,7 @@ const Supporter = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
   const navigation = useNavigation<RootStackNavigation>()
   const prefs = usePreferences()
-  const { publisher } = prefs
+  const { role } = prefs
 
   // Read `onboardingIntents` defensively — the field is being added by a
   // sibling worktree and may not exist in the preferences store yet. Typing
@@ -51,8 +51,8 @@ const Supporter = ({ goBack, goNext }: Props) => {
     (prefs as unknown as { onboardingIntents?: string[] }).onboardingIntents ??
     []
 
-  const personalizationKey = publisher
-    ? personalizationKeyByPublisher[publisher]
+  const personalizationKey = role
+    ? personalizationKeyByPublisher[role]
     : undefined
 
   const intentCount = intents.length

--- a/src/features/onboarding/components/steps/Two.tsx
+++ b/src/features/onboarding/components/steps/Two.tsx
@@ -16,13 +16,13 @@ interface Props {
 }
 
 const StepTwo = ({ goBack, goNext }: Props) => {
-  const { publisher } = usePreferences()
+  const { role } = usePreferences()
   // Reflect the user's just-made selection in the CTA. For 'custom' the role
   // label would be "Custom" which isn't meaningful as a subject — fall back
   // to plain "Continue" there.
   const ctaLabel =
-    publisher && publisher !== 'custom'
-      ? i18n.t('continueAs', { role: i18n.t(publisher) })
+    role && role !== 'custom'
+      ? i18n.t('continueAs', { role: i18n.t(role) })
       : i18n.t('continue')
 
   return (

--- a/src/features/onboarding/components/steps/YourPlanPreview.tsx
+++ b/src/features/onboarding/components/steps/YourPlanPreview.tsx
@@ -1136,15 +1136,15 @@ const SegmentBar = ({
 
 const YourPlanPreview = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
-  const { publisher, publisherHours, pioneerStartDate, onboardingIntents } =
+  const { role, publisherHours, pioneerStartDate, onboardingIntents } =
     usePreferences()
   const { name: trimmedName, hasName } = usePublisher()
 
-  const monthlyGoalHours = publisherHours[publisher] ?? 0
-  const publisherLabel = i18n.t(publisher)
-  const entryMode = getEntryMode(publisher)
+  const monthlyGoalHours = publisherHours[role] ?? 0
+  const publisherLabel = i18n.t(role)
+  const entryMode = getEntryMode(role)
 
-  const pioneering = isInFullTimeService(publisher) && pioneerStartDate
+  const pioneering = isInFullTimeService(role) && pioneerStartDate
   const pioneeringLine = pioneering
     ? i18n.t('yourPlanPioneeringSince', {
         date: moment(pioneerStartDate).format('MMM YYYY'),

--- a/src/features/progress/components/MilestoneAdjustSheet.tsx
+++ b/src/features/progress/components/MilestoneAdjustSheet.tsx
@@ -75,7 +75,7 @@ const MilestoneAdjustSheet = ({ visible, onClose }: Props) => {
   const theme = useTheme()
   const navigation = useNavigation<RootStackNavigation>()
   const {
-    publisher,
+    role,
     publisherHours,
     milestoneOverrides,
     setMilestoneOverrides,
@@ -83,14 +83,14 @@ const MilestoneAdjustSheet = ({ visible, onClose }: Props) => {
   } = usePreferences()
   const { serviceReports } = useServiceReport()
 
-  const annualGoalHours = publisherHours[publisher] * 12
+  const annualGoalHours = publisherHours[role] * 12
 
   // Seed / re-seed the local draft whenever the sheet opens or the persisted
   // list changes (e.g. Reset to Defaults). We keep a local copy so the user
   // can freely type / reorder without stomping preferences until they tap Done.
   const [draft, setDraft] = useState<number[]>(() =>
     sanitizeDraft(
-      milestoneOverrides ?? DEFAULT_MILESTONES_BY_PUBLISHER[publisher],
+      milestoneOverrides ?? DEFAULT_MILESTONES_BY_PUBLISHER[role],
       annualGoalHours
     )
   )
@@ -103,12 +103,12 @@ const MilestoneAdjustSheet = ({ visible, onClose }: Props) => {
     if (!visible) return
     setDraft(
       sanitizeDraft(
-        milestoneOverrides ?? DEFAULT_MILESTONES_BY_PUBLISHER[publisher],
+        milestoneOverrides ?? DEFAULT_MILESTONES_BY_PUBLISHER[role],
         annualGoalHours
       )
     )
     setInputBuffers({})
-  }, [visible, milestoneOverrides, publisher, annualGoalHours])
+  }, [visible, milestoneOverrides, role, annualGoalHours])
 
   // Live hours completed for the current service year — same math the rest of
   // the app uses. Must filter to just this service year first; passing the raw
@@ -222,7 +222,7 @@ const MilestoneAdjustSheet = ({ visible, onClose }: Props) => {
             resetMilestoneOverrides()
             setDraft(
               sanitizeDraft(
-                DEFAULT_MILESTONES_BY_PUBLISHER[publisher],
+                DEFAULT_MILESTONES_BY_PUBLISHER[role],
                 annualGoalHours
               )
             )

--- a/src/features/progress/components/ProgressYearTab.tsx
+++ b/src/features/progress/components/ProgressYearTab.tsx
@@ -51,15 +51,11 @@ const MonthRow = ({
 }) => {
   const theme = useTheme()
   const cardStyle = useCardStyle()
-  const {
-    publisher,
-    publisherHours,
-    overrideCreditLimit,
-    customCreditLimitHours,
-  } = usePreferences()
+  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
+    usePreferences()
   const { serviceReports, dayPlans, recurringPlans } = useServiceReport()
 
-  const goalHours = publisherHours[publisher]
+  const goalHours = publisherHours[role]
 
   const monthsReports = useMemo(
     () => getMonthsReports(serviceReports, month, year),
@@ -71,7 +67,7 @@ const MonthRow = ({
       monthsReports,
       month,
       year,
-      publisher,
+      role,
       { enabled: overrideCreditLimit, customLimitHours: customCreditLimitHours }
     )
     return adjusted.value / 60
@@ -79,7 +75,7 @@ const MonthRow = ({
     monthsReports,
     month,
     year,
-    publisher,
+    role,
     overrideCreditLimit,
     customCreditLimitHours,
   ])

--- a/src/features/progress/screens/ProgressScreen.tsx
+++ b/src/features/progress/screens/ProgressScreen.tsx
@@ -31,7 +31,7 @@ export type ProgressTab = 'month' | 'year' | 'allTime'
 const ProgressScreen = ({ route, navigation }: Props) => {
   const theme = useTheme()
   const insets = useSafeAreaInsets()
-  const { publisher, publisherHours } = usePreferences()
+  const { role, publisherHours } = usePreferences()
 
   const now = moment()
   const currentYear = now.year()
@@ -43,7 +43,7 @@ const ProgressScreen = ({ route, navigation }: Props) => {
   // Publisher types with no annual goal (e.g. `publisher` or custom-at-0) cannot
   // meaningfully render the Year tab. Hide it from the selector and coerce
   // route-param landings away from `year`.
-  const hideYearTab = (publisherHours[publisher] ?? 0) === 0
+  const hideYearTab = (publisherHours[role] ?? 0) === 0
 
   const initialTab: ProgressTab = (() => {
     const requested = route.params?.tab

--- a/src/features/service-reports/components/HourEntryCard.tsx
+++ b/src/features/service-reports/components/HourEntryCard.tsx
@@ -24,7 +24,7 @@ import { HomeTabStackNavigation } from '@/types/homeStack'
 export default function HourEntryCard() {
   const theme = useTheme()
   const {
-    publisher,
+    role,
     publisherHours,
     displayDetailsOnProgressBarHomeScreen,
     timeDisplayFormat,
@@ -35,7 +35,7 @@ export default function HourEntryCard() {
   const navigation = useNavigation<
     HomeTabStackNavigation & RootStackNavigation
   >()
-  const goalHours = publisherHours[publisher]
+  const goalHours = publisherHours[role]
   const monthReports = useMemo(
     () => getMonthsReports(serviceReports, moment().month(), moment().year()),
     [serviceReports]
@@ -47,13 +47,13 @@ export default function HourEntryCard() {
         monthReports,
         moment().month(),
         moment().year(),
-        publisher,
+        role,
         {
           enabled: overrideCreditLimit,
           customLimitHours: customCreditLimitHours,
         }
       ),
-    [monthReports, publisher, overrideCreditLimit, customCreditLimitHours]
+    [monthReports, role, overrideCreditLimit, customCreditLimitHours]
   )
 
   const progress = useMemo(

--- a/src/features/service-reports/components/MonthReport.tsx
+++ b/src/features/service-reports/components/MonthReport.tsx
@@ -81,20 +81,20 @@ const MonthReport = ({
 }: MonthReportProps) => {
   const theme = useTheme()
   const {
-    publisher,
+    role,
     publisherHours,
     overrideCreditLimit,
     customCreditLimitHours,
     celebratedTiers,
     markTierCelebrated,
   } = usePreferences()
-  const goalHours = publisherHours[publisher]
+  const goalHours = publisherHours[role]
   const navigation = useNavigation<RootStackNavigation>()
   const tabNavigation = useNavigation<HomeTabStackNavigation>()
   const rollover = useRollover()
 
   const adjustedMinutes: AdjustedMinutes = monthsReports
-    ? adjustedMinutesForSpecificMonth(monthsReports, month, year, publisher, {
+    ? adjustedMinutesForSpecificMonth(monthsReports, month, year, role, {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
       })
@@ -121,22 +121,16 @@ const MonthReport = ({
     const reports = getMonthsReports(serviceReports, prevMonth, prevMonthYear)
     if (!reports.length) return null
     return (
-      adjustedMinutesForSpecificMonth(
-        reports,
-        prevMonth,
-        prevMonthYear,
-        publisher,
-        {
-          enabled: overrideCreditLimit,
-          customLimitHours: customCreditLimitHours,
-        }
-      ).value / 60
+      adjustedMinutesForSpecificMonth(reports, prevMonth, prevMonthYear, role, {
+        enabled: overrideCreditLimit,
+        customLimitHours: customCreditLimitHours,
+      }).value / 60
     )
   }, [
     serviceReports,
     prevMonth,
     prevMonthYear,
-    publisher,
+    role,
     overrideCreditLimit,
     customCreditLimitHours,
   ])
@@ -219,7 +213,7 @@ const MonthReport = ({
       month,
       year,
       hoursCompleted,
-      publisher,
+      role,
       {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
@@ -232,7 +226,7 @@ const MonthReport = ({
     month,
     year,
     hoursCompleted,
-    publisher,
+    role,
     overrideCreditLimit,
     customCreditLimitHours,
   ])

--- a/src/features/service-reports/components/MonthServiceReportProgressBar.tsx
+++ b/src/features/service-reports/components/MonthServiceReportProgressBar.tsx
@@ -134,12 +134,8 @@ const MonthServiceReportProgressBar = ({
 }: ProgressBarProps) => {
   const theme = useTheme()
   const { serviceReports } = useServiceReport()
-  const {
-    publisher,
-    publisherHours,
-    overrideCreditLimit,
-    customCreditLimitHours,
-  } = usePreferences()
+  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
+    usePreferences()
 
   // Animation setup
   const pulseAnimation = useRef(new Animated.Value(0)).current
@@ -149,11 +145,11 @@ const MonthServiceReportProgressBar = ({
     () => getMonthsReports(serviceReports, month, year),
     [month, serviceReports, year]
   )
-  const goalHours = publisherHours[publisher]
+  const goalHours = publisherHours[role]
 
   const adjustedMinutes = useMemo(
     () =>
-      adjustedMinutesForSpecificMonth(monthReports, month, year, publisher, {
+      adjustedMinutesForSpecificMonth(monthReports, month, year, role, {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
       }),
@@ -161,7 +157,7 @@ const MonthServiceReportProgressBar = ({
       month,
       monthReports,
       year,
-      publisher,
+      role,
       overrideCreditLimit,
       customCreditLimitHours,
     ]

--- a/src/features/service-reports/components/OnboardingBackfillBanner.tsx
+++ b/src/features/service-reports/components/OnboardingBackfillBanner.tsx
@@ -19,7 +19,7 @@ const OnboardingBackfillBanner = () => {
   const {
     serviceYearCatchUpStatus,
     installedOn,
-    publisher,
+    role,
     userSpecifiedHasAnnualGoal,
     set,
   } = usePreferences()
@@ -31,7 +31,7 @@ const OnboardingBackfillBanner = () => {
   // — even though `status` remains 'skipped'. Also hide when an iCloud
   // restore (or other prior data) already filled the catch-up window.
   const eligible =
-    effectiveHasAnnualGoal(publisher, userSpecifiedHasAnnualGoal) &&
+    effectiveHasAnnualGoal(role, userSpecifiedHasAnnualGoal) &&
     moment(installedOn).month() !== 8 &&
     !hasReportsInCatchUpWindow(serviceReports, installedOn)
 

--- a/src/features/service-reports/components/YearScreenMonthRow.tsx
+++ b/src/features/service-reports/components/YearScreenMonthRow.tsx
@@ -56,18 +56,14 @@ export default function YearScreenMonthRow(props: {
 }) {
   const { month, year, monthsReports } = props
 
-  const {
-    publisher,
-    publisherHours,
-    overrideCreditLimit,
-    customCreditLimitHours,
-  } = usePreferences()
+  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
+    usePreferences()
   const { serviceReports } = useServiceReport()
-  const goalHours = publisherHours[publisher]
+  const goalHours = publisherHours[role]
   const theme = useTheme()
 
   const adjustedMinutes: AdjustedMinutes = monthsReports
-    ? adjustedMinutesForSpecificMonth(monthsReports, month, year, publisher, {
+    ? adjustedMinutesForSpecificMonth(monthsReports, month, year, role, {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
       })
@@ -89,7 +85,7 @@ export default function YearScreenMonthRow(props: {
       month,
       year,
       hoursCompleted,
-      publisher,
+      role,
       {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
@@ -102,7 +98,7 @@ export default function YearScreenMonthRow(props: {
     serviceReports,
     month,
     year,
-    publisher,
+    role,
     overrideCreditLimit,
     customCreditLimitHours,
   ])

--- a/src/features/service-reports/screens/AddTimeScreen.tsx
+++ b/src/features/service-reports/screens/AddTimeScreen.tsx
@@ -52,7 +52,7 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
   const {
     serviceReportTags,
     set,
-    publisher,
+    role,
     publisherHours,
     overrideCreditLimit,
     customCreditLimitHours,
@@ -325,7 +325,7 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
     // queue anything, so the fireworks don't fire on every submission. The
     // queue is keyed by `(month, year)` so it only pops when the user is
     // actually viewing the month they crossed.
-    const goalHours = publisherHours[publisher]
+    const goalHours = publisherHours[role]
     if (goalHours > 0) {
       const reportMoment = moment(serviceReport.date)
       const reportMonth = reportMoment.month()
@@ -343,14 +343,14 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
         beforeReports,
         reportMonth,
         reportYear,
-        publisher,
+        role,
         creditOverride
       ).value
       const afterMinutes = adjustedMinutesForSpecificMonth(
         [...beforeReports, serviceReport],
         reportMonth,
         reportYear,
-        publisher,
+        role,
         creditOverride
       ).value
       const goalMinutes = goalHours * 60

--- a/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
@@ -21,7 +21,7 @@ import { getStartDateLabels } from '@/constants/publisher'
 
 const PublisherPreferencesSection = () => {
   const {
-    publisher,
+    role,
     pioneerStartDate,
     hasCompletedProfileSetup,
     overrideCreditLimit,
@@ -103,7 +103,7 @@ const PublisherPreferencesSection = () => {
         </InputRowContainer>
         {tracksPioneerStartDate && (
           <InputRowContainer
-            label={i18n.t(getStartDateLabels(publisher).label)}
+            label={i18n.t(getStartDateLabels(role).label)}
             lastInSection={isCheckboxMode}
           >
             <View style={{ flex: 1, alignItems: 'flex-end' }}>

--- a/src/hooks/usePublisher.ts
+++ b/src/hooks/usePublisher.ts
@@ -7,7 +7,7 @@ import i18n from '@/lib/locales'
 
 const usePublisher = (): PublisherCapabilities => {
   const {
-    publisher,
+    role,
     publisherHours,
     userSpecifiedHasAnnualGoal,
     milestoneOverrides,
@@ -17,7 +17,7 @@ const usePublisher = (): PublisherCapabilities => {
   } = usePreferences()
 
   const capabilities = derivePublisherCapabilities({
-    publisher,
+    publisher: role,
     publisherHours,
     userSpecifiedHasAnnualGoal,
     milestoneOverrides,

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -225,7 +225,7 @@ export function getEffectiveHomeScreenOrder(
 }
 
 export const PREFERENCE_DEFAULTS = {
-  publisher: 'publisher' as Publisher,
+  role: 'publisher' as Publisher,
   publisherHours: publisherHours,
 
   /** Overrides publisherHours hour requirement for given month. */
@@ -603,8 +603,8 @@ export const PREFERENCE_DEFAULTS = {
    * ladder" from `src/lib/milestones.ts`. When non-null, these hours override
    * the defaults and persist across publisher-type changes (shared list, not
    * per-publisher). The final row — the annual goal — is derived from
-   * `publisherHours[publisher] * 12` at render time and is NOT stored here.
-   * "Reset to defaults" sets this back to `null`.
+   * `publisherHours[role] * 12` at render time and is NOT stored here. "Reset
+   * to defaults" sets this back to `null`.
    */
   milestoneOverrides: null as number[] | null,
   /**
@@ -761,6 +761,12 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
  *   identical; only the field names change. We also migrate the
  *   `preferenceUpdatedAt` timestamp map so iCloud last-writer-wins continues to
  *   work across the rename. The legacy fields are dropped from disk.
+ * - V1 → v2: rename `publisher` → `role`. The field stores a `Publisher` enum
+ *   value (the user's field-ministry role); the new name reads more naturally
+ *   (`preferences.role === 'regularPioneer'`) and matches the glossary. The
+ *   leaf enum value `'publisher'` (Regular Publisher) is canonical and stays.
+ *   The `preferenceUpdatedAt` timestamp map is migrated alongside so iCloud
+ *   last-writer-wins continues to work across the rename.
  *
  * Exported for unit testing. Idempotent — re-running on an already-migrated
  * blob is a no-op.
@@ -774,6 +780,9 @@ export const migratePreferencesPersistedState = (
   let next = persistedState
   if (version < 1) {
     next = migrateExcludedMeetingWeekdaysToOffMeetingDays(next)
+  }
+  if (version < 2) {
+    next = migratePublisherToRole(next)
   }
   return next
 }
@@ -806,6 +815,30 @@ const migrateExcludedMeetingWeekdaysToOffMeetingDays = (state: any): any => {
     }
     if (meetingTs !== undefined && nextTs.meetingDays === undefined) {
       nextTs.meetingDays = meetingTs
+    }
+    next.preferenceUpdatedAt = nextTs
+  }
+  return next
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const migratePublisherToRole = (state: any): any => {
+  if (!state || typeof state !== 'object') return state
+  const { publisher, ...rest } = state
+  const next = { ...rest }
+  // If the new key already carries a value, it wins (defensive — a
+  // downgrade-then-upgrade could leave both keys present).
+  if (publisher !== undefined && next.role === undefined) {
+    next.role = publisher
+  }
+  if (
+    next.preferenceUpdatedAt &&
+    typeof next.preferenceUpdatedAt === 'object'
+  ) {
+    const { publisher: publisherTs, ...restTs } = next.preferenceUpdatedAt
+    const nextTs: Record<string, number> = { ...restTs }
+    if (publisherTs !== undefined && nextTs.role === undefined) {
+      nextTs.role = publisherTs
     }
     next.preferenceUpdatedAt = nextTs
   }
@@ -850,7 +883,7 @@ export const usePreferences = create(
 
       return {
         set,
-        setPublisher: (publisher: Publisher) => set({ publisher }),
+        setRole: (role: Publisher) => set({ role }),
         incrementGeocodeApiCallCount: () =>
           set(({ calledGoecodeApiTimes }) => ({
             calledGoecodeApiTimes: calledGoecodeApiTimes + 1,
@@ -943,7 +976,7 @@ export const usePreferences = create(
       storage: createJSONStorage(() =>
         hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
       ),
-      version: 1,
+      version: 2,
       migrate: (persistedState, version) =>
         migratePreferencesPersistedState(persistedState, version),
     }


### PR DESCRIPTION
## Why

Glossary defines **Publisher** = the User's field-ministry role. A field of type `Publisher` named `publisher` on the preferences store reads awkwardly. `preferences.role === 'regularPioneer'` matches the glossary directly.

The `Publisher` type itself and its leaf enum value `'publisher'` (= Regular Publisher) are **canonical and unchanged**. Only the storage field name moves, plus the `setPublisher` action renames to `setRole` for symmetry with the field.

## Risks

- **MMKV v1 → v2 migration.** Persisted preferences blobs written by v1 builds will be migrated on first read: the `publisher` field is renamed to `role`, and its matching entry in the `preferenceUpdatedAt` last-writer-wins map is moved alongside. Idempotent — re-running on a v2 blob is a no-op. Migration is unit-tested at `src/__tests__/preferencesPersistMigration.test.ts:99` including the chained `v0 → v2` path. If a v2 build sees a v1 blob with both `publisher` and `role` keys (e.g. via a downgrade-then-upgrade), the new key wins and the legacy key is dropped.
- **Cross-device iCloud sync.** A peer device still on v1 emits payloads with `preferencesStore.values.publisher` (and the matching `updatedAt` key). `src/app/sync/payloadFieldRenames.ts:25` rewrites these on read so the v2 receiver merges the value into `role` correctly. Tested at `src/app/sync/__tests__/payloadFieldRenames.test.ts:80`.
- **Visual collision worth flagging for the reviewer:** existing call sites compare the field to the leaf enum value `'publisher'` (Regular Publisher) — e.g. `preferences.role === 'publisher'`. This is correct (the leaf enum stays `'publisher'`), but the dual usage of the word in one expression is now more visible. The type system catches mismatches.

## Tests required

- Manual cross-device iCloud sync verification on a device that was on v1 before upgrade: confirm the publisher role persists and merges correctly after the migration.