### PR TITLE
refactor: extract Profile store from Preferences

### DIFF
--- a/src/__tests__/preferencesPersistMigration.test.ts
+++ b/src/__tests__/preferencesPersistMigration.test.ts
@@ -195,3 +195,61 @@ describe('preferences persist migrate v1 → v2 (publisher → role)', () => {
     // here is fine — the migration just shouldn't *introduce* the legacy field.
   })
 })
+
+describe('preferences persist migrate v2 → v3 (Profile extraction marker)', () => {
+  // The v2 → v3 step is intentionally a no-op inside the persist `migrate`
+  // callback — the actual split into the new Profile store runs in a boot
+  // runner (`src/app/App.tsx`) so the legacy fields stay readable until that
+  // runner has copied them. See the doc comment on
+  // `migratePreferencesPersistedState`.
+  it('passes the profile-shaped fields through unchanged so the boot runner can read them', () => {
+    const v2State = {
+      role: 'regularPioneer',
+      name: 'Alice',
+      avatar: { type: 'image', value: 'avatar://x' },
+      customAvatarBackground: '#FFAABB',
+      hasCompletedProfileSetup: true,
+      monthlyGoalOverride: 50,
+    }
+
+    const migrated = migratePreferencesPersistedState(v2State, 2)
+
+    expect(migrated.name).toBe('Alice')
+    expect(migrated.avatar).toEqual({ type: 'image', value: 'avatar://x' })
+    expect(migrated.customAvatarBackground).toBe('#FFAABB')
+    expect(migrated.hasCompletedProfileSetup).toBe(true)
+    expect(migrated.role).toBe('regularPioneer')
+    expect(migrated.monthlyGoalOverride).toBe(50)
+  })
+
+  it('is idempotent — re-running on an already-v3 state is a no-op', () => {
+    const v2State = {
+      role: 'regularPioneer',
+      name: 'Alice',
+    }
+    const v3State = migratePreferencesPersistedState(v2State, 2)
+    const v3Again = migratePreferencesPersistedState(v3State, 3)
+
+    expect(JSON.stringify(v3Again)).toEqual(JSON.stringify(v3State))
+  })
+
+  it('chains cleanly through v0 → v3 (renames still apply, profile fields pass through)', () => {
+    const v0State = {
+      excludedWeekdays: [0, 6],
+      meetingWeekdays: [3],
+      publisher: 'regularPioneer',
+      name: 'Alice',
+      avatar: { type: 'image', value: 'avatar://x' },
+    }
+
+    const migrated = migratePreferencesPersistedState(v0State, 0)
+
+    expect(migrated.offDays).toEqual([0, 6])
+    expect(migrated.meetingDays).toEqual([3])
+    expect(migrated.role).toBe('regularPioneer')
+    expect(migrated).not.toHaveProperty('publisher')
+    // Profile fields survive — the boot runner is responsible for moving them.
+    expect(migrated.name).toBe('Alice')
+    expect(migrated.avatar).toEqual({ type: 'image', value: 'avatar://x' })
+  })
+})

--- a/src/__tests__/profileExtraction.test.ts
+++ b/src/__tests__/profileExtraction.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { version: '1.0.0' } },
+}))
+vi.mock('expo-device', () => ({ DeviceType: { TABLET: 2 }, deviceType: 1 }))
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'en-US' }],
+}))
+vi.mock('@/lib/locales', () => ({
+  default: { t: (k: string) => k },
+}))
+vi.mock('@/shaders/registry', () => ({
+  DEFAULT_SHADER_ID: 'holographic',
+}))
+
+import {
+  extractProfileFromPreferences,
+  PROFILE_FIELD_KEYS,
+} from '@/lib/profileMigration'
+
+describe('extractProfileFromPreferences (boot-runner one-shot)', () => {
+  it('splits identity-shaped fields out of a preferences blob into a profile blob', () => {
+    const prefs = {
+      role: 'regularPioneer',
+      name: 'Alice',
+      avatar: { type: 'image', value: 'file:///avatar.jpg' },
+      customAvatarBackground: '#FFAABB',
+      hasCompletedProfileSetup: true,
+      monthlyGoalOverride: 50,
+      preferenceUpdatedAt: {
+        role: 1700000001000,
+        name: 1700000002000,
+        avatar: 1700000003000,
+        customAvatarBackground: 1700000004000,
+        hasCompletedProfileSetup: 1700000005000,
+        monthlyGoalOverride: 1700000006000,
+      },
+    }
+
+    const result = extractProfileFromPreferences(prefs)
+
+    // Profile fields land in the new slice with their timestamps.
+    expect(result.profile.values).toEqual({
+      name: 'Alice',
+      avatar: { type: 'image', value: 'file:///avatar.jpg' },
+      customAvatarBackground: '#FFAABB',
+      hasCompletedProfileSetup: true,
+    })
+    expect(result.profile.updatedAt).toEqual({
+      name: 1700000002000,
+      avatar: 1700000003000,
+      customAvatarBackground: 1700000004000,
+      hasCompletedProfileSetup: 1700000005000,
+    })
+
+    // Preferences no longer carries them.
+    expect(result.preferences).not.toHaveProperty('name')
+    expect(result.preferences).not.toHaveProperty('avatar')
+    expect(result.preferences).not.toHaveProperty('customAvatarBackground')
+    expect(result.preferences).not.toHaveProperty('hasCompletedProfileSetup')
+    expect(result.preferences.role).toBe('regularPioneer')
+    expect(result.preferences.monthlyGoalOverride).toBe(50)
+
+    // Settings-side updatedAt entries for the moved fields are dropped.
+    expect(result.preferences.preferenceUpdatedAt).toEqual({
+      role: 1700000001000,
+      monthlyGoalOverride: 1700000006000,
+    })
+  })
+
+  it('is idempotent — re-running on an already-extracted preferences blob is a no-op', () => {
+    const prefs = {
+      role: 'regularPioneer',
+      monthlyGoalOverride: 50,
+      preferenceUpdatedAt: { role: 1700000001000 },
+    }
+
+    const result = extractProfileFromPreferences(prefs)
+
+    expect(result.profile.values).toEqual({})
+    expect(result.profile.updatedAt).toEqual({})
+    expect(result.preferences).toEqual(prefs)
+  })
+
+  it('returns an empty profile slice when no profile fields are present', () => {
+    const prefs = { role: 'publisher' }
+    const result = extractProfileFromPreferences(prefs)
+    expect(result.profile.values).toEqual({})
+    expect(result.profile.updatedAt).toEqual({})
+  })
+
+  it('preserves profile-field values even when their updatedAt entry is missing', () => {
+    // A pre-sync install may have profile data but no timestamp map.
+    const prefs = {
+      name: 'Bob',
+      avatar: { type: 'emoji', value: '🌱' },
+    }
+    const result = extractProfileFromPreferences(prefs)
+    expect(result.profile.values.name).toBe('Bob')
+    expect(result.profile.values.avatar).toEqual({
+      type: 'emoji',
+      value: '🌱',
+    })
+    expect(result.profile.updatedAt).toEqual({})
+  })
+
+  it('exports the canonical list of profile field keys', () => {
+    // Public contract — the sync layer and the boot runner both rely on this
+    // list. Asserting it explicitly catches accidental drift.
+    expect(new Set(PROFILE_FIELD_KEYS)).toEqual(
+      new Set([
+        'name',
+        'avatar',
+        'customAvatarBackground',
+        'hasCompletedProfileSetup',
+      ])
+    )
+  })
+
+  it('handles the example case from the spec', () => {
+    const v2 = {
+      role: 'regularPioneer',
+      name: 'Alice',
+      avatar: { type: 'image', value: 'avatar://x' },
+      monthlyGoalOverride: 50,
+    }
+    const result = extractProfileFromPreferences(v2)
+    expect(result.preferences).toEqual({
+      role: 'regularPioneer',
+      monthlyGoalOverride: 50,
+    })
+    expect(result.profile.values).toEqual({
+      name: 'Alice',
+      avatar: { type: 'image', value: 'avatar://x' },
+    })
+  })
+})

