### PR TITLE
fix(projected-total): probe correct calendar day in TZ-shifted walks

### DIFF
--- a/src/__tests__/projectedTotal.test.ts
+++ b/src/__tests__/projectedTotal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
 
@@ -644,6 +644,68 @@ describe('computeProjectedTotal', () => {
         loggedMonths: [logged(2026, 4, 5 * 60)],
       })
       expect(r.state).toBe('unreachable_gap')
+    })
+  })
+
+  // The day-walk must probe the same calendar day it buckets, regardless of
+  // device TZ. The walk's cursor is a UTC moment; handing its instant to
+  // getPlansIntersectingDay (which re-extracts the *local* calendar day) shifts
+  // every probe by a day in TZs west of UTC (future scopes start at midnight
+  // UTC = previous local day) or east of UTC+11 (noon-UTC `today` anchor =
+  // next local day).
+  describe('day-walk TZ stability', () => {
+    const originalTZ = process.env.TZ
+    afterEach(() => {
+      if (originalTZ === undefined) delete process.env.TZ
+      else process.env.TZ = originalTZ
+    })
+
+    it('a fully future month counts every recurring instance and none from the prior month (US TZ)', () => {
+      // The issue-report scenario: viewed from June 10, July 2026 has five
+      // Friday instances at 8h (3, 10, 17, 24, 31) plus a Tuesday plan that
+      // ends June 30. Expected planned = 40h. The shifted walk instead probed
+      // June 30–July 30: it missed Friday the 31st and leaked the June 30
+      // Tuesday instance into July → 36h, matching the screenshot.
+      process.env.TZ = 'America/Los_Angeles'
+      const result = computeProjectedTotal({
+        scope: { kind: 'month', year: 2026, month: 6 },
+        today: normalizeDateForStorage('2026-06-10'),
+        goalMinutes: 50 * 60,
+        loggedMonths: [],
+        dayPlans: [],
+        recurringPlans: [
+          weeklyRecurring('rec-friday', '2026-01-02', 8 * 60),
+          weeklyRecurring('rec-tuesday', '2026-01-06', 4 * 60, '2026-06-30'),
+        ],
+        categories: [],
+        creditCapMinutes: 55 * 60,
+      })
+
+      expect(result.plannedMinutes).toBe(5 * 8 * 60)
+    })
+
+    it("counts today's recurring instance in the current month (UTC+12)", () => {
+      // In NZST the noon-UTC `today` anchor is midnight the *next* local day,
+      // so the shifted walk probed June 11 onward and dropped today's
+      // instance. Weekly Wednesdays 10/17/24 (ends the 24th) from today June
+      // 10 must all count.
+      process.env.TZ = 'Pacific/Auckland'
+      const result = computeProjectedTotal({
+        scope: { kind: 'month', year: 2026, month: 5 },
+        // A live instant (the production input — useProjectedTotal passes
+        // `new Date()`), not a pre-normalized stored date: 9am local NZST.
+        today: new Date(2026, 5, 10, 9, 0, 0),
+        goalMinutes: 50 * 60,
+        loggedMonths: [],
+        dayPlans: [],
+        recurringPlans: [
+          weeklyRecurring('rec-wednesday', '2026-06-10', 60, '2026-06-24'),
+        ],
+        categories: [],
+        creditCapMinutes: 55 * 60,
+      })
+
+      expect(result.plannedMinutes).toBe(3 * 60)
     })
   })
 })

--- a/src/lib/assistantRecommendation.ts
+++ b/src/lib/assistantRecommendation.ts
@@ -2,7 +2,11 @@ import moment from 'moment'
 import type { Visit } from '@/types/visit'
 import type { DayPlan, RecurringPlan } from '@/types/timeEntry'
 import type { AssistantEvent, RecommendationShape } from '@/types/assistant'
