### PR TITLE
fix: save contacts immediately, geocode in the background

### DIFF
--- a/src/features/contacts/screens/ContactFormScreen.tsx
+++ b/src/features/contacts/screens/ContactFormScreen.tsx
@@ -423,23 +423,27 @@ const ContactFormScreen = ({ route, navigation }: Props) => {
     (resolve: (value: unknown) => void) => {
       const newContact = { ...contact }
       updatePrefillAddress(newContact.address)
-      if (
-        !newContact.userDraggedCoordinate &&
-        newContact.address &&
-        !!Object.keys(newContact.address)
-      ) {
-        handleFetchCoordinate(newContact).finally(() => {
-          addContact(newContact)
-          setFetching(false)
-          resolve(newContact)
+      // Persist immediately so the contact lands in the list right away.
+      // Geocoding is best-effort enrichment — gating the write on it meant a
+      // slow or hung request (axios has no timeout) delayed, or silently
+      // dropped, the new contact.
+      addContact(newContact)
+      resolve(newContact)
+      if (!newContact.userDraggedCoordinate && newContact.address) {
+        handleFetchCoordinate(newContact).then((c) => {
+          if (c.coordinate) {
+            updateContact(c)
+          }
         })
-      } else {
-        // User input custom coordinate
-        addContact(newContact)
-        resolve(newContact)
       }
     },
-    [addContact, contact, handleFetchCoordinate, updatePrefillAddress]
+    [
+      addContact,
+      contact,
+      handleFetchCoordinate,
+      updateContact,
+      updatePrefillAddress,
+    ]
   )
 
   const submit = useCallback(() => {

--- a/src/features/contacts/screens/ContactFormScreen.tsx
+++ b/src/features/contacts/screens/ContactFormScreen.tsx
@@ -396,18 +396,24 @@ const ContactFormScreen = ({ route, navigation }: Props) => {
         contact.address
       )
       if (contact.userDraggedCoordinate && addressChanged) {
-        // Ask the user if they wanna update their coordinate automatically
+        // Ask the user if they wanna update their coordinate automatically.
+        // This path persists the contact inside the alert handlers.
         await askUserToUpdateCoordinatesAutomatically(newContact, resolve)
-      } else {
-        if (addressChanged || !contact.coordinate) {
-          handleFetchCoordinate(newContact).finally(() => {
-            updateContact(newContact)
-            resolve(newContact)
-          })
-          return
-        }
-        updateContact(newContact)
-        resolve(newContact)
+        return
+      }
+      // Persist the edit immediately so a changed address can't be lost to a
+      // slow or hung geocode request (axios has no timeout) — previously the
+      // write lived inside the geocode's completion callback, which the
+      // changed address always triggers. The coordinate refresh below runs in
+      // the background and patches the contact once it resolves.
+      updateContact(newContact)
+      resolve(newContact)
+      if (addressChanged || !contact.coordinate) {
+        handleFetchCoordinate(newContact).then((c) => {
+          if (c.coordinate) {
+            updateContact(c)
+          }
+        })
       }
     },
     [


### PR DESCRIPTION
## Why

New contacts and address edits were only persisted *after* geocoding resolved, so a slow or failed geocode could delay — or drop — the save.

## What

- Save a new contact immediately on submit; run geocoding in the background and patch in coordinates when it returns (`29faea64`).
- Persist contact address edits before kicking off the background geocode (`d3dd4338`).