--- a/src/__tests__/profileStore.test.ts
+++ b/src/__tests__/profileStore.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+
+import { useProfile, PROFILE_DEFAULTS } from '@/stores/profile'
+
+describe('useProfile store', () => {
+  beforeEach(() => {
+    // Reset to defaults between tests. Using setState directly bypasses
+    // the stamping wrapper so we can start each test from a clean slate.
+    useProfile.setState({ ...PROFILE_DEFAULTS, profileUpdatedAt: {} })
+  })
+
+  it('exposes the expected default shape', () => {
+    const state = useProfile.getState()
+    expect(state.name).toBe('')
+    expect(state.avatar).toEqual({ type: 'none', value: '' })
+    expect(state.customAvatarBackground).toBeNull()
+    expect(state.hasCompletedProfileSetup).toBe(false)
+  })
+
+  it('sets the name through the setter', () => {
+    useProfile.getState().setName('Alice')
+    expect(useProfile.getState().name).toBe('Alice')
+  })
+
+  it('sets the avatar through the setter', () => {
+    useProfile.getState().setAvatar({ type: 'emoji', value: '🌱' })
+    expect(useProfile.getState().avatar).toEqual({
+      type: 'emoji',
+      value: '🌱',
+    })
+  })
+
+  it('stamps profileUpdatedAt on syncable field writes', () => {
+    const before = Date.now()
+    useProfile.getState().set({ name: 'Bob' })
+    const after = Date.now()
+    const stamp = useProfile.getState().profileUpdatedAt.name
+    expect(stamp).toBeDefined()
+    expect(stamp).toBeGreaterThanOrEqual(before)
+    expect(stamp).toBeLessThanOrEqual(after)
+  })
+
+  it('updates the customAvatarBackground field', () => {
+    useProfile.getState().set({ customAvatarBackground: '#112233' })
+    expect(useProfile.getState().customAvatarBackground).toBe('#112233')
+  })
+
+  it('flips hasCompletedProfileSetup independently of other fields', () => {
+    useProfile.getState().set({ hasCompletedProfileSetup: true })
+    expect(useProfile.getState().hasCompletedProfileSetup).toBe(true)
+    expect(useProfile.getState().name).toBe('') // unchanged
+  })
+})

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,6 +52,8 @@ import {
 import useContacts from '@/stores/contactsStore'
 import useCategories from '@/stores/categories'
 import useServiceReport from '@/stores/serviceReport'
+import { useProfile } from '@/stores/profile'
+import { extractProfileFromPreferences } from '@/lib/profileMigration'
 import { migrateCustomFieldsToIds } from '@/features/contacts/lib/customFieldsMigration'
 import { migrateTagsToCategories } from '@/lib/categories'
 import AnimationViewProvider from '@/providers/AnimationViewProvider'
@@ -391,6 +393,78 @@ export default function App() {
       hasMigratedTagsToCategories: true,
       ...({ serviceReportTags: undefined } as Record<string, unknown>),
     } as never)
+  }, [hasMigrated])
+
+  // Split the identity-shaped fields out of the legacy preferences blob into
+  // the new Profile store (`@/stores/profile`). Runs once per install after
+  // MMKV is ready, gated on `hasMigratedProfileFromPreferences`. The
+  // preferences persist `migrate` callback at v2 → v3 is intentionally a
+  // no-op for this split (it can only return its own blob); this runner is
+  // the single source of truth for both the seeding AND the cleanup. See
+  // `src/lib/profileMigration.ts` for the pure transform.
+  //
+  // Wave-3 of the store-narrowing series (after customFieldsMigration and
+  // tagsToCategories). Mirrors that pattern: the runner reads legacy fields
+  // from the rehydrated preferences state via a cast (the keys are no longer
+  // in PREFERENCE_DEFAULTS, so combine() doesn't fill defaults for them and
+  // the persisted v2 values pass through untouched).
+  useEffect(() => {
+    if (!hasMigrated) return
+    const prefs = usePreferences.getState()
+    if (prefs.hasMigratedProfileFromPreferences) return
+
+    // Cast through unknown — the moved keys are gone from the typed state, but
+    // a v2 persisted blob still carries them in raw rehydrated form until we
+    // drop them below.
+    const legacyPrefs = prefs as unknown as Record<string, unknown>
+    const result = extractProfileFromPreferences(legacyPrefs)
+
+    // Seed the new Profile store with the extracted values + their existing
+    // updatedAt timestamps. Raw setState bypasses the stamping wrapper so we
+    // don't bump `profileUpdatedAt` to `Date.now()` on first-launch upgrade —
+    // we want LWW to reflect when the user last changed each field.
+    if (Object.keys(result.profile.values).length > 0) {
+      useProfile.setState({
+        ...result.profile.values,
+        profileUpdatedAt: result.profile.updatedAt,
+      } as never)
+    }
+
+    // Drop the legacy fields from preferences + flip the flag. `undefined`
+    // values are omitted by `JSON.stringify`, so the next persist write
+    // produces a v3-shaped blob with no profile-shaped keys.
+    usePreferences.setState({
+      hasMigratedProfileFromPreferences: true,
+      ...({
+        name: undefined,
+        avatar: undefined,
+        customAvatarBackground: undefined,
+        hasCompletedProfileSetup: undefined,
+      } as Record<string, unknown>),
+    } as never)
+
+    // Also drop the moved keys from `preferenceUpdatedAt` so settings-side
+    // LWW stops tracking them. Done as a second raw setState so we can pull
+    // the latest map (it may have been mutated by the seeding step above).
+    const latest = usePreferences.getState()
+    if (
+      latest.preferenceUpdatedAt &&
+      typeof latest.preferenceUpdatedAt === 'object'
+    ) {
+      const cleaned: Record<string, number> = {}
+      for (const [key, ts] of Object.entries(latest.preferenceUpdatedAt)) {
+        if (
+          key === 'name' ||
+          key === 'avatar' ||
+          key === 'customAvatarBackground' ||
+          key === 'hasCompletedProfileSetup'
+        ) {
+          continue
+        }
+        cleaned[key] = ts
+      }
+      usePreferences.setState({ preferenceUpdatedAt: cleaned })
+    }
   }, [hasMigrated])
 
   // Normalize the legacy `'es-mx'` locale to `'es-es'` after the es-MX bundle

--- a/src/app/navigation/ToolsScreen.tsx
+++ b/src/app/navigation/ToolsScreen.tsx
@@ -20,6 +20,7 @@ import { useToastController } from '@tamagui/toast'
 import { RecurringPlanFrequencies } from '@/lib/serviceReport'
 import { useTimeCache } from '@/stores/timeCache'
 import { PREFERENCE_DEFAULTS, usePreferences } from '@/stores/preferences'
+import { useProfile, PROFILE_DEFAULTS } from '@/stores/profile'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { mmkvStorage } from '@/stores/mmkv'
 import DateTimePicker from '@/components/ui/DateTimePicker'
@@ -100,14 +101,14 @@ export default function ToolsScreen() {
     devShowAppIconAlerts,
     supporterNudgeDismissedAt,
     hideSupporterNudge,
-    hasCompletedProfileSetup,
-    name,
     devRolloverDateOverride,
     lastRolloverYearMonth,
     autoRolloverEnabled,
     celebratedTiers,
     set: setPreferences,
   } = preferences
+  // Profile-shaped fields live in the dedicated Profile store after wave-3.
+  const { hasCompletedProfileSetup, name, set: setProfile } = useProfile()
   const celebrationQueue = useCelebrationQueue()
   const { isSupporter, since: supporterSince } = useIsSupporter()
   const navigation = useNavigation<RootStackNavigation>()
@@ -485,6 +486,7 @@ export default function ToolsScreen() {
     _WARNING_forceDeleteConversations()
     invalidateAllCache()
     setPreferences({ ...PREFERENCE_DEFAULTS, iCloudSyncSetByUser: true })
+    setProfile({ ...PROFILE_DEFAULTS })
     mmkvStorage.clearAll()
     void AsyncStorage.clear()
   }
