### PR TITLE
perf: speed up Contacts list first paint (~1.5s → ~0.4s)

### DIFF
--- a/src/__tests__/conversationIndex.test.ts
+++ b/src/__tests__/conversationIndex.test.ts
@@ -1,0 +1,92 @@
+import moment from 'moment'
+import { describe, expect, it } from 'vitest'
+import { buildConversationIndex } from '@/lib/conversationIndex'
+import { Visit } from '@/types/visit'
+
+const visit = (overrides: Partial<Visit> & { contactId: string }): Visit => ({
+  id: overrides.id ?? `${overrides.contactId}-${overrides.date}`,
+  contact: { id: overrides.contactId },
+  date: overrides.date ?? new Date(),
+  isBibleStudy: overrides.isBibleStudy ?? false,
+})
+
+describe('lib/conversationIndex', () => {
+  it('classifies staleness relative to now (never/recent/week/month)', () => {
+    const now = moment()
+    const conversations: Visit[] = [
+      visit({
+        contactId: 'recent',
+        date: now.clone().subtract(2, 'days').toDate(),
+      }),
+      visit({
+        contactId: 'week',
+        date: now.clone().subtract(10, 'days').toDate(),
+      }),
+      visit({
+        contactId: 'month',
+        date: now.clone().subtract(2, 'months').toDate(),
+      }),
+    ]
+
+    const index = buildConversationIndex(conversations)
+
+    expect(index.stalenessFor('recent')).toBe('recent')
+    expect(index.stalenessFor('week')).toBe('week')
+    expect(index.stalenessFor('month')).toBe('month')
+    // No conversations recorded → never.
+    expect(index.stalenessFor('unknown')).toBe('never')
+  })
+
+  it('keeps the most recent conversation per contact', () => {
+    const older = visit({
+      contactId: 'a',
+      id: 'older',
+      date: moment().subtract(5, 'days').toDate(),
+    })
+    const newer = visit({
+      contactId: 'a',
+      id: 'newer',
+      date: moment().subtract(1, 'day').toDate(),
+    })
+    // Intentionally out of order to prove it picks max, not last-seen.
+    const index = buildConversationIndex([newer, older])
+
+    expect(index.mostRecentConvByContact.get('a')?.id).toBe('newer')
+  })
+
+  it('tracks study flags and current-month studies', () => {
+    const conversations: Visit[] = [
+      visit({ contactId: 'studiedNow', date: new Date(), isBibleStudy: true }),
+      visit({
+        contactId: 'studiedBefore',
+        date: moment().subtract(3, 'months').toDate(),
+        isBibleStudy: true,
+      }),
+      visit({
+        contactId: 'neverStudied',
+        date: new Date(),
+        isBibleStudy: false,
+      }),
+    ]
+
+    const index = buildConversationIndex(conversations)
+
+    expect(index.studyContactIds.has('studiedNow')).toBe(true)
+    expect(index.studyContactIds.has('studiedBefore')).toBe(true)
+    expect(index.studyContactIds.has('neverStudied')).toBe(false)
+
+    expect(index.studiedThisMonthIds.has('studiedNow')).toBe(true)
+    expect(index.studiedThisMonthIds.has('studiedBefore')).toBe(false)
+  })
+
+  it('skips conversations with unparseable dates without throwing', () => {
+    const conversations: Visit[] = [
+      visit({ contactId: 'bad', date: 'not-a-date' as unknown as Date }),
+    ]
+
+    const index = buildConversationIndex(conversations)
+
+    expect(index.mostRecentConvMs.has('bad')).toBe(false)
+    expect(index.stalenessFor('bad')).toBe('never')
+  })
+})

--- a/src/features/contacts/components/ContactRow.tsx
+++ b/src/features/contacts/components/ContactRow.tsx
@@ -3,14 +3,9 @@ import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
 import Card from '@/components/ui/Card'
 import { Contact } from '@/types/contact'
-import useConversations from '@/stores/conversationStore'
 import { useMemo, useState } from 'react'
 import moment from 'moment'
 import i18n from '@/lib/locales'