-import { momentStoredDate, normalizeDateForStorage } from '@/lib/normalizeDate'
+import {
+  localDayFromUtcCursor,
+  momentStoredDate,
+  normalizeDateForStorage,
+} from '@/lib/normalizeDate'
 import { getPlansIntersectingDay } from '@/lib/serviceReport'
 
 export type {
@@ -91,9 +95,10 @@ export type EngineInput = {
    * Projected Total's mirror cap semantics
    * (`ProjectedTotalResult.standardGapMinutes`). The engine sizes its
    * (Standard-only) proposals against this instead of re-deriving a raw logged
-   * + planned sum — so it can never disagree with the Projected Total card it
-   * renders beneath (e.g. vanish while the card shows a reachable gap, or
-   * under-propose when planned credit is squeezed by the cap).
+   *
+   * - Planned sum — so it can never disagree with the Projected Total card it
+   *   renders beneath (e.g. vanish while the card shows a reachable gap, or
+   *   under-propose when planned credit is squeezed by the cap).
    */
   standardGapMinutes: number
   dayPlans: DayPlan[]
@@ -159,7 +164,8 @@ const eligibleDays = (
     const key = cursor.format('YYYY-MM-DD')
     const hasDayPlan = dayPlanKeys.has(key)
     const hasRecurring =
-      getPlansIntersectingDay(cursor.toDate(), recurringPlans).length > 0
+      getPlansIntersectingDay(localDayFromUtcCursor(cursor), recurringPlans)
+        .length > 0
     if (!isOffDay && !hasDayPlan && !hasRecurring) {
       days.push({
         m: cursor.clone(),

--- a/src/lib/normalizeDate.ts
+++ b/src/lib/normalizeDate.ts
@@ -67,6 +67,17 @@ export const preserveOrNormalizeStoredDate = (date: Date | string): Date => {
 export const momentStoredDate = (date: Date | string): moment.Moment =>
   moment.utc(date)
 
+/**
+ * Converts a UTC-mode day cursor (e.g. a `moment.utc` walk) into a local-mode
+ * noon Date carrying the same calendar day. Use when handing a walk's day to
+ * APIs that re-extract the _local_ calendar day via `normalizeDateForStorage`
+ * (`getPlansIntersectingDay`, `getEffectiveMinutesForRecurringPlan`) — passing
+ * `cursor.toDate()` (an instant) lands on the previous local day in TZs west of
+ * UTC and the next one east of UTC+11.
+ */
+export const localDayFromUtcCursor = (cursor: moment.Moment): Date =>
+  new Date(cursor.year(), cursor.month(), cursor.date(), 12)
+
 /** Normalize every Date field on a RecurringPlan to noon-UTC anchor. */
 export const normalizeRecurringPlan = (plan: RecurringPlan): RecurringPlan => ({
   ...plan,

--- a/src/lib/projectedTotal.ts
+++ b/src/lib/projectedTotal.ts
@@ -1,6 +1,10 @@
 import type { Category } from '@/types/category'
 import type { DayPlan, RecurringPlan } from '@/types/timeEntry'
-import { momentStoredDate, normalizeDateForStorage } from '@/lib/normalizeDate'
+import {
+  localDayFromUtcCursor,
+  momentStoredDate,
+  normalizeDateForStorage,
+} from '@/lib/normalizeDate'
 import {
   applyMonthCreditCap,
   getEffectiveMinutesForRecurringPlan,
@@ -184,7 +188,7 @@ const futurePlannedMinutesByMonth = (
       cursor.add(1, 'day')
       continue
     }
-    const dayDate = cursor.toDate()
+    const dayDate = localDayFromUtcCursor(cursor)
     const dp = dayPlanByKey.get(key)
     let minutes = 0
     let isCredit = false
@@ -209,7 +213,6 @@ const futurePlannedMinutesByMonth = (
           isCredit = credit
         }
       }
-      if (winner === null) isCredit = false
     }
     if (minutes > 0) {
       const bucketKey = monthKey(cursor.year(), cursor.month())


### PR DESCRIPTION
## Why

Projected Hours for a fully future month under-counted in US timezones (40h of Friday plans showed as 36h). The walk in `futurePlannedMinutesByMonth` (src/lib/projectedTotal.ts:194) iterates with a UTC cursor but passed `cursor.toDate()` — a midnight-UTC instant — to `getPlansIntersectingDay`, which re-extracts the **local** calendar day. West of UTC every probe shifted back a day: July's walk queried June 30–July 30, missing Friday the 31st (−8h) and leaking June 30's Tuesday plan into July (+4h). East of UTC+11 the mirror failure drops today's instance from the current month. The Assistant's `eligibleDays` (src/lib/assistantRecommendation.ts:166) had the identical pattern, silently treating planned days as free.

Fix: shared `localDayFromUtcCursor` helper (src/lib/normalizeDate.ts:78) converts the cursor's calendar day to a local-mode noon Date, making the local re-extraction round-trip the identity in every TZ. Rejected alternative: teaching `getPlansIntersectingDay` to sniff stored noon-UTC anchors — `preserveOrNormalizeStoredDate`'s docs explain why that's unsafe for arbitrary input.

All other `getPlansIntersectingDay` callers (widgets, calendar, schedule list) already build local-mode dates and are unaffected.

## Risks

- User-visible: future-month Projected Hours and Assistant day recommendations change (to the correct values). Current-month/year numbers in US TZs were already correct and don't move.

New `day-walk TZ stability` tests reproduce the reported scenario exactly (36h → 40h) and the UTC+12 mirror case; both fail without the fix.