@@ -719,9 +721,11 @@ export default function ToolsScreen() {
             onPress={() => {
               setPreferences({
                 onboardingComplete: true,
+                pioneerStartDate: null,
+              })
+              setProfile({
                 hasCompletedProfileSetup: false,
                 name: '',
-                pioneerStartDate: null,
                 avatar: { type: 'none', value: '' },
               })
               showDone('Reset to pre-profile state')

--- a/src/app/sync/__tests__/categoryMerge.test.ts
+++ b/src/app/sync/__tests__/categoryMerge.test.ts
@@ -26,6 +26,8 @@ type LocalState = {
   deletedCategories: CategoryTombstone[]
   preferencesValues: Record<string, unknown>
   preferenceUpdatedAt: Record<string, number>
+  profileValues: Record<string, unknown>
+  profileUpdatedAt: Record<string, number>
 }
 
 const emptyLocal = (): LocalState => ({
@@ -42,6 +44,8 @@ const emptyLocal = (): LocalState => ({
   deletedCategories: [],
   preferencesValues: {},
   preferenceUpdatedAt: {},
+  profileValues: {},
+  profileUpdatedAt: {},
 })
 
 const makeRemote = (overrides: Partial<SyncPayload> = {}): SyncPayload => ({

--- a/src/app/sync/__tests__/payloadFieldRenames.test.ts
+++ b/src/app/sync/__tests__/payloadFieldRenames.test.ts
@@ -116,3 +116,123 @@ describe('normalizeLegacyPayloadFieldNames', () => {
     expect(d.preferencesStore.updatedAt).not.toHaveProperty('publisher')
   })
 })
+
+describe('normalizeLegacyPayloadFieldNames — profile-field routing (wave-3)', () => {
+  it('moves name + avatar from preferencesStore.values into a synthesized profileStore', () => {
+    const d = makePayload(
+      {
+        role: 'regularPioneer',
+        name: 'Bob',
+        avatar: { type: 'image', value: 'avatar://x' },
+      },
+      {
+        role: 1700000000000,
+        name: 1700000001000,
+        avatar: 1700000002000,
+      }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    // Profile slice was created and populated.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const profile = (d as any).profileStore
+    expect(profile).toBeDefined()
+    expect(profile.values.name).toBe('Bob')
+    expect(profile.values.avatar).toEqual({
+      type: 'image',
+      value: 'avatar://x',
+    })
+    expect(profile.updatedAt.name).toBe(1700000001000)
+    expect(profile.updatedAt.avatar).toBe(1700000002000)
+
+    // Legacy fields dropped from preferencesStore.
+    expect(d.preferencesStore.values).not.toHaveProperty('name')
+    expect(d.preferencesStore.values).not.toHaveProperty('avatar')
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('name')
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('avatar')
+
+    // Non-profile prefs survive untouched.
+    expect(d.preferencesStore.values.role).toBe('regularPioneer')
+    expect(d.preferencesStore.updatedAt.role).toBe(1700000000000)
+  })
+
+  it('routes customAvatarBackground + hasCompletedProfileSetup the same way', () => {
+    const d = makePayload(
+      {
+        customAvatarBackground: '#AABBCC',
+        hasCompletedProfileSetup: true,
+      },
+      {
+        customAvatarBackground: 1700000003000,
+        hasCompletedProfileSetup: 1700000004000,
+      }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const profile = (d as any).profileStore
+    expect(profile.values.customAvatarBackground).toBe('#AABBCC')
+    expect(profile.values.hasCompletedProfileSetup).toBe(true)
+    expect(profile.updatedAt.customAvatarBackground).toBe(1700000003000)
+    expect(profile.updatedAt.hasCompletedProfileSetup).toBe(1700000004000)
+    expect(d.preferencesStore.values).not.toHaveProperty(
+      'customAvatarBackground'
+    )
+    expect(d.preferencesStore.values).not.toHaveProperty(
+      'hasCompletedProfileSetup'
+    )
+  })
+
+  it('lands a legacy name value in the profile slice on read (spec test)', () => {
+    // Legacy peer (running an older app version) writes the user's name
+    // inside preferencesStore.values. On read, the canonical destination is
+    // the profile slice.
+    const d = makePayload({ name: 'Bob' }, {})
+    normalizeLegacyPayloadFieldNames(d)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((d as any).profileStore.values.name).toBe('Bob')
+  })
+
+  it('prefers an existing profileStore slice when both schemas are present', () => {
+    // Defensive: a hybrid payload (post-wave-3 device that somehow re-included
+    // legacy fields) routes nothing — the canonical slice wins.
+    const d = {
+      version: 1,
+      preferencesStore: {
+        values: { name: 'OldName' },
+        updatedAt: { name: 1 },
+      },
+      profileStore: {
+        values: { name: 'NewName' },
+        updatedAt: { name: 2 },
+      },
+    }
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.profileStore.values.name).toBe('NewName')
+    expect(d.profileStore.updatedAt.name).toBe(2)
+    expect(d.preferencesStore.values).not.toHaveProperty('name')
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('name')
+  })
+
+  it('leaves a payload without profile fields untouched (no synthesized profileStore)', () => {
+    const d = makePayload({ role: 'publisher' }, { role: 1 })
+    normalizeLegacyPayloadFieldNames(d)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((d as any).profileStore).toBeUndefined()
+  })
+
+  it('is idempotent — second call on the post-routed payload is a no-op', () => {
+    const d = makePayload(
+      { name: 'Bob', avatar: { type: 'emoji', value: '🌱' } },
+      { name: 1, avatar: 2 }
+    )
+    normalizeLegacyPayloadFieldNames(d)
+    const snapshot = JSON.stringify(d)
+    normalizeLegacyPayloadFieldNames(d)
+    expect(JSON.stringify(d)).toBe(snapshot)
+  })
+})

--- a/src/app/sync/iCloudSync.ts
+++ b/src/app/sync/iCloudSync.ts
@@ -7,6 +7,7 @@ import useConversations from '@/stores/conversationStore'
 import useServiceReport from '@/stores/serviceReport'
 import useCategories from '@/stores/categories'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import { useSupporter } from '@/features/supporter/stores/supporter'
 import { buildPayload, parsePayload, SyncPayload } from '@/app/sync/payload'
 import { mergePayload } from '@/app/sync/merge'
@@ -210,6 +211,8 @@ type LocalMergeState = {
   deletedCategories: CategoryTombstone[]
   preferencesValues: Record<string, unknown>
   preferenceUpdatedAt: Record<string, number>
+  profileValues: Record<string, unknown>
+  profileUpdatedAt: Record<string, number>
 }
 
 /**
@@ -244,6 +247,8 @@ function foldRemotePayloads(payloads: SyncPayload[]): SyncPayload | null {
     deletedCategories: first.categoryStore?.deletedCategories ?? [],
     preferencesValues: first.preferencesStore?.values ?? {},
     preferenceUpdatedAt: first.preferencesStore?.updatedAt ?? {},
+    profileValues: first.profileStore?.values ?? {},
+    profileUpdatedAt: first.profileStore?.updatedAt ?? {},
   }
 
   for (let i = 1; i < payloads.length; i++) {
@@ -262,6 +267,8 @@ function foldRemotePayloads(payloads: SyncPayload[]): SyncPayload | null {
       deletedCategories: result.deletedCategories,
       preferencesValues: result.preferencesValues,
       preferenceUpdatedAt: result.preferenceUpdatedAt,
+      profileValues: result.profileValues,
+      profileUpdatedAt: result.profileUpdatedAt,
     }
   }
 
@@ -298,6 +305,10 @@ function foldRemotePayloads(payloads: SyncPayload[]): SyncPayload | null {
     preferencesStore: {
       values: acc.preferencesValues,
       updatedAt: acc.preferenceUpdatedAt,
+    },
+    profileStore: {
+      values: acc.profileValues,
+      updatedAt: acc.profileUpdatedAt,
     },
   }
 }
@@ -358,6 +369,15 @@ export function replaceLocalWithRemote(remote: SyncPayload): void {
     lastiCloudRemoteWrittenAt: remote.writtenAt,
     lastiCloudRemoteDeviceId: remote.deviceId,
     lastiCloudRemoteDeviceName: remote.deviceName ?? null,
+  })
+  // Profile slice — `parsePayload` has already lifted any legacy
+  // profile-shaped fields out of `preferencesStore.values` into
+  // `remote.profileStore` via `normalizeLegacyPayloadFieldNames`, so this
+  // single write covers both fresh-shape and legacy-shape remote payloads.
+  useProfile.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...((remote.profileStore?.values ?? {}) as any),
+    profileUpdatedAt: remote.profileStore?.updatedAt ?? {},
   })
 }
 
@@ -522,7 +542,7 @@ async function pushImagesIfEnabled(
   try {
     const sources = collectLocalAvatarSources({
       contacts: useContacts.getState().contacts,
-      profileAvatar: prefs.avatar,
+      profileAvatar: useProfile.getState().avatar,
       documentDirectory: DOCUMENT_DIR,
     })
     if (sources.length === 0) return
@@ -567,7 +587,7 @@ async function pullImagesIfEnabled(): Promise<void> {
   try {
     const sources = collectExpectedMarkerSources({
       contacts: useContacts.getState().contacts,
-      profileAvatar: prefs.avatar,
+      profileAvatar: useProfile.getState().avatar,
       documentDirectory: DOCUMENT_DIR,
     })
     if (sources.length === 0) return
@@ -584,19 +604,22 @@ async function pullImagesIfEnabled(): Promise<void> {
       return
     }
     const contactsState = useContacts.getState()
+    const profileState = useProfile.getState()
     const applied = applyDownloadedAvatars({
       contacts: contactsState.contacts,
-      profileAvatar: prefs.avatar,
+      profileAvatar: profileState.avatar,
       downloaded: result.downloaded,
     })
     // Write through the stores' own `set` to avoid bumping `updatedAt` — the
     // helper preserved the records' timestamps, and `set` is a raw state
-    // replacement (no stamping). Using `usePreferences.setState` directly
-    // bypasses the iCloud-sync stamping wrapper on the preferences store
-    // for the same reason.
+    // replacement (no stamping). Using `useProfile.setState` directly
+    // bypasses the stamping wrapper on the Profile store for the same reason.
     contactsState.set({ contacts: applied.contacts })
-    if (applied.profileAvatar && applied.profileAvatar !== prefs.avatar) {
-      usePreferences.setState({ avatar: applied.profileAvatar })
+    if (
+      applied.profileAvatar &&
+      applied.profileAvatar !== profileState.avatar
+    ) {
+      useProfile.setState({ avatar: applied.profileAvatar })
     }
     usePreferences.setState({ iCloudImageSync: result.bookkeeping })
     logger.log(`${tag()} image pull`, {
@@ -623,7 +646,9 @@ async function gcImagesIfEnabled(): Promise<void> {
     const active: ActiveIdentity[] = useContacts
       .getState()
       .contacts.map((c) => ({ kind: 'contact', id: c.id }))
-    if (prefs.avatar?.type === 'image') active.push({ kind: 'profile' })
+    if (useProfile.getState().avatar?.type === 'image') {
+      active.push({ kind: 'profile' })
+    }
     const deps = buildImageSyncDeps()
     const result = await gcOrphanImages({ activeIdentities: active, deps })
     if (result.deleted.length > 0) {
@@ -858,12 +883,19 @@ async function pullAndMergeInner(reason: string): Promise<boolean> {
   const serviceReportState = useServiceReport.getState()
   const categoriesState = useCategories.getState()
   const preferencesState = usePreferences.getState()
+  const profileState = useProfile.getState()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const localPrefValues: Record<string, any> = {}
   for (const [key, value] of Object.entries(preferencesState)) {
     if (typeof value === 'function') continue
     localPrefValues[key] = value
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const localProfileValues: Record<string, any> = {}
+  for (const [key, value] of Object.entries(profileState)) {
+    if (typeof value === 'function') continue
+    localProfileValues[key] = value
   }
 
   logger.log(`${tag()} pullAndMerge: local snapshot`, {
@@ -894,6 +926,8 @@ async function pullAndMergeInner(reason: string): Promise<boolean> {
     deletedCategories: categoriesState.deletedCategories,
     preferencesValues: localPrefValues,
     preferenceUpdatedAt: preferencesState.preferenceUpdatedAt ?? {},
+    profileValues: localProfileValues,
+    profileUpdatedAt: profileState.profileUpdatedAt ?? {},
   }
 
   let anyChanged = false
@@ -914,6 +948,8 @@ async function pullAndMergeInner(reason: string): Promise<boolean> {
       deletedCategories: result.deletedCategories,
       preferencesValues: result.preferencesValues,
       preferenceUpdatedAt: result.preferenceUpdatedAt,
+      profileValues: result.profileValues,
+      profileUpdatedAt: result.profileUpdatedAt,
     }
   }
 
@@ -983,6 +1019,11 @@ async function pullAndMergeInner(reason: string): Promise<boolean> {
     preferenceUpdatedAt: acc.preferenceUpdatedAt,
     lastiCloudSyncAt: Date.now(),
     lastiCloudPulledAt: Date.now(),
+  })
+  useProfile.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(acc.profileValues as any),
+    profileUpdatedAt: acc.profileUpdatedAt,
   })
 
   logger.log(`${tag()} pullAndMerge: applied merge to stores`, {
@@ -1120,6 +1161,14 @@ export function installiCloudSync(): () => void {
       schedulePush()
     }
   })
+  // Profile store mirrors the same per-key stamping pattern, so the same
+  // reference check on `profileUpdatedAt` is an accurate filter for
+  // "actual syncable change happened."
+  const unsubProfile = useProfile.subscribe((state, prev) => {
+    if (state.profileUpdatedAt !== prev.profileUpdatedAt) {
+      schedulePush()
+    }
+  })
 
   const onAppState = (state: AppStateStatus) => {
     if (state === 'active') {
@@ -1169,6 +1218,7 @@ export function installiCloudSync(): () => void {
     unsubServiceReports()
     unsubCategories()
     unsubPreferences()
+    unsubProfile()
     appStateSub.remove()
     remoteChangeSub?.remove()
     availabilitySub?.remove()

--- a/src/app/sync/merge.ts
+++ b/src/app/sync/merge.ts
@@ -35,6 +35,8 @@ export type MergeResult = {
   deletedCategories: CategoryTombstone[]
   preferencesValues: Record<string, unknown>
   preferenceUpdatedAt: Record<string, number>
+  profileValues: Record<string, unknown>
+  profileUpdatedAt: Record<string, number>
   /** True when any field above actually differs from local state. */
   changed: boolean
 }
@@ -53,6 +55,8 @@ type LocalState = {
   deletedCategories: CategoryTombstone[]
   preferencesValues: Record<string, unknown>
   preferenceUpdatedAt: Record<string, number>
+  profileValues: Record<string, unknown>
+  profileUpdatedAt: Record<string, number>
 }
 
 /**
@@ -180,6 +184,26 @@ export function mergePayload(
     remote.preferencesStore.updatedAt
   )
 
+  // --- Profile (per-key LWW, mirrors preferences) ---
+  // A pre-wave-3 peer payload won't carry `profileStore`; the legacy fields
+  // have already been routed into a synthesized slice by
+  // `normalizeLegacyPayloadFieldNames`. Defaulting here keeps the merge call
+  // shape uniform either way.
+  const remoteProfile = remote.profileStore ?? {
+    values: {},
+    updatedAt: {},
+  }
+  const {
+    values: mergedProfileValues,
+    updatedAt: mergedProfileTimestamps,
+    changed: profileChanged,
+  } = mergePreferences(
+    local.profileValues,
+    local.profileUpdatedAt,
+    remoteProfile.values,
+    remoteProfile.updatedAt
+  )
+
   const changed =
     contactsChanged ||
     deletedContactsChanged ||
@@ -190,6 +214,7 @@ export function mergePayload(
     recurringPlansChanged ||
     categoriesChanged ||
     prefsChanged ||
+    profileChanged ||
     mergedConversationTombstones.length !== local.deletedConversations.length ||
     mergedReportTombstones.length !== local.deletedServiceReports.length ||
     mergedCategoryTombstones.length !== local.deletedCategories.length
@@ -208,6 +233,8 @@ export function mergePayload(
     deletedCategories: mergedCategoryTombstones,
     preferencesValues: mergedPrefValues,
     preferenceUpdatedAt: mergedPrefTimestamps,
+    profileValues: mergedProfileValues,
+    profileUpdatedAt: mergedProfileTimestamps,
     changed,
   }
 }

--- a/src/app/sync/payload.ts
+++ b/src/app/sync/payload.ts
@@ -4,6 +4,7 @@ import useServiceReport from '@/stores/serviceReport'
 import useCategories from '@/stores/categories'
 import { usePreferences } from '@/stores/preferences'
 import { NON_SYNCABLE_PREFERENCE_KEYS } from '@/stores/preferences'
+import { useProfile, NON_SYNCABLE_PROFILE_KEYS } from '@/stores/profile'
 import { ProfileAvatar } from '@/types/avatar'
 import {
   sanitizeContactAvatar,
@@ -67,6 +68,18 @@ export type SyncPayload = {
     values: Record<string, any>
     updatedAt: Record<string, number>
   }
+  /**
+   * Identity-shaped fields (name, avatar, avatar background, profile-setup
+   * completion). Split out of `preferencesStore` in wave-3 of the
+   * store-narrowing series. Optional in the wire shape because older clients
+   * write profile fields _inside_ `preferencesStore.values`; on read we rewrite
+   * those into this slice via `normalizeLegacyPayloadFieldNames`.
+   */
+  profileStore?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    values: Record<string, any>
+    updatedAt: Record<string, number>
+  }
 }
 
 /**
@@ -88,6 +101,7 @@ export function buildPayload(args: {
   const serviceReports = useServiceReport.getState()
   const categories = useCategories.getState()
   const prefs = usePreferences.getState()
+  const profile = useProfile.getState()
 
   const includeImages = prefs.iCloudSyncIncludeImages === true
   const avatarOpts = { includeImages }
@@ -99,14 +113,29 @@ export function buildPayload(args: {
   for (const [key, value] of Object.entries(prefs)) {
     if (typeof value === 'function') continue
     if (NON_SYNCABLE_PREFERENCE_KEYS.has(key)) continue
+    syncablePrefs[key] = value
+  }
+
+  // Profile slice — same allow-list pattern. The avatar field is sanitized
+  // identically to how it used to be inside `preferencesStore.values`, just
+  // routed through the new slice so the wire shape matches the on-device
+  // store split. Older clients still pre-wave-3 will receive these values
+  // back in their `preferencesStore.values` because the receiving side keeps
+  // the legacy shape; the sync-time translation on read folds them back into
+  // `profileStore`. See `payloadFieldRenames.ts`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const syncableProfile: Record<string, any> = {}
+  for (const [key, value] of Object.entries(profile)) {
+    if (typeof value === 'function') continue
+    if (NON_SYNCABLE_PROFILE_KEYS.has(key)) continue
     if (key === 'avatar') {
-      syncablePrefs[key] = sanitizeProfileAvatar(
+      syncableProfile[key] = sanitizeProfileAvatar(
         value as ProfileAvatar,
         avatarOpts
       )
       continue
     }
-    syncablePrefs[key] = value
+    syncableProfile[key] = value
   }
 
   return {
@@ -140,6 +169,10 @@ export function buildPayload(args: {
     preferencesStore: {
       values: syncablePrefs,
       updatedAt: prefs.preferenceUpdatedAt ?? {},
+    },
+    profileStore: {
+      values: syncableProfile,
+      updatedAt: profile.profileUpdatedAt ?? {},
     },
   }
 }

--- a/src/app/sync/payloadFieldRenames.ts
+++ b/src/app/sync/payloadFieldRenames.ts
@@ -16,6 +16,13 @@
  *   enum value — only the field name renamed; the leaf enum value `'publisher'`
  *   for Regular Publisher is canonical and unchanged)
  * - The matching keys inside `preferencesStore.updatedAt`
+ * - `preferencesStore.values.{name,avatar,customAvatarBackground,hasCompletedProfileSetup}`
+ *   → `profileStore.values.<same>` (wave-3 store split). Older peer devices
+ *   that pre-date the split still write the four identity-shaped fields inside
+ *   `preferencesStore.values`. On read, we relocate them into a synthesized
+ *   `profileStore` so the merge step sees the canonical post-split shape.
+ *   Matching keys move out of `preferencesStore.updatedAt` into
+ *   `profileStore.updatedAt`.
  * - `serviceReportStore.serviceReports.*.*.tag` (per entry) is preserved
  *   alongside any incoming `categoryId`. The receiving device runs the local
  *   `migrateTagsToCategories` boot pass (idempotent) to seed Category records
@@ -26,6 +33,13 @@
  * New name wins if both keys somehow coexist on the wire (defensive); the
  * legacy key is always dropped.
  */
+const LEGACY_PROFILE_KEYS = [
+  'name',
+  'avatar',
+  'customAvatarBackground',
+  'hasCompletedProfileSetup',
+] as const
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function normalizeLegacyPayloadFieldNames(d: any): void {
   const prefs = d?.preferencesStore
@@ -36,6 +50,72 @@ export function normalizeLegacyPayloadFieldNames(d: any): void {
   renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
   renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
   renameKey(prefs.updatedAt, 'publisher', 'role')
+  routeLegacyProfileFields(d)
+}
+
+/**
+ * Lifts the four identity-shaped fields out of `preferencesStore.values` and
+ * into `profileStore.values` (creating the slice if a legacy payload doesn't
+ * carry one). Mirrors the routing for `preferencesStore.updatedAt` →
+ * `profileStore.updatedAt` so iCloud LWW continues to work after the split.
+ *
+ * Defensive against a payload that carries both `profileStore` and the legacy
+ * fields inside `preferencesStore.values` — when both exist, the profile slice
+ * wins (newer schema), and the legacy keys are dropped.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeLegacyProfileFields(d: any): void {
+  const prefs = d?.preferencesStore
+  if (!prefs || typeof prefs !== 'object') return
+
+  // Detect whether any legacy profile field is present before allocating the
+  // profile slice — keeps round-trip diffs minimal when nothing needs moving.
+  const valuesObj = prefs.values
+  const timestampsObj = prefs.updatedAt
+  let needsRoute = false
+  for (const key of LEGACY_PROFILE_KEYS) {
+    if (valuesObj && typeof valuesObj === 'object' && key in valuesObj) {
+      needsRoute = true
+      break
+    }
+    if (
+      timestampsObj &&
+      typeof timestampsObj === 'object' &&
+      key in timestampsObj
+    ) {
+      needsRoute = true
+      break
+    }
+  }
+  if (!needsRoute) return
+
+  if (!d.profileStore || typeof d.profileStore !== 'object') {
+    d.profileStore = { values: {}, updatedAt: {} }
+  }
+  const profile = d.profileStore
+  if (!profile.values || typeof profile.values !== 'object') {
+    profile.values = {}
+  }
+  if (!profile.updatedAt || typeof profile.updatedAt !== 'object') {
+    profile.updatedAt = {}
+  }
+
+  for (const key of LEGACY_PROFILE_KEYS) {
+    if (valuesObj && typeof valuesObj === 'object' && key in valuesObj) {
+      if (!(key in profile.values)) profile.values[key] = valuesObj[key]
+      delete valuesObj[key]
+    }
+    if (
+      timestampsObj &&
+      typeof timestampsObj === 'object' &&
+      key in timestampsObj
+    ) {
+      if (!(key in profile.updatedAt)) {
+        profile.updatedAt[key] = timestampsObj[key]
+      }
+      delete timestampsObj[key]
+    }
+  }
 }
 
 function renameKey(

--- a/src/features/onboarding/components/steps/ProfileSetup.tsx
+++ b/src/features/onboarding/components/steps/ProfileSetup.tsx
@@ -8,7 +8,7 @@ import Wrapper from '@/components/ui/layout/Wrapper'
 import ActionButton from '@/components/ui/ActionButton'
 import useTheme from '@/contexts/theme'
 import ProfileCard from '@/features/profile/components/ProfileCard'
-import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 
 interface Props {
   goBack: () => void
@@ -17,7 +17,7 @@ interface Props {
 
 const ProfileSetup = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
-  const { set } = usePreferences()
+  const { set } = useProfile()
 
   const handleContinue = () => {
     set({ hasCompletedProfileSetup: true })

--- a/src/features/onboarding/components/steps/iCloudRestore.tsx
+++ b/src/features/onboarding/components/steps/iCloudRestore.tsx
@@ -22,6 +22,7 @@ import * as ICloudBridge from '../../../../../modules/icloud-bridge'
 import { iCloudSync } from '@/app/sync/iCloudSync'
 import { SyncPayload } from '@/app/sync/payload'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import useFeatureAccess from '@/hooks/useFeatureAccess'
 
 interface Props {
@@ -77,6 +78,7 @@ function remoteReferencesImages(remote: SyncPayload): boolean {
 const ICloudRestore = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
   const { set } = usePreferences()
+  const { set: setProfile } = useProfile()
   const { hasAccess: canEnableICloudSync } = useFeatureAccess('iCloudSync')
   const [probe, setProbe] = useState<Probe>({ state: 'probing' })
   const [restoring, setRestoring] = useState(false)
@@ -161,12 +163,12 @@ const ICloudRestore = ({ goBack, goNext }: Props) => {
       // revision, but an older remote payload may not contain them.)
       set({
         onboardingComplete: true,
-        hasCompletedProfileSetup: true,
         hasCompletedMapOnboarding: true,
         ...(canEnableICloudSync
           ? { iCloudSyncEnabled: true, iCloudSyncSetByUser: true }
           : {}),
       })
+      setProfile({ hasCompletedProfileSetup: true })
 
       // If the restored payload references images via iCloud markers, prompt
       // the user to also pull those photos down. Per-device consent means we

--- a/src/features/profile/components/ProfileCard.tsx
+++ b/src/features/profile/components/ProfileCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import useTheme from '@/contexts/theme'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import usePublisher from '@/hooks/usePublisher'
 import useIsSupporter from '@/hooks/useIsSupporter'
 import Card from '@/components/ui/Card'
@@ -94,16 +95,22 @@ const CARD_PADDING_H = 16
 const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
   const theme = useTheme()
   const {
+    installedOn,
+    pioneerStartDate,
+    profileCardShaderEnabled,
+    profileCardShaderId,
+  } = usePreferences()
+  // Profile-shaped fields live in the Profile store (wave-3 store split).
+  // ProfileCard reads + writes both stores because the card is the editing
+  // surface for *Profile* (name, avatar, avatar background, setup flag) while
+  // still rendering Preferences-driven chrome (shader toggle, tenure).
+  const {
     name,
     avatar,
     customAvatarBackground,
-    installedOn,
-    pioneerStartDate,
     hasCompletedProfileSetup,
-    profileCardShaderEnabled,
-    profileCardShaderId,
-    set,
-  } = usePreferences()
+    set: setProfile,
+  } = useProfile()
   const {
     type: publisher,
     isInFullTimeService,
@@ -244,11 +251,13 @@ const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
   const avatarEl = editable ? (
     <AvatarPickerPopover
       value={avatar}
-      onChange={(next) => set({ avatar: next })}
+      onChange={(next) => setProfile({ avatar: next })}
       name={trimmedName}
       size={44}
       backgroundValue={customAvatarBackground}
-      onBackgroundChange={(next) => set({ customAvatarBackground: next })}
+      onBackgroundChange={(next) =>
+        setProfile({ customAvatarBackground: next })
+      }
     />
   ) : (
     <Avatar avatar={avatar} name={trimmedName} size={44} />
@@ -257,7 +266,7 @@ const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
   const nameEl = editable ? (
     <RNTextInput
       value={name}
-      onChangeText={(val) => set({ name: val })}
+      onChangeText={(val) => setProfile({ name: val })}
       placeholder={i18n.t('firstNamePlaceholder')}
       placeholderTextColor={theme.colors.textAlt}
       autoCapitalize='words'

--- a/src/features/profile/components/ProfileDetailOverlay.tsx
+++ b/src/features/profile/components/ProfileDetailOverlay.tsx
@@ -26,6 +26,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import useTheme from '@/contexts/theme'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import usePublisher from '@/hooks/usePublisher'
 import useIsSupporter from '@/hooks/useIsSupporter'
 import useConversations from '@/stores/conversationStore'
@@ -110,7 +111,8 @@ const ProfileDetailOverlay = ({ origin, open, onClose, onClosed }: Props) => {
   const insets = useSafeAreaInsets()
   const navigation = useNavigation<RootStackNavigation>()
   const { width: winW, height: winH } = useWindowDimensions()
-  const { avatar, pioneerStartDate } = usePreferences()
+  const { pioneerStartDate } = usePreferences()
+  const { avatar } = useProfile()
 
   const handleEdit = () => {
     onClose()

--- a/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
@@ -10,6 +10,7 @@ import AnnualGoalSelector from '@/features/settings/components/AnnualGoalSelecto
 import ProfileCard from '@/features/profile/components/ProfileCard'
 import DateTimePicker from '@/components/ui/DateTimePicker'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
 import Card from '@/components/ui/Card'
@@ -23,7 +24,6 @@ const PublisherPreferencesSection = () => {
   const {
     role,
     pioneerStartDate,
-    hasCompletedProfileSetup,
     overrideCreditLimit,
     customCreditLimitHours,
     autoRolloverEnabled,
@@ -32,6 +32,9 @@ const PublisherPreferencesSection = () => {
     setAutoRolloverEnabled,
     set,
   } = usePreferences()
+  // `hasCompletedProfileSetup` lives in the Profile store after wave-3 because
+  // it gates Profile data (name + avatar) being filled in.
+  const { hasCompletedProfileSetup, set: setProfile } = useProfile()
   const {
     type: publisherType,
     entryMode,
@@ -45,9 +48,9 @@ const PublisherPreferencesSection = () => {
 
   useEffect(() => {
     if (!hasCompletedProfileSetup && hasName) {
-      set({ hasCompletedProfileSetup: true })
+      setProfile({ hasCompletedProfileSetup: true })
     }
-  }, [hasCompletedProfileSetup, hasName, set])
+  }, [hasCompletedProfileSetup, hasName, setProfile])
 
   const showAdvanced = !hasUnlimitedCreditDefault || !isCheckboxMode
 

--- a/src/hooks/usePublisher.ts
+++ b/src/hooks/usePublisher.ts
@@ -1,4 +1,5 @@
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import {
   derivePublisherCapabilities,
   type PublisherCapabilities,
@@ -13,8 +14,11 @@ const usePublisher = (): PublisherCapabilities => {
     milestoneOverrides,
     overrideCreditLimit,
     customCreditLimitHours,
-    name,
   } = usePreferences()
+  // `name` moved to the Profile store in wave-3. Publisher capabilities still
+  // surface it via the same shape so consumers (e.g. ProfileCard) don't have
+  // to call both hooks; a future `useUser()` will retire this seam.
+  const { name } = useProfile()
 
   const capabilities = derivePublisherCapabilities({
     publisher: role,

--- a/src/lib/profileMigration.ts
+++ b/src/lib/profileMigration.ts
@@ -1,0 +1,116 @@
+/**
+ * One-shot migration that extracts identity-shaped fields from the legacy
+ * preferences blob (MMKV key `preferences`) into the new Profile store (MMKV
+ * key `profile`).
+ *
+ * Why a boot runner instead of the Zustand `persist.migrate` callback: a
+ * persist `migrate` only sees its own blob, so it can drop fields from
+ * `preferences` but cannot atomically write them to a sibling store. The wave-2
+ * Category refactor used the same boot-runner pattern — see
+ * `migrateTagsToCategories` and the `hasMigratedTagsToCategories` flag in
+ * `src/app/App.tsx`.
+ *
+ * This module is intentionally a pure transform so it can be unit-tested
+ * without pulling in React Native, the storage adapter, or Zustand persist —
+ * the runner that calls it lives in `src/app/App.tsx`.
+ */
+
+/**
+ * Canonical list of preference keys that get extracted into the new profile
+ * store. Exported so the iCloud sync layer can use the same list when
+ * translating legacy payloads from older peers that still ship these fields
+ * inside `preferencesStore.values` (see `payloadFieldRenames.ts`).
+ *
+ * Glossary mapping:
+ *
+ * - `name` — User's first name (identity).
+ * - `avatar` — User's profile avatar (identity).
+ * - `customAvatarBackground` — Identity-shaped tint applied to the avatar. The
+ *   settings-side accent colour stays in Preferences; only the avatar-specific
+ *   override moves.
+ * - `hasCompletedProfileSetup` — Profile-setup completion gate. Lives with
+ *   Profile because it gates whether Profile data has been collected, not
+ *   whether the app behaves a certain way.
+ */
+export const PROFILE_FIELD_KEYS = [
+  'name',
+  'avatar',
+  'customAvatarBackground',
+  'hasCompletedProfileSetup',
+] as const
+
+export type ProfileFieldKey = (typeof PROFILE_FIELD_KEYS)[number]
+
+const PROFILE_KEY_SET: ReadonlySet<string> = new Set(PROFILE_FIELD_KEYS)
+
+export type ProfileSlice = {
+  values: Record<string, unknown>
+  updatedAt: Record<string, number>
+}
+
+export type ExtractResult = {
+  /** Preferences blob with profile fields stripped out. */
+  preferences: Record<string, unknown>
+  /** Profile blob — values + per-key updatedAt map for iCloud LWW. */
+  profile: ProfileSlice
+}
+
+/**
+ * Splits a legacy preferences blob into (preferences-without-profile-fields,
+ * profile-slice). Idempotent: calling it on an already-split preferences blob
+ * yields an empty profile slice and returns the preferences blob structurally
+ * unchanged.
+ *
+ * Preserves the per-key `preferenceUpdatedAt` timestamps for the moved fields
+ * by relocating them into the profile slice's `updatedAt` map and dropping them
+ * from the preferences' `preferenceUpdatedAt`.
+ */
+export function extractProfileFromPreferences(
+  preferences: Record<string, unknown>
+): ExtractResult {
+  if (!preferences || typeof preferences !== 'object') {
+    return {
+      preferences: preferences ?? {},
+      profile: { values: {}, updatedAt: {} },
+    }
+  }
+
+  const nextPrefs: Record<string, unknown> = {}
+  const profileValues: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(preferences)) {
+    if (PROFILE_KEY_SET.has(key)) {
+      profileValues[key] = value
+    } else {
+      nextPrefs[key] = value
+    }
+  }
+
+  // Reroute the per-key timestamps so iCloud LWW continues to work after the
+  // split. The settings-side `preferenceUpdatedAt` keeps everything except
+  // the moved fields; the profile slice's `updatedAt` carries the moved
+  // entries.
+  const profileUpdatedAt: Record<string, number> = {}
+  const existingPrefTimestamps = preferences.preferenceUpdatedAt as
+    | Record<string, number>
+    | undefined
+  if (
+    existingPrefTimestamps &&
+    typeof existingPrefTimestamps === 'object' &&
+    !Array.isArray(existingPrefTimestamps)
+  ) {
+    const remainingPrefTimestamps: Record<string, number> = {}
+    for (const [key, ts] of Object.entries(existingPrefTimestamps)) {
+      if (PROFILE_KEY_SET.has(key)) {
+        profileUpdatedAt[key] = ts
+      } else {
+        remainingPrefTimestamps[key] = ts
+      }
+    }
+    nextPrefs.preferenceUpdatedAt = remainingPrefTimestamps
+  }
+
+  return {
+    preferences: nextPrefs,
+    profile: { values: profileValues, updatedAt: profileUpdatedAt },
+  }
+}

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import { ThemeContext } from '@/contexts/theme'
 import getThemeFromColorScheme from '@/constants/theme'
 import { useColorScheme } from 'react-native'
 import { usePreferences } from '@/stores/preferences'
+import { useProfile } from '@/stores/profile'
 import useFeatureAccess from '@/hooks/useFeatureAccess'
 import { mix, withAlpha } from '@/lib/color'
 
@@ -10,11 +11,11 @@ interface Props {}
 
 const ThemeProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
   const colorScheme = useColorScheme()
-  const {
-    colorScheme: theme,
-    customAccentColor,
-    customAvatarBackground,
-  } = usePreferences()
+  const { colorScheme: theme, customAccentColor } = usePreferences()
+  // `customAvatarBackground` is profile-shaped (it tints the User's avatar),
+  // so it lives in the Profile store. The theme still consumes it because the
+  // avatar background also drives `accentBackground` system-wide.
+  const { customAvatarBackground } = useProfile()
   const { hasAccess: canCustomizeAccent } =
     useFeatureAccess('customAccentColor')
   const scheme = colorScheme === 'unspecified' ? undefined : colorScheme

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -8,7 +8,6 @@ import moment from 'moment'
 import * as Device from 'expo-device'
 import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
 import { Address } from '@/types/contact'
-import { ProfileAvatar } from '@/types/avatar'
 import { MinuteDisplayFormat } from '@/types/serviceReport'
 import type { AssistantEvent } from '@/types/assistant'
 import { appendAssistantEventCapped } from '@/lib/assistantState'
@@ -227,13 +226,11 @@ export const PREFERENCE_DEFAULTS = {
   /** Overrides publisherHours hour requirement for given month. */
   oneOffGoalHours: [] as GoalHours[],
   onboardingComplete: false,
-  /**
-   * Distinct from onboardingComplete so existing users — who installed before
-   * the profile step existed — can be prompted to fill it in post-onboarding.
-   */
-  hasCompletedProfileSetup: false,
-  /** User's first name. Collected during onboarding profile step. */
-  name: '',
+  // `name`, `avatar`, `customAvatarBackground`, and `hasCompletedProfileSetup`
+  // moved to `@/stores/profile` in preferences v3 — see `src/lib/profileMigration.ts`
+  // and the boot runner in `src/app/App.tsx`. Glossary disambiguation: those
+  // four fields are the User's *identity* (Profile), not the User's *settings*
+  // (Preferences).
   /**
    * Multi-select intents captured during onboarding (`IntentPicker` step).
    * Drives the post-onboarding `HomeChecklist` and personalizes later
@@ -246,11 +243,11 @@ export const PREFERENCE_DEFAULTS = {
    * stores the start date for any role that tracks one — see `tracksStartDate`
    * in `constants/publisher.ts` (regular pioneer, special pioneer, circuit
    * overseer, regular auxiliary). Used by ProfileCard / ProfileDetailOverlay to
-   * display duration (e.g. "Pioneering for 2 years").
+   * display duration (e.g. "Pioneering for 2 years"). Stays in Preferences
+   * because it's tied to the publisher _role_ (a setting), not the User's
+   * identity.
    */
   pioneerStartDate: null as Date | null,
-  /** Profile avatar — stored locally, never uploaded. */
-  avatar: { type: 'none', value: '' } as ProfileAvatar,
   installedOn: new Date(),
   contactSort: 'suggested' as ContactSortKey,
   /**
@@ -333,6 +330,16 @@ export const PREFERENCE_DEFAULTS = {
    * migrates its own persisted state once.
    */
   hasMigratedTagsToCategories: false,
+  /**
+   * One-shot flag for the Profile-store extraction (wave-3). Boot runner gates
+   * on this: when false, it splits the legacy `preferences` blob and seeds the
+   * new `useProfile()` store with the identity-shaped fields (`name`, `avatar`,
+   * `customAvatarBackground`, `hasCompletedProfileSetup`). The preferences
+   * persist `migrate` callback (v2→v3) drops those fields from disk in
+   * parallel. See `src/lib/profileMigration.ts`. Non-syncable — each device
+   * migrates its own persisted state once.
+   */
+  hasMigratedProfileFromPreferences: false,
   hasAttemptedToMigrateToMmkv: false,
   /**
    * Hidden dev tools for diagnosing issues. To enable/disable, navigate to
@@ -409,13 +416,10 @@ export const PREFERENCE_DEFAULTS = {
    * it only while supporter status is active.
    */
   customAccentColor: null as string | null,
-  /**
-   * Supporter-only override for the avatar/profile-picture background color.
-   * When null, the avatar background follows the accent color. Kept separate so
-   * users who want a different-colored avatar than their accent can opt in
-   * without affecting the rest of the app's tint.
-   */
-  customAvatarBackground: null as string | null,
+  // `customAvatarBackground` moved to `@/stores/profile` in preferences v3
+  // alongside `name` + `avatar` — see glossary: the avatar background is
+  // identity-shaped (it tints the User's avatar), while `customAccentColor`
+  // (theme) and `customAppIcon` (app icon) are settings and stay here.
   /**
    * Supporter-only override for the iOS Home Screen app icon. `null` /
    * `'Default'` use the bundle's primary icon. `'Seasonal'` is resolved at
@@ -727,6 +731,7 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
   'hasMigratedToSyncSchema',
   'hasMigratedCustomFieldsToIds',
   'hasMigratedTagsToCategories',
+  'hasMigratedProfileFromPreferences',
   // Legacy field — removed from the schema but may still exist on disk for
   // installs that pre-date the id-keyed migration. Listed here so the boot
   // cleanup that wipes it doesn't propagate the deletion through sync.
@@ -766,6 +771,16 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
  *   leaf enum value `'publisher'` (Regular Publisher) is canonical and stays.
  *   The `preferenceUpdatedAt` timestamp map is migrated alongside so iCloud
  *   last-writer-wins continues to work across the rename.
+ * - V2 → v3: split the identity-shaped fields (`name`, `avatar`,
+ *   `customAvatarBackground`, `hasCompletedProfileSetup`) out into the new
+ *   Profile store (`@/stores/profile`). This callback only sees the preferences
+ *   blob, so it can drop the fields here — but the cross-store _seeding_ runs
+ *   in a boot runner (`src/app/App.tsx`) gated on
+ *   `hasMigratedProfileFromPreferences`. To avoid losing the values between
+ *   `migrate` and the boot runner, the persist callback leaves the fields in
+ *   place; the boot runner is the single source of truth for both the seeding
+ *   and the drop. The version bump still happens so a downgrade to v2 isn't
+ *   silently re-promoted.
  *
  * Exported for unit testing. Idempotent — re-running on an already-migrated
  * blob is a no-op.
@@ -782,6 +797,9 @@ export const migratePreferencesPersistedState = (
   }
   if (version < 2) {
     next = migratePublisherToRole(next)
+  }
+  if (version < 3) {
+    next = migrateDropProfileFields(next)
   }
   return next
 }
@@ -843,6 +861,29 @@ const migratePublisherToRole = (state: any): any => {
   }
   return next
 }
+
+/**
+ * V2 → v3: the persist `migrate` callback is intentionally a no-op for the
+ * Profile extraction. The split runs in a boot runner (`src/app/App.tsx`, gated
+ * on `hasMigratedProfileFromPreferences`) because:
+ *
+ * 1. The boot runner needs to _seed_ a sibling MMKV store (`@/stores/profile`),
+ *    which a Zustand persist `migrate` callback can't do — it only sees its own
+ *    blob.
+ * 2. Leaving the legacy fields on the persisted preferences blob until the boot
+ *    runner copies them avoids any race where the values are lost between
+ *    `migrate` and the runner.
+ *
+ * The version bump still happens so the schema marker on disk advances —
+ * preventing a downgrade-then-upgrade from re-triggering this migration
+ * accidentally, and giving future migrations (v3 → v4) a stable base. The boot
+ * runner then drops the legacy fields from preferences via raw `setState({
+ * name: undefined, ... } as any)` and flips `hasMigratedProfileFromPreferences`
+ * so the runner is one-shot. See wave-2's `serviceReportTags` cleanup for the
+ * exact same pattern.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const migrateDropProfileFields = (state: any): any => state
 
 export const usePreferences = create(
   persist(
@@ -975,7 +1016,7 @@ export const usePreferences = create(
       storage: createJSONStorage(() =>
         hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
       ),
-      version: 2,
+      version: 3,
       migrate: (persistedState, version) =>
         migratePreferencesPersistedState(persistedState, version),
     }

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -1,0 +1,111 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { create } from 'zustand'
+import { persist, combine, createJSONStorage } from 'zustand/middleware'
+import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import type { ProfileAvatar } from '@/types/avatar'
+
+/**
+ * Persisted defaults for the Profile store — the User's identity-shaped data.
+ *
+ * The glossary disambiguates **Profile** (User identity: name, avatar, avatar
+ * background) from **Preferences** (User settings: role, goals, sync toggles,
+ * theme, etc.). These fields lived inside `preferences` historically; the
+ * boot-runner migration in `src/lib/profileMigration.ts` extracts them on first
+ * launch after upgrade and seeds this store. See `docs/refactor-log.md`.
+ */
+export const PROFILE_DEFAULTS = {
+  /** User's first name. Collected during onboarding profile step. */
+  name: '',
+  /** Profile avatar — stored locally, never uploaded except via image sync. */
+  avatar: { type: 'none', value: '' } as ProfileAvatar,
+  /**
+   * Supporter-only override for the avatar/profile-picture background color.
+   * When null, the avatar background follows the accent color. Kept here (not
+   * in Preferences) because it's an identity-shaped tint applied to the User's
+   * avatar — the surface that represents "who they are."
+   */
+  customAvatarBackground: null as string | null,
+  /**
+   * Distinct from `onboardingComplete` so existing users — who installed before
+   * the profile step existed — can be prompted to fill it in post-onboarding.
+   * Sits in Profile because it gates Profile data, not settings.
+   */
+  hasCompletedProfileSetup: false,
+  /**
+   * Per-key epoch ms of the most recent change for syncable profile keys.
+   * Merged last-writer-wins per key, mirroring the Preferences store's
+   * `preferenceUpdatedAt` map.
+   */
+  profileUpdatedAt: {} as Record<string, number>,
+}
+
+/**
+ * Keys that never participate in cross-device sync. The Profile slice today has
+ * none — every field is identity-shaped and should follow the User. Kept as an
+ * explicit empty set so future per-device flags can be added without
+ * reorganising the store.
+ */
+export const NON_SYNCABLE_PROFILE_KEYS = new Set<string>(['profileUpdatedAt'])
+
+/**
+ * Persisted profile store. Brand new at version 0; the v2→v3 preferences
+ * migration plus the `hasMigratedProfileFromPreferences` boot runner seed this
+ * store from the legacy `preferences` blob on upgrade.
+ *
+ * Stamping wrapper mirrors `usePreferences`: every partial update writes
+ * `profileUpdatedAt[<key>] = Date.now()` for each touched syncable key so the
+ * iCloud LWW merge can resolve cross-device edits the same way it does for
+ * preferences.
+ */
+export const useProfile = create(
+  persist(
+    combine(PROFILE_DEFAULTS, (rawSet, getState) => {
+      const set: typeof rawSet = (partial, replace) => {
+        const resolved =
+          typeof partial === 'function' ? partial(getState()) : partial
+
+        if (
+          resolved &&
+          typeof resolved === 'object' &&
+          !Array.isArray(resolved) &&
+          !replace
+        ) {
+          const now = Date.now()
+          const current = getState().profileUpdatedAt ?? {}
+          const next: Record<string, number> = { ...current }
+          let changed = false
+          for (const key of Object.keys(resolved)) {
+            if (NON_SYNCABLE_PROFILE_KEYS.has(key)) continue
+            next[key] = now
+            changed = true
+          }
+          if (changed) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            rawSet({ ...(resolved as any), profileUpdatedAt: next })
+            return
+          }
+        }
+        rawSet(resolved, replace as never)
+      }
+
+      return {
+        set,
+        setName: (name: string) => set({ name }),
+        setAvatar: (avatar: ProfileAvatar) => set({ avatar }),
+        setCustomAvatarBackground: (customAvatarBackground: string | null) =>
+          set({ customAvatarBackground }),
+        setHasCompletedProfileSetup: (hasCompletedProfileSetup: boolean) =>
+          set({ hasCompletedProfileSetup }),
+      }
+    }),
+    {
+      name: 'profile',
+      storage: createJSONStorage(() =>
+        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+      ),
+      version: 0,
+    }
+  )
+)
+
+export default useProfile


### PR DESCRIPTION
## Why

Glossary disambiguation: **Profile** (User identity — name, avatar, avatar background, profile-setup completion) is conceptually distinct from **Preferences** (User settings — role, goals, sync toggles, theme, app icon). They shared a single MMKV store, which made scoping changes, persisting differently, and reasoning about ownership awkward. Splits them into separate MMKV stores so they can evolve, sync, and persist independently. Sets up the future `useUser()` consolidator (refactor #9).

## How

**Fields moved to the new `@/stores/profile`:**

- `name`
- `avatar`
- `customAvatarBackground` (the avatar-tint override — `customAccentColor`/`customAppIcon` stay in Preferences because they're _theme/icon_ settings, not identity)
- `hasCompletedProfileSetup` (gates whether Profile data exists, not how the app behaves)

**Migration — boot runner, mirroring the wave-2 Category pattern:**

- Preferences MMKV bumps v2 → v3. The persist `migrate` callback is intentionally a no-op for the profile split; it can only return its own blob, not seed a sibling store. The version bump still happens so a downgrade can't silently re-promote a v2 blob.
- A boot runner in `src/app/App.tsx`, gated on the new non-syncable flag `hasMigratedProfileFromPreferences`, reads the legacy fields from the rehydrated preferences state via a cast (the keys are no longer in `PREFERENCE_DEFAULTS`, so persisted v2 values pass through untouched), writes them into `useProfile` with their per-key `updatedAt` timestamps preserved, then drops the legacy fields from `usePreferences` via raw `setState({ name: undefined, ... })`.
- Profile store at v0 — brand new, no `migrate` callback needed.

**iCloud sync:**

- New optional `profileStore` slice on `SyncPayload`. **No `PAYLOAD_VERSION` bump** — additive.
- `payloadFieldRenames.ts` routes legacy profile-shaped fields out of `preferencesStore.values` into a synthesized `profileStore` slice on read, so older peers (pre-wave-3 devices that still ship `name`/`avatar`/etc. inside the preferences slice) merge into the right place.
- `mergePayload` threads `profileValues`/`profileUpdatedAt` through the same per-key LWW algorithm used for preferences.
- `installiCloudSync` subscribes to `useProfile` changes to schedule pushes the same way it does for preferences.

**Highest-impact files for review:**

- `src/stores/profile.ts:1` — new store with stamping wrapper modelled on `usePreferences`.
- `src/lib/profileMigration.ts:1` — pure transform powering the boot runner.
- `src/app/App.tsx:411` — wave-3 boot runner (gated on `hasMigratedProfileFromPreferences`).
- `src/app/sync/payloadFieldRenames.ts:50` — sync-time legacy translation (`routeLegacyProfileFields`).

**Tests:** new `profileExtraction.test.ts`, `profileStore.test.ts`, additional cases in `preferencesPersistMigration.test.ts` and `payloadFieldRenames.test.ts` for the v2→v3 bump and the sync-time routing.

## Risks

- **MMKV preferences v2→v3 migration.** Existing users will hit the boot runner on first launch — it must read the legacy fields from rehydrated state, seed Profile, and clear preferences without losing data.
- **Cross-device iCloud sync.** Two-way compatibility:
  - Device A (post-refactor) pushes a payload with `profileStore` populated. Device B (older version) ignores the unknown slice and keeps reading from `preferencesStore.values` — but since `buildPayload` no longer emits profile fields there, the older device will see them as empty.
  - Device A (older version) pushes a payload with profile fields inside `preferencesStore.values`. Device B (post-refactor) lifts them into the synthesized `profileStore` slice via `payloadFieldRenames` and merges normally.
- **Consumers that read profile fields directly from preferences will break** if not updated. Typecheck catches them — every typed read is gone; only the boot runner's `as unknown as` cast still touches them.
- **The `usePublisher()` hook still surfaces `name` as part of capabilities** — it now reads from `useProfile` internally. Component consumers see no API change.

## Tests required

- **Manual QA — upgrade path:** Upgrade an existing build with a populated profile (name + avatar + custom avatar background + profile setup complete). Verify all four survive on first launch, render correctly in the home `ProfileCard`, profile detail overlay, and PublisherPreferencesSection.
- **Manual QA — cross-device sync:** With Device A migrated and Device B running an older version, edit `name`/`avatar` on Device A and pull on Device B. Then edit on Device B and pull on Device A. Verify both directions converge (Device B continues to round-trip the fields inside `preferencesStore.values`; Device A re-routes them on read).