### PR TITLE
fix(picker): unmount native UIPickerView on close — fix EXC_BAD_ACCESS crash (JW-TIME-BK)

### DIFF
--- a/src/components/ui/SelectWheel.tsx
+++ b/src/components/ui/SelectWheel.tsx
@@ -170,21 +170,31 @@ const SelectWheel = <T,>({
                 </Text>
               </Pressable>
             </View>
-            <Picker
-              style={{ height: 216 }}
-              selectedValue={draftValue}
-              onValueChange={(next) => setDraftValue(String(next))}
-              itemStyle={{ color: theme.colors.text }}
-            >
-              {items.map((item) => (
-                <Picker.Item
-                  key={String(item.value)}
-                  label={item.label}
-                  value={String(item.value)}
-                  color={theme.colors.text}
-                />
-              ))}
-            </Picker>
+            {/* Only mount the native UIPickerView while the sheet is open.
+                During the dismiss animation the Modal stays mounted (see the
+                300ms unmount delay above), but the native UIPickerView tears
+                down its backing UITableView cells. A touch landing on the
+                picker in that window hit-tests freed cells and crashes with
+                EXC_BAD_ACCESS in -[UIPickerView hitTest:withEvent:]
+                (Sentry JW-TIME-BK). Unmounting on close removes it from the
+                hit-test hierarchy before teardown. */}
+            {open && (
+              <Picker
+                style={{ height: 216 }}
+                selectedValue={draftValue}
+                onValueChange={(next) => setDraftValue(String(next))}
+                itemStyle={{ color: theme.colors.text }}
+              >
+                {items.map((item) => (
+                  <Picker.Item
+                    key={String(item.value)}
+                    label={item.label}
+                    value={String(item.value)}
+                    color={theme.colors.text}
+                  />
+                ))}
+              </Picker>
+            )}
           </Sheet.Frame>
         </Sheet>
       </Modal>

--- a/src/features/progress/components/AddEarlierYearSheet.tsx
+++ b/src/features/progress/components/AddEarlierYearSheet.tsx
@@ -106,21 +106,31 @@ const AddEarlierYearSheet = ({
               </Text>
             </Pressable>
           </View>
-          <Picker
-            style={{ height: 216 }}
-            selectedValue={draftValue}
-            onValueChange={(next) => setDraftValue(Number(next))}
-            itemStyle={{ color: theme.colors.text }}
-          >
-            {availableEndYears.map((endYear) => (
-              <Picker.Item
-                key={endYear}
-                label={formatPickerLabel(endYear)}
-                value={endYear}
-                color={theme.colors.text}
-              />
-            ))}
-          </Picker>
+          {/* Only mount the native UIPickerView while the sheet is open.
+              During the dismiss animation the Modal stays mounted (see the
+              300ms unmount delay above), but the native UIPickerView tears
+              down its backing UITableView cells. A touch landing on the
+              picker in that window hit-tests freed cells and crashes with
+              EXC_BAD_ACCESS in -[UIPickerView hitTest:withEvent:]
+              (Sentry JW-TIME-BK). Unmounting on close removes it from the
+              hit-test hierarchy before teardown. */}
+          {open && (
+            <Picker
+              style={{ height: 216 }}
+              selectedValue={draftValue}
+              onValueChange={(next) => setDraftValue(Number(next))}
+              itemStyle={{ color: theme.colors.text }}
+            >
+              {availableEndYears.map((endYear) => (
+                <Picker.Item
+                  key={endYear}
+                  label={formatPickerLabel(endYear)}
+                  value={endYear}
+                  color={theme.colors.text}
+                />
+              ))}
+            </Picker>
+          )}
         </Sheet.Frame>
       </Sheet>
     </Modal>


### PR DESCRIPTION
## Sentry issue
[JW-TIME-BK — EXC_BAD_ACCESS: _endSuspendingUpdates](https://levi-wilkerson.sentry.io/issues/7472223970/)

Fatal native crash. ~270 affected users, highest-impact issue in the app. iOS only (new architecture / Fabric, `RCTViewComponentView`).

## Root cause
The crash stack is a use-after-free during touch hit-testing on a native `UIPickerView`:

```
objc_msgSend
-[UITableView _updateVisibleCellsForRanges:createIfNecessary:]
-[UITableView _visibleCellsUsingPresentationValues:]
-[UIPickerColumnView _allVisibleCells]
-[UIPickerView hitTest:withEvent:]
-[RCTViewComponentView betterHitTest:withEvent:]   <- [in-app]
```

The breadcrumbs show `touch` events (`onDismiss:`, `_handleMultiTapGesture:`) immediately before the crash.

Both `SelectWheel` and `AddEarlierYearSheet` wrap a tamagui `Sheet` (containing the `@react-native-picker/picker` `UIPickerView`) inside an RN `Modal`, and deliberately keep that `Modal` mounted for **300ms after close** so the sheet can play its slide-down animation:

```ts
const t = setTimeout(() => setMounted(false), 300)
```

During that 300ms window the native `UIPickerView` is tearing down its backing `UITableView` cells, but it is still in the view hierarchy and still hit-testable. If the user taps the picker area while it slides away, `-[UIPickerView hitTest:withEvent:]` walks `_allVisibleCells` and dereferences cells that are mid-deallocation → `EXC_BAD_ACCESS` (`KERN_INVALID_ADDRESS`).

This is a known class of iOS `UIPickerView` use-after-free during cell teardown, not a bug fixed in any released `@react-native-picker/picker` version, so the fix is in app code.

## Change
Gate the `<Picker>` on the `open` prop in both components so the native `UIPickerView` unmounts the instant the close begins (rather than lingering for the 300ms animation tail). This removes it from the hit-test hierarchy before its cells are freed. The `Sheet.Frame` stays mounted, so the slide-down animation is unchanged.

- `src/components/ui/SelectWheel.tsx`
- `src/features/progress/components/AddEarlierYearSheet.tsx`

## Impact
Eliminates the top fatal crash affecting ~270 users.

## How to verify
1. Open a SelectWheel-backed select (e.g. a form using `SelectWheel`) or the "Add earlier year" sheet on Progress.
2. Open the picker, then dismiss it and tap rapidly on the picker area as it slides down (the previous repro for the use-after-free).
3. App no longer crashes; the wheel unmounts immediately on close while the sheet still animates out.

Cannot run native iOS build here. Type/JSX-validated; change is a minimal `{open && (...)}` render guard around the unchanged picker element.