### PR TITLE
refactor: introduce useUser() hook for profile reads

### DIFF
--- a/src/__tests__/publisherCapabilities.test.ts
+++ b/src/__tests__/publisherCapabilities.test.ts
@@ -15,7 +15,6 @@ const baseInput = {
   milestoneOverrides: null as number[] | null,
   overrideCreditLimit: false,
   customCreditLimitHours: 55,
-  name: '',
 }
 
 const derive = (

--- a/src/__tests__/useUser.test.ts
+++ b/src/__tests__/useUser.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+vi.mock('@/lib/locales', () => ({
+  default: { t: (k: string) => k },
+}))
+
+// Replace the React-aware `useProfile` hook with a plain function reading
+// directly from the underlying zustand store. The store itself is still real
+// (so `setName` / `set` exercise the same stamping wrapper), but calling
+// `useProfile()` no longer goes through `useSyncExternalStore` — which keeps
+// the hook callable outside a React tree.
+vi.mock('@/stores/profile', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/stores/profile')>('@/stores/profile')
+  const useProfile = ((selector?: (s: unknown) => unknown) => {
+    const state = actual.useProfile.getState()
+    return selector ? selector(state) : state
+  }) as unknown as typeof actual.useProfile
+  Object.assign(useProfile, actual.useProfile)
+  return { ...actual, useProfile }
+})
+
+import { useProfile, PROFILE_DEFAULTS } from '@/stores/profile'
+import useUser from '@/hooks/useUser'
+import i18n from '@/lib/locales'
+
+describe('useUser', () => {
+  beforeEach(() => {
+    useProfile.setState({ ...PROFILE_DEFAULTS, profileUpdatedAt: {} })
+  })
+
+  it('falls back to the localized greeting when no name is set', () => {
+    const user = useUser()
+    expect(user.name).toBe('')
+    expect(user.hasName).toBe(false)
+    expect(user.displayName).toBe(i18n.t('profileGreetingNoName'))
+  })
+
+  it('treats a whitespace-only name as unset', () => {
+    useProfile.getState().setName('   ')
+    const user = useUser()
+    expect(user.name).toBe('')
+    expect(user.hasName).toBe(false)
+    expect(user.displayName).toBe(i18n.t('profileGreetingNoName'))
+  })
+
+  it('returns the trimmed name and uses it as the display name', () => {
+    useProfile.getState().setName('  Alice  ')
+    const user = useUser()
+    expect(user.name).toBe('Alice')
+    expect(user.hasName).toBe(true)
+    expect(user.displayName).toBe('Alice')
+  })
+
+  it('reacts to the Profile store updating between calls', () => {
+    expect(useUser().hasName).toBe(false)
+    useProfile.getState().setName('Bob')
+    expect(useUser()).toMatchObject({
+      name: 'Bob',
+      hasName: true,
+      displayName: 'Bob',
+    })
+    useProfile.getState().setName('')
+    expect(useUser().hasName).toBe(false)
+  })
+
+  it('passes through avatar, customAvatarBackground, and setup flag', () => {
+    useProfile.getState().set({
+      avatar: { type: 'emoji', value: '🌱' },
+      customAvatarBackground: '#112233',
+      hasCompletedProfileSetup: true,
+    })
+    const user = useUser()
+    expect(user.avatar).toEqual({ type: 'emoji', value: '🌱' })
+    expect(user.customAvatarBackground).toBe('#112233')
+    expect(user.hasCompletedProfileSetup).toBe(true)
+  })
+})

--- a/src/features/onboarding/components/steps/YourPlanPreview.tsx
+++ b/src/features/onboarding/components/steps/YourPlanPreview.tsx
@@ -37,7 +37,7 @@ import WeekStripTeaser from '@/features/service-reports/components/WeekStripTeas
 import useTheme from '@/contexts/theme'
 import i18n, { TranslationKey } from '@/lib/locales'
 import { OnboardingIntent, usePreferences } from '@/stores/preferences'