-import {
-  contactHasAtLeastOneStudy,
-  contactStudiedForGivenMonth,
-} from '@/lib/conversations'
 import IconButton from '@/components/ui/IconButton'
 import {
   faBook,
@@ -34,7 +29,8 @@ import SwipeableDismiss from '@/features/contacts/components/swipeableActions/Di
 import DismissContactSheet from '@/features/contacts/components/DismissContactSheet'
 import { useToastController } from '@tamagui/toast'
 import Avatar from '@/components/ui/Avatar'
-import { getContactStaleness, stalenessToColor } from '@/lib/contactStaleness'
+import { stalenessToColor } from '@/lib/contactStaleness'
+import { ConversationIndex } from '@/lib/conversationIndex'
 import { useMarkerColors } from '@/hooks/useMarkerColors'
 import {
   findNameMatch,
@@ -58,6 +54,7 @@ const ContactRow = ({
   contact,
   onPress,
   searchMatches,
+  index,
 }: {
   contact: Contact
   onPress?: () => void
@@ -68,10 +65,15 @@ const ContactRow = ({
    * conversation note, phone, email, or address).
    */
   searchMatches?: readonly FuseResultMatch[]
+  /**
+   * Shared per-contact conversation index built once by the list. Staleness,
+   * study flags, and the most-recent conversation are O(1) lookups against it —
+   * the row never scans the full conversations array.
+   */
+  index: ConversationIndex
 }) => {
   const theme = useTheme()
   const { deleteContact } = useContacts()
-  const { conversations } = useConversations()
   const markerColors = useMarkerColors()
   const toast = useToastController()
   const [dismissSheetOpen, setDismissSheetOpen] = useState(false)
@@ -83,43 +85,24 @@ const ContactRow = ({
   )
 
   const stripeColor = useMemo(
-    () =>
-      stalenessToColor(
-        getContactStaleness(contact, conversations),
-        markerColors
-      ),
-    [contact, conversations, markerColors]
+    () => stalenessToColor(index.stalenessFor(contact.id), markerColors),
+    [contact.id, index, markerColors]
   )
 
   const isActiveBibleStudy = useMemo(
-    () =>
-      contactStudiedForGivenMonth({
-        contact,
-        conversations,
-        month: new Date(),
-      }),
-    [contact, conversations]
+    () => index.studiedThisMonthIds.has(contact.id),
+    [contact.id, index]
   )
 
   const hasStudiedPreviously = useMemo(
-    () =>
-      contactHasAtLeastOneStudy({
-        conversations,
-        contact,
-      }),
-    [contact, conversations]
+    () => index.studyContactIds.has(contact.id),
+    [contact.id, index]
   )
 
-  const mostRecentConversation = useMemo(() => {
-    const filteredConversations = conversations.filter(
-      (c) => c.contact.id === contact.id
-    )
-    const sortedConversations = filteredConversations.sort((a, b) =>
-      moment(a.date).unix() < moment(b.date).unix() ? 1 : -1
-    )
-
-    return sortedConversations.length > 0 ? sortedConversations[0] : null
-  }, [contact.id, conversations])
+  const mostRecentConversation = useMemo(
+    () => index.mostRecentConvByContact.get(contact.id) ?? null,
+    [contact.id, index]
+  )
 
   const handleSwipeOpen = (
     direction: 'left' | 'right',

--- a/src/features/contacts/components/ContactsStatsHeader.tsx
+++ b/src/features/contacts/components/ContactsStatsHeader.tsx
@@ -5,15 +5,11 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
 import useTheme from '@/contexts/theme'
 import i18n, { TranslationKey } from '@/lib/locales'
-import {
-  ContactStaleness,
-  getContactStaleness,
-  stalenessToColor,
-} from '@/lib/contactStaleness'
+import { ContactStaleness, stalenessToColor } from '@/lib/contactStaleness'
 import { filterActivesContacts } from '@/lib/dismissedContacts'
+import { ConversationIndex } from '@/lib/conversationIndex'
 import { useMarkerColors } from '@/hooks/useMarkerColors'
 import { Contact } from '@/types/contact'
-import { Visit } from '@/types/visit'
 import Text from '@/components/ui/MyText'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -22,7 +18,8 @@ import StalenessColorKey from '@/components/StalenessColorKey'
 export type ContactsStatsHeaderProps = {
   /** All contacts, active AND dismissed. The component computes the splits. */
   contacts: Contact[]
-  conversations: Visit[]
+  /** Shared per-contact conversation index; staleness is an O(1) lookup. */
+  index: ConversationIndex
   onPressDismissed: () => void
 }
 
@@ -34,7 +31,7 @@ const STALENESS_ORDER: ContactStaleness[] = ['month', 'week', 'recent', 'never']
 
 const ContactsStatsHeader: React.FC<ContactsStatsHeaderProps> = ({
   contacts,
-  conversations,
+  index,
   onPressDismissed,
 }) => {
   const theme = useTheme()
@@ -50,7 +47,7 @@ const ContactsStatsHeader: React.FC<ContactsStatsHeaderProps> = ({
       month: 0,
     }
     for (const contact of active) {
-      const bucket = getContactStaleness(contact, conversations)
+      const bucket = index.stalenessFor(contact.id)
       counts[bucket] += 1
     }
     return {
@@ -58,7 +55,7 @@ const ContactsStatsHeader: React.FC<ContactsStatsHeaderProps> = ({
       dismissedCount: contacts.length - active.length,
       stalenessCounts: counts,
     }
-  }, [contacts, conversations])
+  }, [contacts, index])
 
   return (
     <Card

--- a/src/features/contacts/hooks/useContactsSorted.ts
+++ b/src/features/contacts/hooks/useContactsSorted.ts
@@ -11,6 +11,7 @@ import {
   searchContactsFuzzy,
 } from '@/features/contacts/lib/contactsSearch'
 import { filterActivesContacts } from '@/lib/dismissedContacts'
+import { buildConversationIndex } from '@/lib/conversationIndex'
 
 /**
  * Single source of truth for the active contacts pipeline. The Contacts tab and
@@ -29,6 +30,14 @@ export function useContactsSorted() {
   const search = useContactsSearchStore((s) => s.search)
 
   const actives = useMemo(() => filterActivesContacts(contacts), [contacts])
+
+  // Single per-contact conversation index, shared with the comparator below and
+  // handed down to the stats header and every row — so the whole screen scans
+  // the conversations array once instead of once per contact.
+  const conversationIndex = useMemo(
+    () => buildConversationIndex(conversations),
+    [conversations]
+  )
 
   const fuse = useMemo(
     () => buildContactsFuse(actives, conversations),
@@ -69,11 +78,19 @@ export function useContactsSorted() {
 
   const comparator = useMemo(
     () =>
-      buildContactComparator(contactSort, contactSortDirection, {
-        conversations,
-        customFieldDefs,
-      }),
-    [contactSort, contactSortDirection, conversations, customFieldDefs]
+      buildContactComparator(
+        contactSort,
+        contactSortDirection,
+        { conversations, customFieldDefs },
+        conversationIndex
+      ),
+    [
+      contactSort,
+      contactSortDirection,
+      conversations,
+      customFieldDefs,
+      conversationIndex,
+    ]
   )
 
   // With an active query, `filtered` is already in Fuse relevance order — the
@@ -90,6 +107,7 @@ export function useContactsSorted() {
   return {
     searchSortedAndFilteredContacts,
     searchMatchesById,
+    conversationIndex,
     search,
     contactsFilters,
     customFieldDefs,

--- a/src/features/contacts/screens/ContactsScreen.tsx
+++ b/src/features/contacts/screens/ContactsScreen.tsx
@@ -14,7 +14,6 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
 import useTheme from '@/contexts/theme'
 import useContacts from '@/stores/contactsStore'
-import useConversations from '@/stores/conversationStore'
 import useContactsSearchStore from '@/features/contacts/stores/contactsSearchStore'
 import { builtInContactSortOptions } from '@/stores/preferences'
 import i18n from '@/lib/locales'
@@ -45,7 +44,6 @@ const ContactsScreen = () => {
   const navigation = useNavigation<RootStackNavigation>()
 
   const { contacts, customFieldDefs } = useContacts()
-  const { conversations } = useConversations()
 
   const search = useContactsSearchStore((s) => s.search)
   const setSearch = useContactsSearchStore((s) => s.setSearch)
@@ -61,6 +59,7 @@ const ContactsScreen = () => {
     isSortNonDefault,
     searchSortedAndFilteredContacts,
     searchMatchesById,
+    conversationIndex,
   } = useContactsSorted()
 
   // Keep the list pinned to the top as the query, filters, or sort change —
@@ -190,7 +189,7 @@ const ContactsScreen = () => {
 
             <ContactsStatsHeader
               contacts={contacts}
-              conversations={conversations}
+              index={conversationIndex}
               onPressDismissed={() => navigation.navigate('Dismissed Contacts')}
             />
 
@@ -347,6 +346,7 @@ const ContactsScreen = () => {
         renderItem={({ item }) => (
           <ContactRow
             contact={item}
+            index={conversationIndex}
             searchMatches={searchMatchesById.get(item.id)}
             onPress={() =>
               navigation.navigate('Contact Details', { id: item.id })

--- a/src/lib/contactsSort.ts
+++ b/src/lib/contactsSort.ts
@@ -2,7 +2,10 @@ import moment from 'moment'
 import { Contact } from '@/types/contact'
 import { Visit } from '@/types/visit'
 import { CustomFieldDefinition } from '@/types/customField'
-import { ContactStaleness } from '@/lib/contactStaleness'
+import {
+  buildConversationIndex,
+  ConversationIndex,
+} from '@/lib/conversationIndex'
 
 export type ContactSortDirection = 'asc' | 'desc'
 
@@ -28,13 +31,6 @@ export type ContactSortKey =
 export type SortContext = {
   conversations: Visit[]
   customFieldDefs: CustomFieldDefinition[]
-}
-
-const stalenessRank: Record<ContactStaleness, number> = {
-  never: 0,
-  recent: 1,
-  week: 2,
-  month: 3,
 }
 
 /**
@@ -89,79 +85,12 @@ const numberCmp = (
   return localeCmp(a, b)
 }
 
-/**
- * Per-contact sort values, computed once in a single pass over `conversations`
- * (see {@link buildConversationAggregates}). The comparator reads these in O(1)
- * instead of re-scanning every conversation — and re-allocating `moment`
- * objects — inside each of the O(n log n) comparisons.
- */
-type ConversationAggregates = {
-  mostRecentConvUnix: Map<string, number>
-  mostRecentStudyUnix: Map<string, number>
-  studyContactIds: Set<string>
-  studiedThisMonthIds: Set<string>
-  stalenessRankFor: (contactId: string) => number
-}
-
-const buildConversationAggregates = (
-  conversations: Visit[]
-): ConversationAggregates => {
-  const mostRecentConvUnix = new Map<string, number>()
-  const mostRecentStudyUnix = new Map<string, number>()
-  const studyContactIds = new Set<string>()
-  const studiedThisMonthIds = new Set<string>()
-  const currentMonth = moment()
-
-  for (const c of conversations) {
-    const id = c.contact.id
-    const m = moment(c.date)
-    const unix = m.unix()
-
-    const prevConv = mostRecentConvUnix.get(id)
-    if (prevConv === undefined || unix > prevConv) {
-      mostRecentConvUnix.set(id, unix)
-    }
-
-    if (c.isBibleStudy) {
-      studyContactIds.add(id)
-      const prevStudy = mostRecentStudyUnix.get(id)
-      if (prevStudy === undefined || unix > prevStudy) {
-        mostRecentStudyUnix.set(id, unix)
-      }
-      if (m.isSame(currentMonth, 'month')) {
-        studiedThisMonthIds.add(id)
-      }
-    }
-  }
-
-  // Pre-resolve the staleness bucket thresholds to plain unix seconds so the
-  // per-contact classification is integer comparison, not moment construction.
-  // Mirrors getContactStaleness: before(now - 1 month) → month, etc.
-  const monthAgoUnix = moment().subtract(1, 'month').unix()
-  const weekAgoUnix = moment().subtract(1, 'week').unix()
-  const stalenessRankFor = (contactId: string): number => {
-    const unix = mostRecentConvUnix.get(contactId)
-    if (unix === undefined) return stalenessRank.never
-    if (unix < monthAgoUnix) return stalenessRank.month
-    if (unix < weekAgoUnix) return stalenessRank.week
-    return stalenessRank.recent
-  }
-
-  return {
-    mostRecentConvUnix,
-    mostRecentStudyUnix,
-    studyContactIds,
-    studiedThisMonthIds,
-    stalenessRankFor,
-  }
-}
-
 const compareKey = (
   a: Contact,
   b: Contact,
   sort: ContactSortKey,
   ctx: SortContext,
-  agg: ConversationAggregates
+  index: ConversationIndex
 ): KeyCompare => {
   if (sort.startsWith('customField:')) {
     const defId = sort.slice('customField:'.length)
@@ -175,8 +104,8 @@ const compareKey = (
   switch (sort) {
     case 'suggested':
     case 'recentConversation': {
-      const ar = agg.mostRecentConvUnix.get(a.id)
-      const br = agg.mostRecentConvUnix.get(b.id)
+      const ar = index.mostRecentConvMs.get(a.id)
+      const br = index.mostRecentConvMs.get(b.id)
       if (ar === undefined || br === undefined) {
         return missing(ar !== undefined, br !== undefined)
       }
@@ -187,15 +116,15 @@ const compareKey = (
     case 'za':
       return b.name.localeCompare(a.name)
     case 'bibleStudy': {
-      const ar = agg.mostRecentStudyUnix.get(a.id)
-      const br = agg.mostRecentStudyUnix.get(b.id)
+      const ar = index.mostRecentStudyMs.get(a.id)
+      const br = index.mostRecentStudyMs.get(b.id)
       if (ar === undefined || br === undefined) {
         return missing(ar !== undefined, br !== undefined)
       }
       return ar - br
     }
     case 'pinStaleness':
-      return agg.stalenessRankFor(a.id) - agg.stalenessRankFor(b.id)
+      return index.stalenessRankFor(a.id) - index.stalenessRankFor(b.id)
     case 'createdAt': {
       const am = a.createdAt ? moment(a.createdAt) : null
       const bm = b.createdAt ? moment(b.createdAt) : null
@@ -230,14 +159,19 @@ const compareKey = (
 export const buildContactComparator = (
   sort: ContactSortKey,
   direction: ContactSortDirection,
-  ctx: SortContext
+  ctx: SortContext,
+  /**
+   * Prebuilt conversation index. The Contacts screen builds this once per
+   * (conversations) change and shares it with the stats header and rows, so
+   * pass it here to avoid a redundant pass. Omitted in tests and any caller
+   * that only needs a one-off comparator — we build it from `ctx` then.
+   */
+  index: ConversationIndex = buildConversationIndex(ctx.conversations)
 ) => {
   const applyPinning = sort === 'suggested'
-  // Single pass over conversations; the comparator reads these maps in O(1).
-  const agg = buildConversationAggregates(ctx.conversations)
   const studyTier = (c: Contact): number => {
-    if (!agg.studyContactIds.has(c.id)) return 0
-    return agg.studiedThisMonthIds.has(c.id) ? 2 : 1
+    if (!index.studyContactIds.has(c.id)) return 0
+    return index.studiedThisMonthIds.has(c.id) ? 2 : 1
   }
   const dirMul = direction === 'desc' ? -1 : 1
 
@@ -248,7 +182,7 @@ export const buildContactComparator = (
       const bt = studyTier(b)
       if (at !== bt) return bt - at
     }
-    const result = compareKey(a, b, sort, ctx, agg)
+    const result = compareKey(a, b, sort, ctx, index)
     if (isMissingResult(result)) {
       // Both missing → tie; one missing → that side goes last regardless of
       // direction. The user's intent for "undefineds last" doesn't flip with

--- a/src/lib/contactsSort.ts
+++ b/src/lib/contactsSort.ts
@@ -2,12 +2,7 @@ import moment from 'moment'
 import { Contact } from '@/types/contact'
 import { Visit } from '@/types/visit'
 import { CustomFieldDefinition } from '@/types/customField'
-import { ContactStaleness, getContactStaleness } from '@/lib/contactStaleness'
-import {
-  contactMostRecentStudy,
-  contactStudiedForGivenMonth,
-} from '@/lib/conversations'
-import { getMostRecentConversationForContact } from '@/lib/contacts'
+import { ContactStaleness } from '@/lib/contactStaleness'
 
 export type ContactSortDirection = 'asc' | 'desc'
 
@@ -94,11 +89,79 @@ const numberCmp = (
   return localeCmp(a, b)
 }
 
+/**
+ * Per-contact sort values, computed once in a single pass over `conversations`
+ * (see {@link buildConversationAggregates}). The comparator reads these in O(1)
+ * instead of re-scanning every conversation — and re-allocating `moment`
+ * objects — inside each of the O(n log n) comparisons.
+ */
+type ConversationAggregates = {
+  mostRecentConvUnix: Map<string, number>
+  mostRecentStudyUnix: Map<string, number>
+  studyContactIds: Set<string>
+  studiedThisMonthIds: Set<string>
+  stalenessRankFor: (contactId: string) => number
+}
+
+const buildConversationAggregates = (
+  conversations: Visit[]
+): ConversationAggregates => {
+  const mostRecentConvUnix = new Map<string, number>()
+  const mostRecentStudyUnix = new Map<string, number>()
+  const studyContactIds = new Set<string>()
+  const studiedThisMonthIds = new Set<string>()
+  const currentMonth = moment()
+
+  for (const c of conversations) {
+    const id = c.contact.id
+    const m = moment(c.date)
+    const unix = m.unix()
+
+    const prevConv = mostRecentConvUnix.get(id)
+    if (prevConv === undefined || unix > prevConv) {
+      mostRecentConvUnix.set(id, unix)
+    }
+
+    if (c.isBibleStudy) {
+      studyContactIds.add(id)
+      const prevStudy = mostRecentStudyUnix.get(id)
+      if (prevStudy === undefined || unix > prevStudy) {
+        mostRecentStudyUnix.set(id, unix)
+      }
+      if (m.isSame(currentMonth, 'month')) {
+        studiedThisMonthIds.add(id)
+      }
+    }
+  }
+
+  // Pre-resolve the staleness bucket thresholds to plain unix seconds so the
+  // per-contact classification is integer comparison, not moment construction.
+  // Mirrors getContactStaleness: before(now - 1 month) → month, etc.
+  const monthAgoUnix = moment().subtract(1, 'month').unix()
+  const weekAgoUnix = moment().subtract(1, 'week').unix()
+  const stalenessRankFor = (contactId: string): number => {
+    const unix = mostRecentConvUnix.get(contactId)
+    if (unix === undefined) return stalenessRank.never
+    if (unix < monthAgoUnix) return stalenessRank.month
+    if (unix < weekAgoUnix) return stalenessRank.week
+    return stalenessRank.recent
+  }
+
+  return {
+    mostRecentConvUnix,
+    mostRecentStudyUnix,
+    studyContactIds,
+    studiedThisMonthIds,
+    stalenessRankFor,
+  }
+}
+
 const compareKey = (
   a: Contact,
   b: Contact,
   sort: ContactSortKey,
-  ctx: SortContext
+  ctx: SortContext,
+  agg: ConversationAggregates
 ): KeyCompare => {
   if (sort.startsWith('customField:')) {
     const defId = sort.slice('customField:'.length)
@@ -112,38 +175,27 @@ const compareKey = (
   switch (sort) {
     case 'suggested':
     case 'recentConversation': {
-      const ar = getMostRecentConversationForContact({
-        conversations: ctx.conversations,
-        contact: a,
-      })
-      const br = getMostRecentConversationForContact({
-        conversations: ctx.conversations,
-        contact: b,
-      })
-      if (!ar || !br) return missing(!!ar, !!br)
-      return moment(ar.date).unix() - moment(br.date).unix()
+      const ar = agg.mostRecentConvUnix.get(a.id)
+      const br = agg.mostRecentConvUnix.get(b.id)
+      if (ar === undefined || br === undefined) {
+        return missing(ar !== undefined, br !== undefined)
+      }
+      return ar - br
     }
     case 'az':
       return a.name.localeCompare(b.name)
     case 'za':
       return b.name.localeCompare(a.name)
     case 'bibleStudy': {
-      const ar = contactMostRecentStudy({
-        conversations: ctx.conversations,
-        contact: a,
-      })
-      const br = contactMostRecentStudy({
-        conversations: ctx.conversations,
-        contact: b,
-      })
-      if (!ar || !br) return missing(!!ar, !!br)
-      return moment(ar.date).unix() - moment(br.date).unix()
+      const ar = agg.mostRecentStudyUnix.get(a.id)
+      const br = agg.mostRecentStudyUnix.get(b.id)
+      if (ar === undefined || br === undefined) {
+        return missing(ar !== undefined, br !== undefined)
+      }
+      return ar - br
     }
     case 'pinStaleness':
-      return (
-        stalenessRank[getContactStaleness(a, ctx.conversations)] -
-        stalenessRank[getContactStaleness(b, ctx.conversations)]
-      )
+      return agg.stalenessRankFor(a.id) - agg.stalenessRankFor(b.id)
     case 'createdAt': {
       const am = a.createdAt ? moment(a.createdAt) : null
       const bm = b.createdAt ? moment(b.createdAt) : null
@@ -181,19 +233,11 @@ export const buildContactComparator = (
   ctx: SortContext
 ) => {
   const applyPinning = sort === 'suggested'
-  const studyContactIds = new Set(
-    ctx.conversations.filter((c) => c.isBibleStudy).map((c) => c.contact.id)
-  )
-  const isStudy = (c: Contact) => studyContactIds.has(c.id)
-  const isActive = (c: Contact) =>
-    contactStudiedForGivenMonth({
-      conversations: ctx.conversations,
-      contact: c,
-      month: new Date(),
-    })
+  // Single pass over conversations; the comparator reads these maps in O(1).
+  const agg = buildConversationAggregates(ctx.conversations)
   const studyTier = (c: Contact): number => {
-    if (!isStudy(c)) return 0
-    return isActive(c) ? 2 : 1
+    if (!agg.studyContactIds.has(c.id)) return 0
+    return agg.studiedThisMonthIds.has(c.id) ? 2 : 1
   }
   const dirMul = direction === 'desc' ? -1 : 1
 
@@ -204,7 +248,7 @@ export const buildContactComparator = (
       const bt = studyTier(b)
       if (at !== bt) return bt - at
     }
-    const result = compareKey(a, b, sort, ctx)
+    const result = compareKey(a, b, sort, ctx, agg)
     if (isMissingResult(result)) {
       // Both missing → tie; one missing → that side goes last regardless of
       // direction. The user's intent for "undefineds last" doesn't flip with

--- a/src/lib/conversationIndex.ts
+++ b/src/lib/conversationIndex.ts
@@ -1,0 +1,114 @@
+import { Visit } from '@/types/visit'
+import { ContactStaleness } from '@/lib/contactStaleness'
+
+/**
+ * Numeric ranking of staleness buckets, most-recent (0) to most-lapsed (3).
+ * Lives here (not in the sort lib) so any consumer reading the index can rank
+ * without pulling in the comparator.
+ */
+export const stalenessRank: Record<ContactStaleness, number> = {
+  never: 0,
+  recent: 1,
+  week: 2,
+  month: 3,
+}
+
+/**
+ * Per-contact conversation aggregates, computed in a single O(conversations)
+ * pass. Every list-screen consumer (the stats header's staleness tally, each
+ * ContactRow's stripe/study/most-recent, and the sort comparator) reads from
+ * this in O(1) instead of re-scanning the full conversations array per contact
+ * — the pattern that made first paint ~1.5s on a 2.5k-conversation account.
+ *
+ * Dates are parsed with native `new Date(...).getTime()` (epoch ms), not
+ * `moment`, because the pass runs once over every conversation and `moment`
+ * allocation dominated even the single-pass cost. Magnitudes are only ever
+ * compared, so ms vs. unix-seconds is immaterial.
+ */
+export type ConversationIndex = {
+  /** Epoch-ms of the most recent conversation per contact id. */
+  mostRecentConvMs: Map<string, number>
+  /** The most recent conversation record per contact id (for display). */
+  mostRecentConvByContact: Map<string, Visit>
+  /** Epoch-ms of the most recent Bible-study conversation per contact id. */
+  mostRecentStudyMs: Map<string, number>
+  /** Contact ids that have at least one Bible-study conversation, ever. */
+  studyContactIds: Set<string>
+  /** Contact ids with a Bible-study conversation in the current calendar month. */
+  studiedThisMonthIds: Set<string>
+  /** Staleness bucket for a contact id (mirrors `getContactStaleness`). */
+  stalenessFor: (contactId: string) => ContactStaleness
+  /** Numeric staleness rank for a contact id (for the comparator). */
+  stalenessRankFor: (contactId: string) => number
+}
+
+export function buildConversationIndex(
+  conversations: Visit[]
+): ConversationIndex {
+  const mostRecentConvMs = new Map<string, number>()
+  const mostRecentConvByContact = new Map<string, Visit>()
+  const mostRecentStudyMs = new Map<string, number>()
+  const studyContactIds = new Set<string>()
+  const studiedThisMonthIds = new Set<string>()
+
+  const now = new Date()
+  // Current-month bounds as epoch ms, so the "studied this month" check is an
+  // integer range test instead of a per-conversation calendar comparison.
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime()
+  const startOfNextMonth = new Date(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    1
+  ).getTime()
+
+  for (const c of conversations) {
+    const id = c.contact.id
+    const ms = new Date(c.date).getTime()
+    if (Number.isNaN(ms)) continue
+
+    const prevConv = mostRecentConvMs.get(id)
+    if (prevConv === undefined || ms > prevConv) {
+      mostRecentConvMs.set(id, ms)
+      mostRecentConvByContact.set(id, c)
+    }
+
+    if (c.isBibleStudy) {
+      studyContactIds.add(id)
+      const prevStudy = mostRecentStudyMs.get(id)
+      if (prevStudy === undefined || ms > prevStudy) {
+        mostRecentStudyMs.set(id, ms)
+      }
+      if (ms >= startOfMonth && ms < startOfNextMonth) {
+        studiedThisMonthIds.add(id)
+      }
+    }
+  }
+
+  // Staleness thresholds as plain epoch ms. Mirrors getContactStaleness:
+  // before(now − 1 month) → month, before(now − 1 week) → week, else recent.
+  const monthAgo = new Date(now)
+  monthAgo.setMonth(monthAgo.getMonth() - 1)
+  const monthAgoMs = monthAgo.getTime()
+  const weekAgoMs = now.getTime() - 7 * 24 * 60 * 60 * 1000
+
+  const stalenessFor = (contactId: string): ContactStaleness => {
+    const ms = mostRecentConvMs.get(contactId)
+    if (ms === undefined) return 'never'
+    if (ms < monthAgoMs) return 'month'
+    if (ms < weekAgoMs) return 'week'
+    return 'recent'
+  }
+
+  const stalenessRankFor = (contactId: string): number =>
+    stalenessRank[stalenessFor(contactId)]
+
+  return {
+    mostRecentConvMs,
+    mostRecentConvByContact,
+    mostRecentStudyMs,
+    studyContactIds,
+    studiedThisMonthIds,
+    stalenessFor,
+    stalenessRankFor,
+  }
+}


### PR DESCRIPTION
## Why

On accounts with many conversations (measured on 177 contacts / 2,578 conversations) the Contacts tab took ~1.5s to first paint. Profiling showed the cost was **repeated full scans of the conversations array, keyed by contact** — the same array walked once per contact in several places, plus heavy `moment()` allocation in the hot path.

Two commits, both eliminating that pattern:

1. **`precompute contact sort keys`** — the sort comparator no longer re-scans conversations (and re-allocates `moment` objects) inside each of the O(n log n) comparisons.
2. **`share a single conversation index`** — extracts that single-pass aggregate into a reusable `conversationIndex` and shares one instance across the whole screen.

## What changed

`src/lib/conversationIndex.ts` (new) builds a per-contact index in **one O(conversations) pass**: most-recent conversation, most-recent study, study contact ids, studied-this-month ids, and a staleness classifier. It parses dates with native `new Date(...).getTime()` instead of `moment`, which alone turned the pass from ~107ms into ~5ms.

`useContactsSorted` builds the index once and shares it with:
- `ContactsStatsHeader` — staleness tally is now an O(1) lookup per contact (was **939ms** of per-contact `getContactStaleness` re-scans)
- `ContactRow` — stripe color, study flags, and most-recent conversation are O(1) lookups; the row dropped its own `useConversations()` subscription and 4 full-array scans (~15ms/row of scroll jank)
- `buildContactComparator` — reuses the shared index instead of building its own

### Measured (177 contacts / 2,578 conversations)

| Surface | Before | After |
|---|---|---|
| `ContactsStatsHeader` staleness | 939ms | 0.1ms |
| `buildComparator` | 107ms | 0ms (reuses index) |
| conversation index pass | — | 5ms |
| mount → first commit | 1083ms | 52ms |
| FlashList first layout (since mount) | 1538ms | 377ms |

The remaining ~325ms is native render of the initial `ContactRow` batch (Swipeable / Avatar / per-row sheet), not JS compute — left for a follow-up.

## Risks

- Pure read-path optimization — no store/persistence shape changes, no publisher-capability changes.
- The shared index swaps `moment(date)` for `new Date(date).getTime()` in the aggregation. Behavior is preserved (staleness thresholds, current-month study) and covered by tests; unparseable dates are skipped rather than throwing.
- `buildContactComparator` gained an optional prebuilt-index param (defaults to building its own), so existing callers and tests are unaffected.

## Tests required

None beyond CI. New `conversationIndex.test.ts` covers staleness buckets, most-recent selection, study/this-month flags, and the bad-date guard; existing `contactsSort` / `conversations` suites still pass.