### PR TITLE
refactor: collapse ldc boolean into LDC builtin Category

### DIFF
--- a/src/__tests__/achievementTier.test.ts
+++ b/src/__tests__/achievementTier.test.ts
@@ -6,7 +6,11 @@ import {
   resolveTier,
   tierFromPercent,
 } from '@/lib/achievementTier'
-import { ServiceReport, ServiceReportsByYears } from '@/types/serviceReport'
+import {
+  LegacyServiceReport,
+  ServiceReport,
+  ServiceReportsByYears,
+} from '@/types/serviceReport'
 import { Publisher } from '@/types/publisher'
 import { normalizeDateForStorage } from '@/lib/normalizeDate'
 
@@ -25,7 +29,7 @@ type ReportInput = {
   credit?: boolean
 }
 
-const buildReport = (input: ReportInput, idx: number): ServiceReport => ({
+const buildReport = (input: ReportInput, idx: number): LegacyServiceReport => ({
   id: `r-${idx}`,
   // Mid-month, anchored noon-UTC the same way the production write-path does
   // it. Using the 15th avoids any "first/last day rolls into adjacent month
@@ -45,7 +49,7 @@ const buildServiceReports = (inputs: ReportInput[]): ServiceReportsByYears => {
   inputs.forEach((input, idx) => {
     if (!out[input.year]) out[input.year] = {}
     if (!out[input.year][input.month]) out[input.year][input.month] = []
-    out[input.year][input.month].push(buildReport(input, idx))
+    out[input.year][input.month].push(buildReport(input, idx) as ServiceReport)
   })
   return out
 }

--- a/src/__tests__/categoryMigration.test.ts
+++ b/src/__tests__/categoryMigration.test.ts
@@ -13,7 +13,11 @@ import {
   migrateTagsToCategories,
   resolveCategoryForReport,
 } from '@/lib/categories'
-import { ServiceReport, ServiceReportsByYears } from '@/types/serviceReport'
+import {
+  LegacyServiceReport,
+  ServiceReport,
+  ServiceReportsByYears,
+} from '@/types/serviceReport'
 import { normalizeDateForStorage } from '@/lib/normalizeDate'
 
 type ReportInput = {
@@ -27,7 +31,7 @@ type ReportInput = {
   credit?: boolean
 }
 
-const makeReport = (input: ReportInput, idx: number): ServiceReport => ({
+const makeReport = (input: ReportInput, idx: number): LegacyServiceReport => ({
   id: input.id ?? `r-${idx}`,
   date: normalizeDateForStorage(
     new Date(Date.UTC(input.year, input.month, 15))
@@ -42,7 +46,7 @@ const makeReport = (input: ReportInput, idx: number): ServiceReport => ({
 const buildReports = (inputs: ReportInput[]): ServiceReportsByYears => {
   const out: ServiceReportsByYears = {}
   inputs.forEach((input, idx) => {
-    const report = makeReport(input, idx)
+    const report = makeReport(input, idx) as ServiceReport
     const m = moment(report.date)
     const y = m.year()
     const mo = m.month()
@@ -219,7 +223,9 @@ describe('migrateTagsToCategories', () => {
     const ldcReport = result.serviceReports[2026][1][0]
     expect(standard.categoryId).toBeUndefined()
     expect(ldcReport.categoryId).toBeUndefined()
-    expect(ldcReport.ldc).toBe(true)
+    // `migrateTagsToCategories` leaves the legacy LDC flag alone — the
+    // LDC → builtin Category collapse runs as a separate migration step.
+    expect((ldcReport as LegacyServiceReport).ldc).toBe(true)
   })
 
   it('trims tag names so "Hospital" and " Hospital " collapse to one Category', () => {

--- a/src/__tests__/ldcCollapseMigration.test.ts
+++ b/src/__tests__/ldcCollapseMigration.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from 'vitest'
+import moment from 'moment'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+// `migrateLdcToCategory` doesn't call expo-crypto, but `lib/categories.ts`
+// imports `Crypto.randomUUID` at module scope (used by the tag → Category
+// migration); stub it so the import resolves under vitest.
+vi.mock('expo-crypto', () => ({
+  randomUUID: vi.fn(() => 'mock-uuid'),
+}))
+
+import { migrateLdcToCategory } from '@/lib/categories'
+import {
+  LDC_BUILTIN_CATEGORY_ID,
+  LDC_BUILTIN_CATEGORY_NAME,
+} from '@/constants/categories'
+import { Category } from '@/types/category'
+import {
+  LegacyServiceReport,
+  ServiceReportsByYears,
+} from '@/types/serviceReport'
+import { normalizeDateForStorage } from '@/lib/normalizeDate'
+import {
+  adjustedMinutesForSpecificMonth,
+  ldcMinutesForSpecificMonth,
+} from '@/lib/serviceReport'
+
+type ReportInput = {
+  id?: string
+  month: number
+  year: number
+  hours?: number
+  minutes?: number
+  ldc?: boolean
+  categoryId?: string
+  credit?: boolean
+}
+
+const makeReport = (input: ReportInput, idx: number): LegacyServiceReport => ({
+  id: input.id ?? `r-${idx}`,
+  date: normalizeDateForStorage(
+    new Date(Date.UTC(input.year, input.month, 15))
+  ),
+  hours: input.hours ?? 1,
+  minutes: input.minutes ?? 0,
+  ldc: input.ldc,
+  categoryId: input.categoryId,
+  credit: input.credit,
+})
+
+const buildReports = (inputs: ReportInput[]): ServiceReportsByYears => {
+  const out: ServiceReportsByYears = {}
+  inputs.forEach((input, idx) => {
+    const report = makeReport(input, idx)
+    const m = moment(report.date)
+    const y = m.year()
+    const mo = m.month()
+    if (!out[y]) out[y] = {}
+    if (!out[y][mo]) out[y][mo] = []
+    out[y][mo].push(report)
+  })
+  return out
+}
+
+const NOW = 1700000000000
+
+describe('migrateLdcToCategory', () => {
+  it('seeds the LDC builtin Category record on first run', () => {
+    const reports = buildReports([])
+    const result = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [],
+      now: NOW,
+    })
+    expect(result.seededLdcBuiltin).toBe(true)
+    const ldc = result.categories.find((c) => c.id === LDC_BUILTIN_CATEGORY_ID)
+    expect(ldc).toBeDefined()
+    expect(ldc!.name).toBe(LDC_BUILTIN_CATEGORY_NAME)
+    expect(ldc!.isCredit).toBe(true)
+    expect(ldc!.builtin).toBe(true)
+    expect(ldc!.updatedAt).toBe(NOW)
+  })
+
+  it('does not re-seed when the LDC builtin already exists', () => {
+    const existing: Category = {
+      id: LDC_BUILTIN_CATEGORY_ID,
+      name: LDC_BUILTIN_CATEGORY_NAME,
+      isCredit: true,
+      builtin: true,
+      updatedAt: 1234,
+    }
+    const result = migrateLdcToCategory({
+      serviceReports: buildReports([]),
+      categories: [existing],
+      now: NOW,
+    })
+    expect(result.seededLdcBuiltin).toBe(false)
+    expect(result.categories).toHaveLength(1)
+    expect(result.categories[0].updatedAt).toBe(1234)
+  })
+
+  it('rewrites a legacy `ldc: true` entry to the LDC builtin Category', () => {
+    const reports = buildReports([
+      {
+        id: 'r-ldc',
+        month: 0,
+        year: 2026,
+        hours: 2,
+        ldc: true,
+        credit: true,
+      },
+    ])
+
+    const result = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [],
+      now: NOW,
+    })
+
+    const migrated = result.serviceReports[2026][0][0]
+    expect(migrated.categoryId).toBe(LDC_BUILTIN_CATEGORY_ID)
+    expect(migrated.credit).toBe(true)
+    expect((migrated as LegacyServiceReport).ldc).toBeUndefined()
+    expect(result.rewrittenCount).toBe(1)
+    expect(result.conflictedCount).toBe(0)
+  })
+
+  it('is idempotent — re-running on already-migrated state is a no-op', () => {
+    const seed: Category = {
+      id: LDC_BUILTIN_CATEGORY_ID,
+      name: LDC_BUILTIN_CATEGORY_NAME,
+      isCredit: true,
+      builtin: true,
+      updatedAt: NOW,
+    }
+    const reports = buildReports([
+      { id: 'r-ldc', month: 0, year: 2026, hours: 2 },
+    ])
+    // Hand-craft a "post-migration" entry pointing at the builtin id.
+    reports[2026][0][0] = {
+      ...reports[2026][0][0],
+      categoryId: LDC_BUILTIN_CATEGORY_ID,
+      credit: true,
+    }
+
+    const first = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [seed],
+      now: NOW,
+    })
+    const second = migrateLdcToCategory({
+      serviceReports: first.serviceReports,
+      categories: first.categories,
+      now: NOW,
+    })
+    expect(second.rewrittenCount).toBe(0)
+    expect(second.conflictedCount).toBe(0)
+    expect(second.seededLdcBuiltin).toBe(false)
+    expect(JSON.stringify(second.serviceReports)).toBe(
+      JSON.stringify(first.serviceReports)
+    )
+  })
+
+  it('keeps an existing non-LDC categoryId when ldc:true coexists (explicit wins)', () => {
+    // Data corruption shape: legacy ldc: true alongside a real user Category.
+    // The Category wins; the ldc flag is dropped; counted under conflicts.
+    const reports = buildReports([
+      {
+        id: 'r-mixed',
+        month: 0,
+        year: 2026,
+        hours: 1,
+        ldc: true,
+        categoryId: 'user-cat-bethel',
+        credit: true,
+      },
+    ])
+
+    const result = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [
+        {
+          id: 'user-cat-bethel',
+          name: 'Bethel',
+          isCredit: true,
+          updatedAt: 1234,
+        },
+      ],
+      now: NOW,
+    })
+
+    const migrated = result.serviceReports[2026][0][0]
+    expect(migrated.categoryId).toBe('user-cat-bethel')
+    expect((migrated as LegacyServiceReport).ldc).toBeUndefined()
+    expect(result.conflictedCount).toBe(1)
+    expect(result.rewrittenCount).toBe(0)
+  })
+
+  it('strips a stray `ldc: false` field so the canonical shape matches', () => {
+    const reports = buildReports([
+      { id: 'r-std', month: 0, year: 2026, hours: 1, ldc: false },
+    ])
+    const result = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [],
+      now: NOW,
+    })
+    const migrated = result.serviceReports[2026][0][0]
+    expect((migrated as LegacyServiceReport).ldc).toBeUndefined()
+    expect(migrated.categoryId).toBeUndefined()
+  })
+
+  it('leaves non-LDC entries untouched (no categoryId, no field added)', () => {
+    const reports = buildReports([
+      { id: 'r1', month: 0, year: 2026, hours: 1 },
+      { id: 'r2', month: 1, year: 2026, hours: 2, categoryId: 'cat-user' },
+    ])
+    const result = migrateLdcToCategory({
+      serviceReports: reports,
+      categories: [
+        {
+          id: 'cat-user',
+          name: 'Hospital',
+          isCredit: true,
+          updatedAt: 1234,
+        },
+      ],
+      now: NOW,
+    })
+    expect(result.serviceReports[2026][0][0].categoryId).toBeUndefined()
+    expect(result.serviceReports[2026][1][0].categoryId).toBe('cat-user')
+    expect(result.rewrittenCount).toBe(0)
+  })
+
+  it('preserves cap-math output for the same input as the legacy shape', () => {
+    // The brief calls this out as the regression to guard against: the cap
+    // math must produce identical output for an LDC entry before and after
+    // the collapse migration. Pioneer with no override → 55h cap.
+    const month = 0
+    const year = 2026
+    const before = buildReports([
+      { id: 'a', month, year, hours: 30, ldc: true },
+      { id: 'b', month, year, hours: 30 }, // standard
+    ])
+    const beforeMinutes = adjustedMinutesForSpecificMonth(
+      before[year][month] as LegacyServiceReport[],
+      month,
+      year,
+      'regularPioneer'
+    )
+
+    const result = migrateLdcToCategory({
+      serviceReports: before,
+      categories: [],
+      now: NOW,
+    })
+
+    const afterMinutes = adjustedMinutesForSpecificMonth(
+      result.serviceReports[year][month],
+      month,
+      year,
+      'regularPioneer'
+    )
+
+    expect(afterMinutes.value).toBe(beforeMinutes.value)
+    expect(afterMinutes.standard).toBe(beforeMinutes.standard)
+    expect(afterMinutes.credit).toBe(beforeMinutes.credit)
+    expect(afterMinutes.creditOverage).toBe(beforeMinutes.creditOverage)
+
+    // And the LDC slice of the breakdown should still report LDC minutes.
+    expect(
+      ldcMinutesForSpecificMonth(
+        result.serviceReports[year][month],
+        month,
+        year
+      )
+    ).toBe(30 * 60)
+  })
+})

--- a/src/__tests__/serviceReport.test.ts
+++ b/src/__tests__/serviceReport.test.ts
@@ -17,13 +17,24 @@ import {
   calculateMonthlyPlannedMinutesOptimized,
   calculateAnnualPlannedMinutesOptimized,
 } from '@/lib/serviceReport'
-import { ServiceReport, ServiceReportsByYears } from '@/types/serviceReport'
+import {
+  LegacyServiceReport,
+  ServiceReportsByYears,
+} from '@/types/serviceReport'
 import { Publisher } from '@/types/publisher'
 import { monthCreditMaxMinutes } from '@/constants/serviceReports'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock the logger to avoid MMKV dependencies in tests
 vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+
+// Tree of LegacyServiceReports, used by tests that exercise the cap math
+// against the pre-collapse `ldc: true` shape. `LegacyServiceReport` extends
+// `ServiceReport` with the deprecated boolean, so it remains assignable to
+// the production helpers' parameter types.
+type LegacyServiceReportsByYears = {
+  [year: string]: { [month: string]: LegacyServiceReport[] }
+}
 
 describe('lib/serviceReport', () => {
   describe('calculateProgress', () => {
@@ -73,7 +84,7 @@ describe('lib/serviceReport', () => {
 
   describe('adjustedMinutesForSpecificMonth ', () => {
     it('should return the number of minutes in the month', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: new Date(),
@@ -116,7 +127,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should return 0 if no reports provided', () => {
-      const serviceReports: ServiceReport[] = []
+      const serviceReports: LegacyServiceReport[] = []
 
       const adjustedMinutes = adjustedMinutesForSpecificMonth(
         serviceReports,
@@ -128,7 +139,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should not include minutes from previous or upcoming months', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().subtract(1, 'month').toDate(),
@@ -171,7 +182,7 @@ describe('lib/serviceReport', () => {
     })
 
     it("shouldn't allow a user to have greater than 55 hours solely of credit time", () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -191,7 +202,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should result in 55 hours if you have both standard and credit time', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -218,7 +229,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should result in sum if you have both standard and credit time, but less than 55 hours', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -245,7 +256,7 @@ describe('lib/serviceReport', () => {
     })
 
     it("should return as many standard hours even if it's over the credit cap", () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -272,7 +283,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should have no credit limit for special pioneers', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -302,7 +313,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should have no credit limit for circuit overseers', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -332,7 +343,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should still apply credit limit for regular pioneers', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -362,7 +373,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should still apply credit limit for publishers', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -392,7 +403,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should respect user credit limit override - no limit (0 hours)', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -423,7 +434,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should respect user credit limit override - custom limit (70 hours)', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -454,7 +465,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should use default behavior when override is disabled', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -485,7 +496,7 @@ describe('lib/serviceReport', () => {
     })
 
     it('should still respect special pioneer exemption even with override disabled', () => {
-      const serviceReports: ServiceReport[] = [
+      const serviceReports: LegacyServiceReport[] = [
         {
           id: '1',
           date: moment().toDate(),
@@ -892,7 +903,7 @@ describe('lib/serviceReport', () => {
   describe('getTotalMinutesForServiceYear', () => {
     it('should not allow more than 55 hours per month of LDC for a single month', () => {
       const year = 2023
-      const serviceReports: ServiceReportsByYears = {
+      const serviceReports: LegacyServiceReportsByYears = {
         [year]: {
           10: [
             {
@@ -906,13 +917,16 @@ describe('lib/serviceReport', () => {
         },
       }
 
-      const minutes = getTotalMinutesForServiceYear(serviceReports, year)
+      const minutes = getTotalMinutesForServiceYear(
+        serviceReports as ServiceReportsByYears,
+        year
+      )
       expect(minutes).toBe(monthCreditMaxMinutes)
     })
 
     it('should not allow multiple entries to sum to more than 55', () => {
       const year = 2023
-      const serviceReports: ServiceReportsByYears = {
+      const serviceReports: LegacyServiceReportsByYears = {
         [year]: {
           10: [
             {
@@ -933,13 +947,16 @@ describe('lib/serviceReport', () => {
         },
       }
 
-      const minutes = getTotalMinutesForServiceYear(serviceReports, year)
+      const minutes = getTotalMinutesForServiceYear(
+        serviceReports as ServiceReportsByYears,
+        year
+      )
       expect(minutes).toBe(monthCreditMaxMinutes)
     })
 
     it('should properly add different months together, but not exceeding the ldc month cap', () => {
       const year = 2023
-      const reports: ServiceReportsByYears = {
+      const reports: LegacyServiceReportsByYears = {
         [year]: {
           10: [
             {
@@ -1005,7 +1022,10 @@ describe('lib/serviceReport', () => {
         },
       }
 
-      const minutes = getTotalMinutesForServiceYear(reports, year)
+      const minutes = getTotalMinutesForServiceYear(
+        reports as ServiceReportsByYears,
+        year
+      )
       expect(minutes).toBe(monthCreditMaxMinutes * 4)
     })
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,7 +55,7 @@ import useServiceReport from '@/stores/serviceReport'
 import { useProfile } from '@/stores/profile'
 import { extractProfileFromPreferences } from '@/lib/profileMigration'
 import { migrateCustomFieldsToIds } from '@/features/contacts/lib/customFieldsMigration'
-import { migrateTagsToCategories } from '@/lib/categories'
+import { migrateLdcToCategory, migrateTagsToCategories } from '@/lib/categories'
 import AnimationViewProvider from '@/providers/AnimationViewProvider'
 import ConfettiProvider from '@/providers/ConfettiProvider'
 import useUserLocalePrefs from '@/features/settings/hooks/useLocale'
@@ -465,6 +465,49 @@ export default function App() {
       }
       usePreferences.setState({ preferenceUpdatedAt: cleaned })
     }
+  }, [hasMigrated])
+
+  // Collapse the legacy `ServiceReport.ldc` boolean into the LDC builtin
+  // Category (see `migrateLdcToCategory` in `src/lib/categories.ts`). Runs
+  // once per install after MMKV is ready, gated on
+  // `hasCollapsedLdcIntoCategory`. Must run AFTER the tag → Category
+  // migration so the categories list is fully populated before LDC is folded
+  // in. The dependency on `hasMigratedTagsToCategories` is implicit: both
+  // runners gate on `hasMigrated` and write through raw setState, so by the
+  // time this effect fires the tag-migration useEffect has already flipped
+  // `hasMigratedTagsToCategories: true` synchronously in the same render
+  // tick.
+  useEffect(() => {
+    if (!hasMigrated) return
+    const prefs = usePreferences.getState()
+    if (prefs.hasCollapsedLdcIntoCategory) return
+
+    const reports = useServiceReport.getState()
+    const cats = useCategories.getState()
+
+    const result = migrateLdcToCategory({
+      serviceReports: reports.serviceReports,
+      categories: cats.categories,
+      now: Date.now(),
+    })
+
+    // Seed the LDC builtin Category record if it wasn't already present.
+    // Raw setState avoids re-stamping `updatedAt` on every existing record —
+    // `migrateLdcToCategory` stamps only the newly-seeded builtin.
+    if (result.seededLdcBuiltin) {
+      useCategories.setState({ categories: result.categories })
+    }
+
+    // Apply rewritten ServiceReports (categoryId + credit on former LDC
+    // entries; `ldc` stripped). Raw setState skips the per-store updatedAt
+    // re-stamp so existing entries keep their last-edit timestamp.
+    if (result.rewrittenCount > 0 || result.conflictedCount > 0) {
+      reports.set({ serviceReports: result.serviceReports })
+    }
+
+    usePreferences.setState({
+      hasCollapsedLdcIntoCategory: true,
+    } as never)
   }, [hasMigrated])
 
   // Normalize the legacy `'es-mx'` locale to `'es-es'` after the es-MX bundle

--- a/src/app/navigation/ToolsScreen.tsx
+++ b/src/app/navigation/ToolsScreen.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import ActionButton from '@/components/ui/ActionButton'
 import useServiceReport from '@/stores/serviceReport'
 import useCategories from '@/stores/categories'
+import { LDC_BUILTIN_CATEGORY_ID } from '@/constants/categories'
 import useContacts from '@/stores/contactsStore'
 import Card from '@/components/ui/Card'
 import XView from '@/components/ui/layout/XView'
@@ -244,14 +245,19 @@ export default function ToolsScreen() {
         const hours = Math.floor(Math.pow(r, 2.5) * 17)
         const minutes = (seed * 7) % 12 === 0 ? 0 : ((seed * 7) % 12) * 5
         if (hours === 0 && minutes === 0) continue
+        // LDC is now a builtin Category (`LDC_BUILTIN_CATEGORY_ID`); the
+        // generator sprinkles LDC entries by setting categoryId on every
+        // fifth seed slot.
+        const isLdc = seed % 5 === 0
         addServiceReport({
           date: moment().subtract(i, 'day').toDate(),
           hours,
           id: `generated-${i}-${j}`,
           minutes,
-          credit: seed % 3 === 0,
-          ldc: seed % 5 === 0,
-          categoryId: seededIds[seed % seededIds.length],
+          credit: isLdc ? true : seed % 3 === 0,
+          categoryId: isLdc
+            ? LDC_BUILTIN_CATEGORY_ID
+            : seededIds[seed % seededIds.length],
         })
       }
       const gapR = ((i * 2654435761 + 12345) % 1000) / 1000

--- a/src/app/sync/__tests__/payloadFieldRenames.test.ts
+++ b/src/app/sync/__tests__/payloadFieldRenames.test.ts
@@ -236,3 +236,102 @@ describe('normalizeLegacyPayloadFieldNames — profile-field routing (wave-3)', 
     expect(JSON.stringify(d)).toBe(snapshot)
   })
 })
+
+// Kept in sync with `src/constants/categories.ts`'s `LDC_BUILTIN_CATEGORY_ID`.
+// `payloadFieldRenames.ts` inlines it for the no-imports rule; the test
+// inlines it for the same reason.
+const LDC_BUILTIN = 'ldc-builtin-3f9c4a1d'
+
+const makeReportsPayload = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reports: any[]
+) => ({
+  version: 1,
+  preferencesStore: { values: {}, updatedAt: {} },
+  serviceReportStore: {
+    serviceReports: {
+      '2026': {
+        '0': reports,
+      },
+    },
+  },
+})
+
+describe('normalizeLegacyPayloadFieldNames — ServiceReport.ldc collapse', () => {
+  it('rewrites a legacy `ldc: true` entry to the LDC builtin Category', () => {
+    const d = makeReportsPayload([
+      { id: 'r1', hours: 2, minutes: 0, ldc: true, credit: true },
+    ])
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    const report = d.serviceReportStore.serviceReports['2026']['0'][0]
+    expect(report.categoryId).toBe(LDC_BUILTIN)
+    expect(report.credit).toBe(true)
+    expect(report).not.toHaveProperty('ldc')
+  })
+
+  it('keeps an existing non-LDC categoryId; drops the stray ldc flag', () => {
+    // Data corruption shape: ldc: true coexisting with a real user Category.
+    // Explicit Category wins, same precedence as `migrateLdcToCategory`.
+    const d = makeReportsPayload([
+      {
+        id: 'r1',
+        hours: 1,
+        minutes: 0,
+        ldc: true,
+        categoryId: 'user-cat-bethel',
+        credit: true,
+      },
+    ])
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    const report = d.serviceReportStore.serviceReports['2026']['0'][0]
+    expect(report.categoryId).toBe('user-cat-bethel')
+    expect(report).not.toHaveProperty('ldc')
+  })
+
+  it('strips `ldc: false` so the on-disk shape matches the canonical type', () => {
+    const d = makeReportsPayload([
+      { id: 'r1', hours: 1, minutes: 0, ldc: false, credit: false },
+    ])
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    const report = d.serviceReportStore.serviceReports['2026']['0'][0]
+    expect(report).not.toHaveProperty('ldc')
+    expect(report.categoryId).toBeUndefined()
+  })
+
+  it('is idempotent on an already-collapsed payload', () => {
+    const d = makeReportsPayload([
+      {
+        id: 'r1',
+        hours: 2,
+        minutes: 0,
+        categoryId: LDC_BUILTIN,
+        credit: true,
+      },
+    ])
+    normalizeLegacyPayloadFieldNames(d)
+    const snapshot = JSON.stringify(d)
+    normalizeLegacyPayloadFieldNames(d)
+    expect(JSON.stringify(d)).toBe(snapshot)
+  })
+
+  it('no-ops when serviceReportStore is missing or malformed', () => {
+    const d1 = { version: 1, preferencesStore: { values: {}, updatedAt: {} } }
+    expect(() =>
+      normalizeLegacyPayloadFieldNames(d1 as Record<string, unknown>)
+    ).not.toThrow()
+    const d2 = {
+      version: 1,
+      preferencesStore: { values: {}, updatedAt: {} },
+      serviceReportStore: { serviceReports: null },
+    }
+    expect(() =>
+      normalizeLegacyPayloadFieldNames(d2 as Record<string, unknown>)
+    ).not.toThrow()
+  })
+})

--- a/src/app/sync/payloadFieldRenames.ts
+++ b/src/app/sync/payloadFieldRenames.ts
@@ -29,6 +29,14 @@
  *   from any straggler `tag` fields after the iCloud merge — see
  *   `src/lib/categories.ts`. Doing the rewrite here would require access to the
  *   Categories store, which violates the no-imports rule for this module.
+ * - `serviceReportStore.serviceReports.*.*.ldc: true` (per entry) is rewritten to
+ *   `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true` when the entry doesn't
+ *   already carry a `categoryId`. When an explicit non-LDC `categoryId` is
+ *   present, the `ldc` flag is dropped (the explicit Category wins; same
+ *   precedence as `migrateLdcToCategory`). The LDC builtin id is inlined as a
+ *   literal so this module stays free of cross-tier imports;
+ *   `LDC_BUILTIN_CATEGORY_ID` in `src/constants/categories.ts` is its canonical
+ *   home.
  *
  * New name wins if both keys somehow coexist on the wire (defensive); the
  * legacy key is always dropped.
@@ -40,17 +48,26 @@ const LEGACY_PROFILE_KEYS = [
   'hasCompletedProfileSetup',
 ] as const
 
+// Stable LDC builtin Category id. Kept in sync with
+// `src/constants/categories.ts`'s `LDC_BUILTIN_CATEGORY_ID`. Inlined here
+// because this module must remain import-free for the unit-test isolation
+// reason above. If you change one, change the other.
+const LDC_BUILTIN_CATEGORY_ID_LITERAL = 'ldc-builtin-3f9c4a1d'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function normalizeLegacyPayloadFieldNames(d: any): void {
   const prefs = d?.preferencesStore
-  if (!prefs || typeof prefs !== 'object') return
-  renameKey(prefs.values, 'excludedWeekdays', 'offDays')
-  renameKey(prefs.values, 'meetingWeekdays', 'meetingDays')
-  renameKey(prefs.values, 'publisher', 'role')
-  renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
-  renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
-  renameKey(prefs.updatedAt, 'publisher', 'role')
+  if (prefs && typeof prefs === 'object') {
+    renameKey(prefs.values, 'excludedWeekdays', 'offDays')
+    renameKey(prefs.values, 'meetingWeekdays', 'meetingDays')
+    renameKey(prefs.values, 'publisher', 'role')
+    renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
+    renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
+    renameKey(prefs.updatedAt, 'publisher', 'role')
+  }
+
   routeLegacyProfileFields(d)
+  collapseLdcFlagOnServiceReports(d?.serviceReportStore?.serviceReports)
 }
 
 /**
@@ -114,6 +131,49 @@ function routeLegacyProfileFields(d: any): void {
         profile.updatedAt[key] = timestampsObj[key]
       }
       delete timestampsObj[key]
+    }
+  }
+}
+
+/**
+ * Per-ServiceReport rewrite of the legacy `ldc: true` flag onto the LDC builtin
+ * Category id. Mirrors the boot-time `migrateLdcToCategory` so payloads from
+ * older peers don't re-introduce `ldc` after the local install has already
+ * collapsed it.
+ *
+ * Precedence (matches the boot runner):
+ *
+ * - `ldc: true` + no `categoryId` → set `categoryId: <LDC builtin>` + `credit:
+ *   true`; drop `ldc`.
+ * - `ldc: true` + non-LDC `categoryId` → keep `categoryId` (explicit wins); drop
+ *   `ldc`.
+ * - `ldc: true` + LDC builtin `categoryId` → idempotent; drop `ldc`.
+ * - `ldc: false` or missing → drop the field if present.
+ */
+function collapseLdcFlagOnServiceReports(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serviceReports: any
+): void {
+  if (!serviceReports || typeof serviceReports !== 'object') return
+  for (const yearKey of Object.keys(serviceReports)) {
+    const months = serviceReports[yearKey]
+    if (!months || typeof months !== 'object') continue
+    for (const monthKey of Object.keys(months)) {
+      const reports = months[monthKey]
+      if (!Array.isArray(reports)) continue
+      for (const report of reports) {
+        if (!report || typeof report !== 'object') continue
+        if (!('ldc' in report)) continue
+        const ldcTrue = report.ldc === true
+        delete report.ldc
+        if (!ldcTrue) continue
+        const hasNonLdcCategory =
+          typeof report.categoryId === 'string' &&
+          report.categoryId !== LDC_BUILTIN_CATEGORY_ID_LITERAL
+        if (hasNonLdcCategory) continue
+        report.categoryId = LDC_BUILTIN_CATEGORY_ID_LITERAL
+        report.credit = true
+      }
     }
   }
 }

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,49 @@
+import { Category } from '@/types/category'
+
+/**
+ * Stable, install-independent UUID for the LDC builtin Category. Hard-coded as
+ * a constant (rather than generated per device) so cross-device iCloud merges
+ * can match by id without ambiguity — every device that runs the LDC collapse
+ * migration seeds the same record.
+ *
+ * Treat this id as forever-immutable: changing it would orphan every entry
+ * migrated under the old value and create a duplicate "LDC" Category on
+ * existing installs.
+ *
+ * Glossary: `LDC Time` is a common variety of `Credit Time` (see CONTEXT.md).
+ * The builtin Category gives "LDC" first-class representation in the Categories
+ * store; the cap math reads it through the normal Category seam (`isCredit:
+ * true`).
+ */
+export const LDC_BUILTIN_CATEGORY_ID = 'ldc-builtin-3f9c4a1d'
+
+/**
+ * User-visible label for the LDC builtin Category. Stored on the Category
+ * record at seed time so legacy locale rendering keeps working; the
+ * picker/breakdown UI still routes through `i18n.t('ldc')` for translated
+ * display.
+ */
+export const LDC_BUILTIN_CATEGORY_NAME = 'LDC'
+
+/**
+ * Returns true when the Category record represents the LDC builtin. Prefer the
+ * `builtin` flag (post-seed) but fall back to id match so a record that
+ * pre-dates the `builtin` field still resolves correctly.
+ */
+export const isLdcBuiltinCategory = (category: {
+  id: string
+  builtin?: boolean
+}) => category.builtin === true || category.id === LDC_BUILTIN_CATEGORY_ID
+
+/**
+ * Produces the canonical LDC builtin Category record. Callers must stamp
+ * `updatedAt` themselves (typically Date.now()) so the record participates in
+ * iCloud last-writer-wins merge alongside user-created Categories.
+ */
+export const makeLdcBuiltinCategory = (now: number): Category => ({
+  id: LDC_BUILTIN_CATEGORY_ID,
+  name: LDC_BUILTIN_CATEGORY_NAME,
+  isCredit: true,
+  builtin: true,
+  updatedAt: now,
+})

--- a/src/features/service-reports/components/AllDaysList.tsx
+++ b/src/features/service-reports/components/AllDaysList.tsx
@@ -9,7 +9,7 @@ import useCategories from '@/stores/categories'
 import useTheme from '@/contexts/theme'
 import i18n from '@/lib/locales'
 import { getMonthsReports } from '@/lib/serviceReport'
-import { getCategoryLabel } from '@/lib/serviceReportCategory'
+import { getCategoryLabel, isLdcEntry } from '@/lib/serviceReportCategory'
 import { ServiceReport } from '@/types/serviceReport'
 import { RootStackNavigation } from '@/types/rootStack'
 
@@ -150,13 +150,14 @@ const AllDaysList = ({ month, year }: AllDaysListProps) => {
       let categoryLabel = '—'
       if (reportsForDay.length > 0) {
         // Group by stable identity: prefer categoryId (post-migration), fall
-        // back to the legacy `tag` string for unmigrated entries, and use
-        // synthetic keys for rollover / ldc / plain-standard so the bucket
-        // logic doesn't collide a Category named "ldc" with the real LDC
-        // bucket.
+        // back to the legacy `tag` string for unmigrated entries, with
+        // synthetic keys for rollover / plain-standard. LDC is keyed by its
+        // builtin Category id like any other Category — `isLdcEntry` also
+        // matches legacy `ldc: true` entries so unmigrated installs still
+        // bucket correctly.
         const keyFor = (r: ServiceReport): string => {
           if (r.rollover) return '__rollover__'
-          if (r.ldc) return '__ldc__'
+          if (isLdcEntry(r)) return '__ldc__'
           if (r.categoryId) return `cat:${r.categoryId}`
           if (r.tag) return `tag:${r.tag}`
           return '__standard__'

--- a/src/features/service-reports/components/OnboardingBackfillForm.tsx
+++ b/src/features/service-reports/components/OnboardingBackfillForm.tsx
@@ -19,6 +19,7 @@ import { usePreferences } from '@/stores/preferences'
 import useServiceReport from '@/stores/serviceReport'
 import { getServiceYearFromDate } from '@/lib/serviceReport'
 import { ServiceReportsByYears } from '@/types/serviceReport'
+import { LDC_BUILTIN_CATEGORY_ID } from '@/constants/categories'
 
 interface MonthRow {
   monthIndex: number
@@ -233,21 +234,22 @@ const OnboardingBackfillForm = ({
           date,
           hours,
           minutes: 0,
-          ldc: false,
           credit: false,
         })
       }
       if (creditHours > 0) {
-        // Bucket as `ldc: true` so the cap pipeline counts it as credit time
-        // (see `getTotalMinutesForServiceYear`). The cap math sums ldc and
-        // tag-with-credit into `credit`; we use ldc here to avoid surfacing
-        // a synthetic tag in the user's tag list.
+        // Attach to the LDC builtin Category so the cap pipeline counts it as
+        // credit time (see `getTotalMinutesForServiceYear` — LDC entries fold
+        // into the credit bucket alongside any other credit-bearing
+        // Category). LDC is the most-frequent credit category for backfill,
+        // and routing onboarding credit through it avoids inventing a
+        // synthetic category name.
         addServiceReport({
           id: Crypto.randomUUID(),
           date,
           hours: creditHours,
           minutes: 0,
-          ldc: true,
+          categoryId: LDC_BUILTIN_CATEGORY_ID,
           credit: true,
         })
       }

--- a/src/features/service-reports/components/TimeReportRow.tsx
+++ b/src/features/service-reports/components/TimeReportRow.tsx
@@ -19,7 +19,7 @@ import { RootStackNavigation } from '@/types/rootStack'
 import { useFormattedMinutes } from '@/lib/minutes'
 import { useCardStyle } from '@/components/ui/Card'
 import useCategories from '@/stores/categories'
-import { getCategoryLabel } from '@/lib/serviceReportCategory'
+import { getCategoryLabel, isLdcEntry } from '@/lib/serviceReportCategory'
 
 interface TimeReportRowProps {
   report: ServiceReport
@@ -34,6 +34,7 @@ const TimeReportRow = ({ report, onPress }: TimeReportRowProps) => {
   const navigation = useNavigation<RootStackNavigation>()
   const toast = useToastController()
   const categoryLabel = getCategoryLabel(report, categories)
+  const isLdc = isLdcEntry(report)
 
   const totalMinutes = report.hours * 60 + report.minutes
   const formattedTime = useFormattedMinutes(Math.abs(totalMinutes))
@@ -202,9 +203,9 @@ const TimeReportRow = ({ report, onPress }: TimeReportRowProps) => {
             </Text>
           </View>
         )}
-        {!isRollover && (report.ldc || categoryLabel || report.note) && (
+        {!isRollover && (isLdc || categoryLabel || report.note) && (
           <View style={{ gap: 5 }}>
-            {(report.ldc || categoryLabel) && (
+            {(isLdc || categoryLabel) && (
               <View
                 style={{
                   flexDirection: 'row',
@@ -212,16 +213,16 @@ const TimeReportRow = ({ report, onPress }: TimeReportRowProps) => {
                   alignItems: 'center',
                 }}
               >
-                {report.ldc && <IconButton icon={faPersonDigging} />}
+                {isLdc && <IconButton icon={faPersonDigging} />}
                 <Text
                   style={{
                     color: theme.colors.textAlt,
                     fontSize: theme.fontSize('sm'),
                   }}
                 >
-                  {report.ldc ? i18n.t('ldc') : categoryLabel}
+                  {isLdc ? i18n.t('ldc') : categoryLabel}
                 </Text>
-                {(report.credit || report.ldc) && <CreditBadge />}
+                {(report.credit || isLdc) && <CreditBadge />}
               </View>
             )}
             {report.note && (

--- a/src/features/service-reports/screens/AddTimeScreen.tsx
+++ b/src/features/service-reports/screens/AddTimeScreen.tsx
@@ -19,6 +19,7 @@ import SelectWheel from '@/components/ui/SelectWheel'
 import { usePreferences } from '@/stores/preferences'
 import useCategories from '@/stores/categories'
 import { Category } from '@/types/category'
+import { LDC_BUILTIN_CATEGORY_ID } from '@/constants/categories'
 import TextInput from '@/components/ui/TextInput'
 import Button from '@/components/ui/Button'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
@@ -56,10 +57,12 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
   /**
    * Synthetic select values for the two preset entry types that don't
    * correspond to a real Category record. Real categories use their UUID as the
-   * value.
+   * value. LDC is no longer synthetic — it's the LDC builtin Category (see
+   * `LDC_BUILTIN_CATEGORY_ID`); the constant is re-exported here so the picker
+   * can show it alongside the synthetic Standard / Custom presets.
    */
   const STANDARD = '__standard__'
-  const LDC = '__ldc__'
+  const LDC = LDC_BUILTIN_CATEGORY_ID
   const CUSTOM = '__custom__'
 
   const {
@@ -73,11 +76,11 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
     ? getReport(serviceReports, JSON.parse(route.params.existingReport))
     : undefined
 
-  // Initial picker value: prefer LDC if the entry is flagged LDC, else the
-  // referenced Category id (post-migration), else fall back to legacy `tag`
-  // string for unmigrated entries, else Standard.
+  // Initial picker value: the referenced Category id (post-migration), else
+  // fall back to legacy `tag` string for unmigrated entries, else Standard.
+  // LDC is no longer special-cased — entries that point at the LDC builtin
+  // Category id pick it up here like any other Category.
   const initialPickerValue: string = (() => {
-    if (existingServiceReport?.report.ldc) return LDC
     if (existingServiceReport?.report.categoryId) {
       return existingServiceReport.report.categoryId
     }
@@ -103,18 +106,17 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
     date: moment(
       existingServiceReport?.report.date ?? route.params?.date
     ).toDate(),
-    ldc: existingServiceReport?.report.ldc ?? false,
     credit: existingServiceReport?.report.credit ?? false,
     categoryId: existingServiceReport?.report.categoryId,
     note: existingServiceReport?.report.note ?? '',
   })
   const toast = useToastController()
 
-  // The Category currently in focus (null when Standard / LDC / Custom is selected).
+  // The Category currently in focus. Null when one of the synthetic preset
+  // values (Standard / Custom) is selected; non-null for a real Category id
+  // including the LDC builtin.
   const selectedCategory: Category | null =
-    selectedValue === STANDARD ||
-    selectedValue === LDC ||
-    selectedValue === CUSTOM
+    selectedValue === STANDARD || selectedValue === CUSTOM
       ? null
       : (categories.find((c) => c.id === selectedValue) ?? null)
 
@@ -124,27 +126,15 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
       case STANDARD:
         setServiceReport({
           ...serviceReport,
-          ldc: false,
           categoryId: undefined,
           tag: undefined,
           credit: false,
         })
         return
 
-      case LDC:
-        setServiceReport({
-          ...serviceReport,
-          ldc: true,
-          categoryId: undefined,
-          tag: undefined,
-          credit: true,
-        })
-        return
-
       case CUSTOM:
         setServiceReport({
           ...serviceReport,
-          ldc: false,
           categoryId: undefined,
           tag: undefined,
           credit: false,
@@ -152,12 +142,11 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
         return
 
       default: {
-        // A real Category id.
+        // A real Category id (user-created OR the LDC builtin).
         const category = categories.find((c) => c.id === value)
         if (!category) return
         setServiceReport({
           ...serviceReport,
-          ldc: false,
           categoryId: category.id,
           tag: undefined,
           credit: category.isCredit,
@@ -263,10 +252,18 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
   }
 
   type TypeOption = { label: string; value: string }
+  // LDC is technically a Category record now (the builtin), but we still
+  // surface it as a preset slot above the user's own categories — it's the
+  // most common credit-bearing entry type and worth a stable position in the
+  // picker. Strip it from the user-categories spread so it doesn't appear
+  // twice.
+  const userCategories = categories.filter(
+    (c) => c.id !== LDC_BUILTIN_CATEGORY_ID
+  )
   const typeOptions: TypeOption[] = [
     { label: i18n.t('standard'), value: STANDARD },
     { label: i18n.t('ldc'), value: LDC },
-    ...categories.map((c) => ({
+    ...userCategories.map((c) => ({
       // Allow i18n on preset-translatable names (e.g. legacy English-locale
       // entries seeded from the migration); fall back to the stored name.
       label: i18n.t(c.name as TranslationKey, { defaultValue: c.name }),
@@ -524,7 +521,11 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
                         flexShrink: 1,
                       }}
                     >
-                      {hasAnnualGoal && (
+                      {/* Builtin Categories (LDC) own their `isCredit` value
+                          and can't be renamed or deleted — hide the Credit
+                          toggle + remove button. The LDC builtin is always
+                          credit-bearing by definition. */}
+                      {hasAnnualGoal && !selectedCategory.builtin && (
                         <View
                           style={{
                             borderWidth: 1,
@@ -565,23 +566,25 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
                           </Text>
                         </View>
                       )}
-                      <View
-                        style={{
-                          flexDirection: 'row',
-                          justifyContent: 'flex-end',
-                        }}
-                      >
-                        <Button onPress={handleDeleteCurrentCategory}>
-                          <Text
-                            style={{
-                              color: theme.colors.textAlt,
-                              textDecorationLine: 'underline',
-                            }}
-                          >
-                            {i18n.t('removeCategory')}
-                          </Text>
-                        </Button>
-                      </View>
+                      {!selectedCategory.builtin && (
+                        <View
+                          style={{
+                            flexDirection: 'row',
+                            justifyContent: 'flex-end',
+                          }}
+                        >
+                          <Button onPress={handleDeleteCurrentCategory}>
+                            <Text
+                              style={{
+                                color: theme.colors.textAlt,
+                                textDecorationLine: 'underline',
+                              }}
+                            >
+                              {i18n.t('removeCategory')}
+                            </Text>
+                          </Button>
+                        </View>
+                      )}
                     </View>
                   )
                 )}

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,6 +1,14 @@
 import * as Crypto from 'expo-crypto'
 import { Category } from '@/types/category'
-import { ServiceReport, ServiceReportsByYears } from '@/types/serviceReport'
+import {
+  LegacyServiceReport,
+  ServiceReport,
+  ServiceReportsByYears,
+} from '@/types/serviceReport'
+import {
+  LDC_BUILTIN_CATEGORY_ID,
+  makeLdcBuiltinCategory,
+} from '@/constants/categories'
 
 /**
  * Shape of the legacy `preferences.serviceReportTags` entry. We accept both the
@@ -213,6 +221,148 @@ export function migrateTagsToCategories(
     categories,
     serviceReports: rebuiltReports,
     reconciledCreditMismatches,
+  }
+}
+
+export type LdcCollapseMigrationInput = {
+  /** Persisted ServiceReports — may still carry the legacy `ldc: true` flag. */
+  serviceReports: ServiceReportsByYears
+  /** Existing Category records (post tag-to-Category migration). */
+  categories: Category[]
+  /** Now() in epoch ms — stamped onto the seeded LDC builtin record. */
+  now: number
+}
+
+export type LdcCollapseMigrationResult = {
+  /**
+   * Updated Categories list. Includes the LDC builtin record if it wasn't
+   * already present. Existing categories are returned unchanged.
+   */
+  categories: Category[]
+  /**
+   * Rewritten ServiceReports tree. Every entry that carried `ldc: true` now has
+   * `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true` and no `ldc` field.
+   * Entries that already had a non-LDC `categoryId` keep that `categoryId` (the
+   * explicit Category wins per precedence rule); the `ldc` flag is dropped
+   * regardless.
+   */
+  serviceReports: ServiceReportsByYears
+  /**
+   * Number of entries rewritten from `ldc: true` → LDC builtin Category.
+   * Surfaced for observability — non-zero means the user had at least one LDC
+   * entry that was collapsed onto the builtin.
+   */
+  rewrittenCount: number
+  /**
+   * Number of entries that had BOTH `ldc: true` AND a non-LDC `categoryId`
+   * already set (data corruption — shouldn't happen but possible). The explicit
+   * Category wins; the `ldc` flag is dropped. Surfaced for the PR description /
+   * observability.
+   */
+  conflictedCount: number
+  /**
+   * True when the LDC builtin Category had to be seeded as part of this
+   * migration (i.e. it wasn't already present in the categories list). Used by
+   * the boot runner to decide whether to write the categories store.
+   */
+  seededLdcBuiltin: boolean
+}
+
+/**
+ * One-time migration that collapses the legacy `ServiceReport.ldc` boolean into
+ * the LDC builtin Category (`LDC_BUILTIN_CATEGORY_ID`). After this migration
+ * runs, the `ldc` field is no longer authoritative — LDC entries carry
+ * `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true` and look like any other
+ * credit-bearing Category to the cap math.
+ *
+ * Algorithm:
+ *
+ * 1. Ensure the LDC builtin Category record exists in the user's categories list.
+ *    If absent, seed it (`makeLdcBuiltinCategory(now)`).
+ * 2. Walk every ServiceReport:
+ *
+ *    - If `ldc !== true`: drop the field if present, otherwise return unchanged.
+ *    - If `ldc === true` AND `categoryId === undefined`: set `categoryId:
+ *         LDC_BUILTIN_CATEGORY_ID, credit: true`; drop `ldc`.
+ *    - If `ldc === true` AND `categoryId` is already set to a non-LDC value (data
+ *         corruption): keep `categoryId` as-is (explicit Category wins); drop
+ *         `ldc`. Count under `conflictedCount`.
+ * 3. Idempotent — entries that already have `categoryId: LDC_BUILTIN_CATEGORY_ID`
+ *    and no `ldc` field are returned unchanged; the builtin is only seeded if
+ *    it wasn't already present.
+ *
+ * The migration is pure: no store access, no side effects. The boot runner in
+ * `src/app/App.tsx` gates it on `preferences.hasCollapsedLdcIntoCategory` and
+ * sequences it after `migrateTagsToCategories` so the categories list is fully
+ * populated before LDC is folded in.
+ */
+export function migrateLdcToCategory(
+  args: LdcCollapseMigrationInput
+): LdcCollapseMigrationResult {
+  const { serviceReports, categories, now } = args
+
+  const hasLdcBuiltin = categories.some((c) => c.id === LDC_BUILTIN_CATEGORY_ID)
+  const seededLdcBuiltin = !hasLdcBuiltin
+
+  const outCategories: Category[] = hasLdcBuiltin
+    ? categories
+    : [...categories, makeLdcBuiltinCategory(now)]
+
+  let rewrittenCount = 0
+  let conflictedCount = 0
+  const rebuiltReports: ServiceReportsByYears = {}
+
+  for (const [yearKey, year] of Object.entries(serviceReports)) {
+    rebuiltReports[yearKey] = {}
+    for (const [monthKey, month] of Object.entries(year)) {
+      rebuiltReports[yearKey][monthKey] = month.map((report) => {
+        // Treat the input as the legacy shape so we can read `ldc` even
+        // though the canonical type no longer exposes it.
+        const legacy = report as LegacyServiceReport
+        if (legacy.ldc !== true) {
+          // Defensive: an entry might carry `ldc: false` from older writers.
+          // Strip the field so the on-disk shape matches the canonical type
+          // after migration.
+          if ('ldc' in (legacy as Record<string, unknown>)) {
+            const { ldc: _drop, ...rest } = legacy as ServiceReport & {
+              ldc?: boolean
+            }
+            return rest
+          }
+          return report
+        }
+        // `ldc === true` — figure out where the entry should land.
+        const hasNonLdcCategory =
+          typeof legacy.categoryId === 'string' &&
+          legacy.categoryId !== LDC_BUILTIN_CATEGORY_ID
+        if (hasNonLdcCategory) {
+          // Explicit Category wins; drop the LDC flag. Count under conflicts.
+          conflictedCount += 1
+          const { ldc: _drop, ...rest } = legacy as ServiceReport & {
+            ldc?: boolean
+          }
+          return rest
+        }
+        // Standard LDC entry (no other categoryId): fold onto the builtin.
+        rewrittenCount += 1
+        const { ldc: _drop, ...rest } = legacy as ServiceReport & {
+          ldc?: boolean
+        }
+        return {
+          ...rest,
+          categoryId: LDC_BUILTIN_CATEGORY_ID,
+          credit: true,
+        }
+      })
+    }
+  }
+
+  return {
+    categories: outCategories,
+    serviceReports: rebuiltReports,
+    rewrittenCount,
+    conflictedCount,
+    seededLdcBuiltin,
   }
 }
 

--- a/src/lib/serviceReport.ts
+++ b/src/lib/serviceReport.ts
@@ -10,7 +10,7 @@ import {
   ServiceReportsByYears,
   ServiceYear,
 } from '@/types/serviceReport'
-import { hasCategory } from '@/lib/serviceReportCategory'
+import { hasCategory, isLdcEntry } from '@/lib/serviceReportCategory'
 import moment from 'moment'
 import { monthCreditMaxMinutes } from '@/constants/serviceReports'
 import { creditCapMinutesFor, getEntryMode } from '@/lib/publisherCapabilities'
@@ -65,15 +65,18 @@ export const getTotalMinutesDetailedForSpecificMonth = (
     const m = momentStoredDate(report.date)
     return m.month() === month && m.year() === year
   })
+  // "Other" deliberately excludes LDC entries — LDC has its own visual slice
+  // in the breakdown via `ldcMinutesForSpecificMonth`, and double-counting it
+  // here would inflate the credit total.
   const otherWithNonCreditMinutes = reportsForMonth.reduce((prev, report) => {
-    if (hasCategory(report) && !report.credit) {
+    if (hasCategory(report) && !isLdcEntry(report) && !report.credit) {
       return prev + report.hours * 60 + report.minutes
     }
     return prev
   }, 0)
 
   const otherWithCreditMinutes = reportsForMonth.reduce((prev, report) => {
-    if (hasCategory(report) && report.credit) {
+    if (hasCategory(report) && !isLdcEntry(report) && report.credit) {
       return prev + report.hours * 60 + report.minutes
     }
     return prev
@@ -217,7 +220,11 @@ export const ldcMinutesForSpecificMonth = (
   const totalMinutesForMonth = monthsReports
     .filter((report) => {
       const m = momentStoredDate(report.date)
-      return m.month() === targetMonth && m.year() === targetYear && report.ldc
+      return (
+        m.month() === targetMonth &&
+        m.year() === targetYear &&
+        isLdcEntry(report)
+      )
     })
     .reduce((accumulator, report) => {
       return accumulator + report.hours * 60 + report.minutes
@@ -253,7 +260,12 @@ export const otherMinutesForSpecificMonth = (
     const m = momentStoredDate(report.date)
     return m.month() === targetMonth && m.year() === targetYear
   })
-  const taggedReports = reportsForMonth.filter((report) => hasCategory(report))
+  // LDC entries are surfaced via their own breakdown slice (see
+  // `ldcMinutesForSpecificMonth`); exclude them from "other" so the LDC
+  // builtin doesn't appear as a duplicate row in the user Categories list.
+  const taggedReports = reportsForMonth.filter(
+    (report) => hasCategory(report) && !isLdcEntry(report)
+  )
 
   const otherReportsTotalMinutes = taggedReports.reduce<OtherReports>(
     (accumulator, report) => {
@@ -299,7 +311,7 @@ export const standardMinutesForSpecificMonth = (
       return (
         m.month() === targetMonth &&
         m.year() === targetYear &&
-        !report.ldc &&
+        !isLdcEntry(report) &&
         !hasCategory(report)
       )
     })
@@ -413,11 +425,13 @@ export const getTotalMinutesForServiceYear = (
       let otherWithoutCredit = 0
       for (const report of monthReports) {
         const m = report.hours * 60 + report.minutes
-        if (hasCategory(report)) {
+        if (isLdcEntry(report)) {
+          // LDC keeps its own bucket so visual breakdowns stay separable; the
+          // cap math below folds it back into the credit total anyway.
+          ldc += m
+        } else if (hasCategory(report)) {
           if (report.credit) otherWithCredit += m
           else otherWithoutCredit += m
-        } else if (report.ldc) {
-          ldc += m
         } else {
           standardOnly += m
         }

--- a/src/lib/serviceReportCategory.ts
+++ b/src/lib/serviceReportCategory.ts
@@ -1,11 +1,33 @@
 import { Category } from '@/types/category'
-import { ServiceReport } from '@/types/serviceReport'
+import { LegacyServiceReport, ServiceReport } from '@/types/serviceReport'
+import { LDC_BUILTIN_CATEGORY_ID } from '@/constants/categories'
+
+/**
+ * Returns true when a ServiceReport is an LDC entry — either pointing at the
+ * LDC builtin Category (post-collapse) OR carrying the legacy `ldc: true` flag
+ * (pre-collapse). Centralises the LDC predicate so callers don't have to know
+ * whether the migration has run yet; mirrors how `hasCategory` smooths over the
+ * tag → categoryId transition.
+ *
+ * @see migrateLdcToCategory — rewrites `ldc: true` → `categoryId: LDC_BUILTIN_CATEGORY_ID`.
+ */
+export const isLdcEntry = (report: ServiceReport): boolean => {
+  if (report.categoryId === LDC_BUILTIN_CATEGORY_ID) return true
+  // Legacy `ldc: true` field — still readable on persisted state that
+  // pre-dates the collapse migration; the field is dropped on read by the
+  // boot runner and by the iCloud field-rename shim.
+  return (report as LegacyServiceReport).ldc === true
+}
 
 /**
  * Returns true when a ServiceReport belongs to a user-defined Category (i.e.
- * not a Standard entry, not LDC). Replaces the legacy `report.tag` truthiness
- * check, but also accepts the new `report.categoryId` so callers don't need to
- * know whether the migration has run yet.
+ * not a Standard entry). Replaces the legacy `report.tag` truthiness check, but
+ * also accepts the new `report.categoryId` so callers don't need to know
+ * whether the migration has run yet.
+ *
+ * Note: post-LDC-collapse, LDC entries are also "categorised" (they reference
+ * the LDC builtin Category). Callers that want to distinguish LDC from
+ * user-created categories should chain `!isLdcEntry(report)`.
  *
  * @see migrateTagsToCategories — converts legacy `tag` into `categoryId`.
  */
@@ -40,7 +62,10 @@ export const isReportCreditTime = (
   report: ServiceReport,
   categories: Category[]
 ): boolean => {
-  if (report.ldc) return true
+  // Legacy `ldc: true` is still readable from pre-collapse persisted state
+  // and incoming sync payloads from older peers (see
+  // `payloadFieldRenames.ts`).
+  if ((report as LegacyServiceReport).ldc) return true
   if (report.categoryId) {
     const found = categories.find((c) => c.id === report.categoryId)
     if (found) return found.isCredit

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -37,16 +37,31 @@ export const useCategories = create(
         }),
       updateCategory: (category: Partial<Category> & { id: string }) =>
         set(({ categories }) => ({
-          categories: categories.map((c) =>
-            c.id === category.id
-              ? { ...c, ...category, updatedAt: Date.now() }
-              : c
-          ),
+          categories: categories.map((c) => {
+            if (c.id !== category.id) return c
+            // Builtin Categories (LDC) can have `isCredit` flipped but their
+            // identity (id, name, builtin flag) is immutable. Strip those
+            // fields from the partial update so a misbehaving caller can't
+            // rename the LDC Category to something else.
+            if (c.builtin) {
+              const {
+                name: _dropName,
+                builtin: _dropBuiltin,
+                id: _dropId,
+                ...rest
+              } = category
+              return { ...c, ...rest, updatedAt: Date.now() }
+            }
+            return { ...c, ...category, updatedAt: Date.now() }
+          }),
         })),
       deleteCategory: (id: string) =>
         set(({ categories, deletedCategories }) => {
           const found = categories.find((c) => c.id === id)
           if (!found) return {}
+          // Builtin Categories (LDC) cannot be deleted — they're seeded on
+          // every device and the cap math relies on a stable id.
+          if (found.builtin) return {}
           const now = Date.now()
           return {
             categories: categories.filter((c) => c.id !== id),

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -340,6 +340,17 @@ export const PREFERENCE_DEFAULTS = {
    * migrates its own persisted state once.
    */
   hasMigratedProfileFromPreferences: false,
+  /**
+   * One-shot flag for the LDC → builtin Category migration. Boot runner gates
+   * on this: when false, it seeds the LDC builtin Category record (stable id
+   * `LDC_BUILTIN_CATEGORY_ID`) and rewrites every ServiceReport with `ldc:
+   * true` to use `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true` instead.
+   * See `migrateLdcToCategory` in `src/lib/categories.ts`. Must run AFTER
+   * `hasMigratedTagsToCategories` so the categories list is fully populated
+   * before LDC is folded in. Non-syncable — each device migrates its own
+   * persisted state once.
+   */
+  hasCollapsedLdcIntoCategory: false,
   hasAttemptedToMigrateToMmkv: false,
   /**
    * Hidden dev tools for diagnosing issues. To enable/disable, navigate to
@@ -732,6 +743,7 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
   'hasMigratedCustomFieldsToIds',
   'hasMigratedTagsToCategories',
   'hasMigratedProfileFromPreferences',
+  'hasCollapsedLdcIntoCategory',
   // Legacy field — removed from the schema but may still exist on disk for
   // installs that pre-date the id-keyed migration. Listed here so the boot
   // cleanup that wipes it doesn't propagate the deletion through sync.

--- a/src/stores/serviceReport.ts
+++ b/src/stores/serviceReport.ts
@@ -77,6 +77,11 @@ export const migrateServiceReports = (
  *   ServiceReport store's persisted shape is tagged as post-migration once the
  *   runner has executed. The migration step itself is a no-op at the persist
  *   layer — the boot runner is the source of truth.
+ * - V3 → v4: structural bump for the LDC collapse refactor. The actual `ldc:
+ *   true` → `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true` rewrite happens
+ *   in a boot-time runner (`migrateLdcToCategory` in `src/lib/categories.ts`)
+ *   for the same multi-store coordination reason. Same no-op pattern — the
+ *   version bump tags the on-disk shape as post-collapse.
  *
  * Exported for unit testing.
  */
@@ -110,6 +115,11 @@ export const migrateServiceReportPersistedState = (
   // itself is performed by the boot-time runner in `src/app/App.tsx`; this
   // hook only exists so the persisted-state version reflects the on-disk
   // schema once the runner has executed.
+  // v3 → v4: structural marker for the LDC → builtin Category collapse. Same
+  // shape as v2 → v3 — no on-disk rewrite here; the boot runner in
+  // `src/app/App.tsx` (`migrateLdcToCategory`) coordinates the actual change
+  // because it needs to write across the categories + service reports +
+  // preferences stores in one shot.
   return next
 }
 
@@ -547,7 +557,7 @@ export const useServiceReport = create(
       storage: createJSONStorage(() =>
         hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
       ),
-      version: 3,
+      version: 4,
       migrate: (persistedState, version) =>
         migrateServiceReportPersistedState(persistedState, version),
     }

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -22,6 +22,14 @@ export type Category = {
    */
   isCredit: boolean
   /**
+   * App-seeded "builtin" Categories the User cannot rename or delete — LDC is
+   * the canonical example (`LDC_BUILTIN_CATEGORY_ID`). Absent/false on every
+   * user-created Category. UI surfaces (delete button, name edit) gate on this
+   * flag; the categories store hard-blocks mutations against it as a defensive
+   * fallback.
+   */
+  builtin?: boolean
+  /**
    * Epoch ms of the most recent change. Used for iCloud last-writer-wins merge.
    * Optional for historical records that predate sync — backfilled lazily.
    */

--- a/src/types/serviceReport.ts
+++ b/src/types/serviceReport.ts
@@ -3,12 +3,16 @@ export type ServiceReport = {
   hours: number
   minutes: number
   date: Date
-  ldc?: boolean
   /**
    * Reference to a user-defined `Category` record (`types/category.ts`). When
    * set, the entry counts as that category and inherits its `isCredit`
    * attribute. Replaces the legacy `tag: string` field — all writers must use
    * `categoryId` going forward.
+   *
+   * The LDC builtin Category (`LDC_BUILTIN_CATEGORY_ID`) is what legacy `ldc:
+   * true` entries get rewritten to during the LDC collapse migration. After
+   * that migration there is no longer a separate "LDC" boolean — LDC is just a
+   * credit-bearing Category like Bethel or Hospital.
    */
   categoryId?: string
   /**
@@ -47,6 +51,21 @@ export type ServiceReport = {
    * — backfilled lazily.
    */
   updatedAt?: number
+}
+
+/**
+ * Pre-LDC-collapse ServiceReport shape. The canonical `ServiceReport` no longer
+ * carries the `ldc` boolean — LDC is now a builtin Category (see
+ * `src/constants/categories.ts`). This type is used by migration code that
+ * needs to read persisted state from before the collapse ran. Keep this narrow:
+ * nothing in the runtime should consume `ldc` outside the migration step + the
+ * iCloud field-rename shim.
+ *
+ * @deprecated For migration/sync-renames only. Do not write new code that reads
+ *   the `ldc` field.
+ */
+export type LegacyServiceReport = ServiceReport & {
+  ldc?: boolean
 }
 
 /**


### PR DESCRIPTION
## Why

`LDC Time` is a **common variety of Credit Time** per the glossary, not a separate concept. The dual-boolean (`ldc?: boolean` + `credit?: boolean`) on `ServiceReport` was vestigial from before tags existed — the cap math at `src/lib/serviceReport.ts:85` and `:419` already folded LDC + categorised credit into one bucket. With wave-2's Category as first-class, LDC becomes a built-in Category with `isCredit: true` and behaves identically to Bethel, Hospital, etc.

## How

**Option A (seed an LDC builtin Category record).** Stable UUID constant `LDC_BUILTIN_CATEGORY_ID = 'ldc-builtin-3f9c4a1d'` (`src/constants/categories.ts`) so every device matches by id on iCloud merge. New `Category.builtin?: boolean` flag (`src/types/category.ts:18`); the categories store hard-blocks deletes + name/builtin-flag changes on builtin records (`src/stores/categories.ts:37`).

Bethel is **not** seeded — the existing Time Entry form doesn't surface a Bethel preset, so seeding it would expand UI scope beyond this refactor. Users can still create a "Bethel" Category by hand, which is the glossary's documented path.

**Migration chain.** ServiceReport store v3 → v4 (structural marker). One-shot boot-runner in `src/app/App.tsx` gated on the new `preferences.hasCollapsedLdcIntoCategory` flag, **chained after** `hasMigratedTagsToCategories` so the categories list is fully populated before LDC is folded in. For each `ldc: true` entry: set `categoryId: LDC_BUILTIN_CATEGORY_ID, credit: true`, drop the `ldc` field. Precedence on the corruption shape (`ldc: true` + non-LDC `categoryId`): **explicit Category wins**, `ldc` flag dropped.

**iCloud sync.** The LDC builtin record syncs as a regular Category (last-writer-wins merge). Older peers that still write `ldc: true` get normalised on read in `src/app/sync/payloadFieldRenames.ts:48` — same precedence as the boot runner. The shim inlines the LDC builtin id literal because the file is import-free for unit-test isolation.

**Type cleanup.** `ldc` is dropped from the canonical `ServiceReport` type. A separate `LegacyServiceReport = ServiceReport & { ldc?: boolean }` is exported so the migration + sync-rename shim can still read pre-collapse persisted state. The `credit` field stays on `ServiceReport`: legacy/unmigrated entries + the iCloud field-rename shim still depend on it as the fast-path boolean (wave-2 already re-stamps it from `Category.isCredit`), and dropping it cleanly would require a third migration sweep not in scope here.

**Centralised predicate.** `isLdcEntry(report)` in `src/lib/serviceReportCategory.ts` matches either the builtin id OR the legacy `ldc: true` flag, mirroring the `hasCategory` pattern. Cap math + breakdown UI read through it so they work pre- and post-migration without branching.

Key files: `src/lib/categories.ts` (migration), `src/lib/serviceReport.ts` (cap math), `src/app/sync/payloadFieldRenames.ts:48` (iCloud), `src/features/service-reports/screens/AddTimeScreen.tsx` (picker), `src/__tests__/ldcCollapseMigration.test.ts` (8 new tests including a cap-math regression guard).

## Risks

- **ServiceReport v3 → v4 migration**. One-shot at boot; if it throws, the install is stuck on the old shape and the cap math falls back to the legacy `ldc: true` path via `isLdcEntry`. Rollback story: revert this PR — the v4-tagged persisted state stays readable by v3 code because the `ldc` field is just gone, not renamed.
- **LDC builtin appears in every user's Category list.** The post-migration Categories store gains an "LDC" record on first run. UI hides delete + rename on builtins so users can't accidentally orphan their LDC entries. Some users may be surprised to see LDC in their Categories list — flag this in release notes.
- **Cross-device sync for the builtin record.** Every device seeds the same id (`ldc-builtin-3f9c4a1d`), so first-sync between two devices merges by id with no duplicates. iCloud LWW resolves the `isCredit` and `name` fields just like any user-created Category.
- **Existing `credit` overrides on LDC entries.** The migration unconditionally sets `credit: true` on entries it rewrites — matching the LDC builtin's `isCredit: true`. Any user who hand-edited an LDC entry to `credit: false` (no UI path supports this, but the field is on the wire) will have that override clobbered. Acceptable: the brief's "credit attribution lives on the Category" rule.
- **Collision with a user-created Category named "LDC".** If a user already has a Category they named "LDC" (e.g. created post wave-2 from a pre-existing tag), the migration seeds the builtin with the canonical id alongside it. The user ends up with two records — their custom "LDC" (their id, no `builtin` flag) and the builtin (stable id, `builtin: true`). Existing entries on the user's "LDC" Category stay bound to it; legacy `ldc: true` entries get folded onto the builtin. Documented here; not auto-merged because picking the "right" id breaks one set of references.
- **Sync-rename shim duplicates the LDC builtin id literal.** `payloadFieldRenames.ts` stays import-free for vitest isolation (the rationale was already documented in the file). If the constant ever changes, both literals must change together. The file's existing comment block flags this.

## Tests required

- Upgrade an existing user with LDC entries; verify the LDC breakdown line still appears in MonthReport, the cap math still produces the same `adjustedMinutes.value`, and the LDC entries become editable through the picker like any other Category.
- Sandbox an iCloud sync flow between two devices on different app versions — verify a pre-collapse device writing `ldc: true` gets translated by the post-collapse receiver.
- Manual QA on a user who has a custom Category named "LDC" — verify both records appear in the picker and existing entries on the user's record aren't reassigned.