-import usePublisher from '@/hooks/usePublisher'
+import useUser from '@/hooks/useUser'
 import { getEntryMode, isInFullTimeService } from '@/lib/publisherCapabilities'
 import { useMarkerColors } from '@/hooks/useMarkerColors'
 import { Theme } from '@/types/theme'
@@ -1138,7 +1138,7 @@ const YourPlanPreview = ({ goBack, goNext }: Props) => {
   const theme = useTheme()
   const { role, publisherHours, pioneerStartDate, onboardingIntents } =
     usePreferences()
-  const { name: trimmedName, hasName } = usePublisher()
+  const { name: trimmedName, hasName } = useUser()
 
   const monthlyGoalHours = publisherHours[role] ?? 0
   const publisherLabel = i18n.t(role)

--- a/src/features/profile/components/ProfileCard.tsx
+++ b/src/features/profile/components/ProfileCard.tsx
@@ -13,6 +13,7 @@ import useTheme from '@/contexts/theme'
 import { usePreferences } from '@/stores/preferences'
 import { useProfile } from '@/stores/profile'
 import usePublisher from '@/hooks/usePublisher'
+import useUser from '@/hooks/useUser'
 import useIsSupporter from '@/hooks/useIsSupporter'
 import Card from '@/components/ui/Card'
 import Text from '@/components/ui/MyText'
@@ -111,12 +112,8 @@ const ProfileCard = ({ preview, editable, onPressIncomplete }: Props) => {
     hasCompletedProfileSetup,
     set: setProfile,
   } = useProfile()
-  const {
-    type: publisher,
-    isInFullTimeService,
-    name: trimmedName,
-    hasName,
-  } = usePublisher()
+  const { name: trimmedName, hasName } = useUser()
+  const { type: publisher, isInFullTimeService } = usePublisher()
   const { since: supporterSince } = useIsSupporter()
   const [detailOpen, setDetailOpen] = useState(false)
   const [origin, setOrigin] = useState<OriginRect | null>(null)

--- a/src/features/profile/components/ProfileDetailOverlay.tsx
+++ b/src/features/profile/components/ProfileDetailOverlay.tsx
@@ -28,6 +28,7 @@ import useTheme from '@/contexts/theme'
 import { usePreferences } from '@/stores/preferences'
 import { useProfile } from '@/stores/profile'
 import usePublisher from '@/hooks/usePublisher'
+import useUser from '@/hooks/useUser'
 import useIsSupporter from '@/hooks/useIsSupporter'
 import useConversations from '@/stores/conversationStore'
 import Text from '@/components/ui/MyText'
@@ -118,12 +119,8 @@ const ProfileDetailOverlay = ({ origin, open, onClose, onClosed }: Props) => {
     onClose()
     navigation.navigate('PreferencesPublisher')
   }
-  const {
-    type: publisher,
-    tracksPioneerStartDate,
-    entryMode,
-    name: trimmedName,
-  } = usePublisher()
+  const { type: publisher, tracksPioneerStartDate, entryMode } = usePublisher()
+  const { name: trimmedName } = useUser()
   const { since: supporterSince } = useIsSupporter()
   const { conversations } = useConversations()
   const daily = useDailyMinutes()

--- a/src/features/service-reports/screens/ServiceReportViewScreen.tsx
+++ b/src/features/service-reports/screens/ServiceReportViewScreen.tsx
@@ -26,7 +26,7 @@ import useTheme from '@/contexts/theme'
 import i18n, { _i18n } from '@/lib/locales'
 import Haptics from '@/lib/haptics'
 import useMonthReportData from '@/features/service-reports/hooks/useMonthReportData'
-import usePublisher from '@/hooks/usePublisher'
+import useUser from '@/hooks/useUser'
 import { RootStackParamList } from '@/types/rootStack'
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ServiceReportView'>
@@ -125,7 +125,7 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
   const insets = useSafeAreaInsets()
   const { month, year } = route.params
   const data = useMonthReportData(month, year)
-  const { name, hasName } = usePublisher()
+  const { name, hasName } = useUser()
 
   const monthYearLabel = useMemo(
     () => moment().month(month).year(year).format('MMMM YYYY'),

--- a/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/PublisherPreferencesSection.tsx
@@ -18,6 +18,7 @@ import Divider from '@/components/ui/Divider'
 import CheckboxWithLabel from '@/components/ui/inputs/CheckboxWithLabel'
 import TextInputRow from '@/components/ui/inputs/TextInputRow'
 import usePublisher from '@/hooks/usePublisher'
+import useUser from '@/hooks/useUser'
 import { getStartDateLabels } from '@/constants/publisher'
 
 const PublisherPreferencesSection = () => {
@@ -38,10 +39,10 @@ const PublisherPreferencesSection = () => {
   const {
     type: publisherType,
     entryMode,
-    hasName,
     hasUnlimitedCreditDefault,
     tracksPioneerStartDate,
   } = usePublisher()
+  const { hasName } = useUser()
   const theme = useTheme()
   const isCheckboxMode = entryMode === 'checkbox'
   const [advancedOpen, setAdvancedOpen] = useState(false)

--- a/src/hooks/usePublisher.ts
+++ b/src/hooks/usePublisher.ts
@@ -1,11 +1,15 @@
 import { usePreferences } from '@/stores/preferences'
-import { useProfile } from '@/stores/profile'
 import {
   derivePublisherCapabilities,
   type PublisherCapabilities,
 } from '@/lib/publisherCapabilities'
-import i18n from '@/lib/locales'
 
+/**
+ * Resolves the User's field-ministry role to a fully derived
+ * `PublisherCapabilities` object. This hook is the React-side seam for role +
+ * capability data only — for profile-shaped data (name, avatar, etc.) call
+ * `useUser()` instead. Components that need both call both hooks.
+ */
 const usePublisher = (): PublisherCapabilities => {
   const {
     role,
@@ -15,26 +19,15 @@ const usePublisher = (): PublisherCapabilities => {
     overrideCreditLimit,
     customCreditLimitHours,
   } = usePreferences()
-  // `name` moved to the Profile store in wave-3. Publisher capabilities still
-  // surface it via the same shape so consumers (e.g. ProfileCard) don't have
-  // to call both hooks; a future `useUser()` will retire this seam.
-  const { name } = useProfile()
 
-  const capabilities = derivePublisherCapabilities({
+  return derivePublisherCapabilities({
     publisher: role,
     publisherHours,
     userSpecifiedHasAnnualGoal,
     milestoneOverrides,
     overrideCreditLimit,
     customCreditLimitHours,
-    name,
   })
-  return {
-    ...capabilities,
-    displayName: capabilities.hasName
-      ? capabilities.name
-      : i18n.t('profileGreetingNoName'),
-  }
 }
 
 export default usePublisher

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,49 @@
+import { useProfile } from '@/stores/profile'
+import i18n from '@/lib/locales'
+import type { ProfileAvatar } from '@/types/avatar'
+
+/**
+ * Shape of the User's profile-only data, as exposed to React consumers.
+ *
+ * The glossary separates **User** (the human who installed the app — owns
+ * profile, preferences, history) from **Publisher** (the User's field-ministry
+ * role). This hook surfaces the User's identity-shaped data (name, avatar,
+ * avatar background, setup flag) and is the counterpart to `usePublisher()`,
+ * which surfaces role/capability data. Consumers that need both call both
+ * hooks.
+ */
+export type User = {
+  /** Trimmed name from the profile store. Empty string if unset. */
+  name: string
+  /** Whether the User has set a non-empty name. */
+  hasName: boolean
+  /**
+   * Name to render in the UI — falls back to a localized greeting when the User
+   * has not set a name yet.
+   */
+  displayName: string
+  avatar: ProfileAvatar
+  /**
+   * Supporter-only override for the avatar/profile background color. `null`
+   * means follow the accent color.
+   */
+  customAvatarBackground: string | null
+  hasCompletedProfileSetup: boolean
+}
+
+const useUser = (): User => {
+  const { name, avatar, customAvatarBackground, hasCompletedProfileSetup } =
+    useProfile()
+  const trimmedName = (name ?? '').trim()
+  const hasName = trimmedName.length > 0
+  return {
+    name: trimmedName,
+    hasName,
+    displayName: hasName ? trimmedName : i18n.t('profileGreetingNoName'),
+    avatar,
+    customAvatarBackground,
+    hasCompletedProfileSetup,
+  }
+}
+
+export default useUser

--- a/src/lib/publisherCapabilities.ts
+++ b/src/lib/publisherCapabilities.ts
@@ -4,11 +4,6 @@ import type { Publisher, PublisherHours } from '@/types/publisher'
 
 export type PublisherCapabilities = {
   type: Publisher
-  /** Trimmed publisher/user name from onboarding profile. Empty string if unset. */
-  name: string
-  /** Name to render to the user — falls back to a localized greeting when unset. */
-  displayName: string
-  hasName: boolean
   entryMode: 'checkbox' | 'hours'
   /** `null` means no monthly credit cap (unlimited). */
   creditCapMinutes: number | null
@@ -65,7 +60,6 @@ export type PublisherCapabilitiesInput = {
   milestoneOverrides: number[] | null
   overrideCreditLimit: boolean
   customCreditLimitHours: number
-  name: string
 }
 
 const baseCreditCapMinutes = (publisher: Publisher): number | null => {
@@ -132,20 +126,13 @@ export const derivePublisherCapabilities = (
     milestoneOverrides,
     overrideCreditLimit,
     customCreditLimitHours,
-    name,
   } = input
   const monthlyGoalHours = publisherHours[publisher]
   const annualGoalHours = monthlyGoalHours * 12
   const entryMode = getEntryMode(publisher)
   const hoursMode = entryMode === 'hours'
-  const trimmedName = (name ?? '').trim()
   return {
     type: publisher,
-    name: trimmedName,
-    // displayName is filled in by the React-side hook (it needs i18n).
-    // Pure callers can ignore it.
-    displayName: trimmedName,
-    hasName: trimmedName.length > 0,
     entryMode,
     creditCapMinutes: effectiveCreditCapMinutes(
       publisher,


### PR DESCRIPTION
## Why

Glossary disambiguation: **User** (the human — owns profile, preferences, history) vs **Publisher** (the User's field-ministry role). `usePublisher()` was reading from the Profile store to thread `name` / `displayName` / `hasName` through `PublisherCapabilities`, which leaked profile data through the role seam. The original hook comment flagged this as temporary pending a `useUser()` split.

## How

- New `src/hooks/useUser.ts` exposes the User's profile-shaped data: `name` (trimmed), `hasName`, `displayName` (with the same `profileGreetingNoName` fallback as before), `avatar`, `customAvatarBackground`, `hasCompletedProfileSetup`.
- `usePublisher()` no longer touches the Profile store. `PublisherCapabilities` and `derivePublisherCapabilities` lose the `name` / `hasName` / `displayName` fields and the `name` input — capabilities are role-only.
- Consumers reading profile-shaped fields switched to `useUser()`. `ProfileCard` / `ProfileDetailOverlay` / `PublisherPreferencesSection` call both hooks; `ServiceReportViewScreen` and `YourPlanPreview` only needed profile data and dropped `usePublisher` entirely.
- `displayName` / `hasName` semantics are byte-identical to before (same `trim` + `profileGreetingNoName` fallback).

## Risks

Small. No persisted-shape change, no migration. Typecheck catches every consumer break via the removed `PublisherCapabilities` fields.