### PR TITLE
fix(contacts): gracefully handle transient location errors (JW-TIME-7X)

### DIFF
--- a/src/features/contacts/hooks/useLocation.ts
+++ b/src/features/contacts/hooks/useLocation.ts
@@ -1,18 +1,41 @@
 import { useCallback, useEffect, useState } from 'react'
 import * as Location from 'expo-location'
+import * as Sentry from '@sentry/react-native'
+
+/**
+ * `kCLErrorDomain` Code=0 means the location is temporarily unavailable
+ * (e.g. weak GPS signal). It is expected and transient, so we degrade
+ * gracefully instead of surfacing it to the user or Sentry.
+ */
+const isTransientLocationError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('kCLErrorDomain') && message.includes('Code=0')
+}
 
 export default function useLocation() {
   const [status, setStatus] = useState<Location.PermissionStatus | null>(null)
   const [location, setLocation] = useState<Location.LocationObject | null>(null)
 
+  const fetchCurrentPosition = useCallback(async () => {
+    try {
+      const result = await Location.getCurrentPositionAsync()
+      setLocation(result)
+    } catch (error) {
+      // Location can be temporarily unavailable; don't report the expected
+      // transient failure, just leave the previous location in place.
+      if (!isTransientLocationError(error)) {
+        Sentry.captureException(error)
+      }
+    }
+  }, [])
+
   const refreshStatus = useCallback(async () => {
     const result = await Location.getForegroundPermissionsAsync()
     setStatus(result.status)
     if (result.granted) {
-      const location = await Location.getCurrentPositionAsync()
-      setLocation(location)
+      await fetchCurrentPosition()
     }
-  }, [])
+  }, [fetchCurrentPosition])
 
   useEffect(() => {
     refreshStatus()
@@ -22,11 +45,10 @@ export default function useLocation() {
     const result = await Location.requestForegroundPermissionsAsync()
     setStatus(result.status)
     if (result.granted) {
-      const location = await Location.getCurrentPositionAsync()
-      setLocation(location)
+      await fetchCurrentPosition()
     }
     return result
-  }, [])
+  }, [fetchCurrentPosition])
 
   return {
     locationPermission: status === Location.PermissionStatus.GRANTED,


### PR DESCRIPTION
## Sentry issue
[JW-TIME-7X](https://levi-wilkerson.sentry.io/issues/6061316525/) — `Error: Cannot obtain current location: Error Domain=kCLErrorDomain Code=0 "(null)"`
**925 events** (highest event volume in the app) from ~2 users.

## Root cause
`useLocation` (`src/features/contacts/hooks/useLocation.ts`) called `Location.getCurrentPositionAsync()` with **no try/catch** in both `refreshStatus()` and `requestLocation()`.

`refreshStatus()` runs on mount and again on every `AppState` `active` transition (see `AddressAutocomplete.tsx`). A user in a low-signal area who repeatedly re-foregrounds the contacts screen produces an unhandled promise rejection each time. iOS reports this as `kCLErrorDomain Code=0` — "location temporarily unavailable", an expected and transient condition. The React Native Sentry SDK captured every rejection, which explains the extreme event:user ratio (a retry/foreground loop, not a real crash).

## Change
- Extracted a shared `fetchCurrentPosition()` helper that wraps the call in try/catch.
- Transient errors (`kCLErrorDomain` Code=0) are swallowed: the previous `location` value is kept, the UI degrades gracefully (address search just runs without a location bias).
- Genuinely unexpected errors are still reported via `Sentry.captureException`.

## Impact
Eliminates the noise source behind ~925 events. No behavioral change for the happy path; on transient GPS failure the screen no longer throws/reports — it simply keeps the last known location.

## How to verify
- `npm run typecheck` and `eslint` on the changed file pass.
- Manual: on a device with weak GPS, open the contact address autocomplete and background/foreground the app repeatedly. Previously each foreground emitted a Sentry error; now none are emitted and the screen continues to function.

Ref: JW-TIME-7X