### PR TITLE
fix: stop reporting expected offline errors to Sentry (JW-TIME-5B)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -67,6 +67,7 @@ import DeepLinkListeners from '@/app/deep-links/DeepLinkListeners'
 import useIsSupporter from '@/hooks/useIsSupporter'
 import useCustomer from '@/hooks/useCustomer'
 import { useSupporter } from '@/features/supporter/stores/supporter'
+import { isOfflineError } from '@/lib/offlineError'
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -95,6 +96,12 @@ Sentry.init({
   enabled: !__DEV__,
   debug: __DEV__,
   attachScreenshot: true,
+  // Drop expected "device is offline" errors. RevenueCat / RN native modules
+  // reject with these when the user has no connection; they are not bugs and a
+  // single offline user retrying can generate hundreds of duplicate events
+  // (JW-TIME-5B, JW-TIME-BW). Returning null discards the event.
+  beforeSend: (event, hint) =>
+    isOfflineError(hint?.originalException) ? null : event,
 })
 
 Sentry.setTag('deviceId', Constants.sessionId)

--- a/src/lib/offlineError.ts
+++ b/src/lib/offlineError.ts
@@ -1,0 +1,30 @@
+/**
+ * Detects "device is offline" errors so they can be treated as an expected,
+ * handled condition instead of being reported to Sentry as crashes.
+ *
+ * RevenueCat / React Native native modules surface offline failures with the
+ * message "Error performing request because the internet connection appears to
+ * be offline." These are not bugs — the user simply has no connection — but
+ * because they bubble up as rejected promises they would otherwise flood Sentry
+ * (see JW-TIME-5B / JW-TIME-BW), with one user offline for a while generating
+ * hundreds of duplicate events.
+ */
+const OFFLINE_MESSAGE_PATTERNS = [
+  'internet connection appears to be offline',
+  'network connection was lost',
+  'the request timed out',
+]
+
+export const isOfflineError = (error: unknown): boolean => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : ((error as { message?: unknown })?.message ?? '')
+
+  if (typeof message !== 'string') return false
+
+  const lower = message.toLowerCase()
+  return OFFLINE_MESSAGE_PATTERNS.some((pattern) => lower.includes(pattern))
+}

--- a/src/providers/CustomerProvider.tsx
+++ b/src/providers/CustomerProvider.tsx
@@ -10,6 +10,7 @@ import { CustomerContext, CustomerCtx } from '@/contexts/customer'
 import Purchases, { CustomerInfo, LOG_LEVEL } from 'react-native-purchases'
 import * as Sentry from '@sentry/react-native'
 import { logger } from '@/lib/logger'
+import { isOfflineError } from '@/lib/offlineError'
 
 interface Props {}
 
@@ -28,6 +29,13 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       const customerInfo = await Purchases.getCustomerInfo()
       setCustomer(customerInfo)
     } catch (error) {
+      // Offline is an expected, unrecoverable condition here — log it but don't
+      // report to Sentry, otherwise an offline user revalidating in a loop
+      // floods the dashboard (JW-TIME-5B).
+      if (isOfflineError(error)) {
+        logger.warn('[CustomerProvider] getCustomerInfo offline', error)
+        return
+      }
       Sentry.captureException(error)
     }
   }, [])


### PR DESCRIPTION
## Sentry issue
[JW-TIME-5B](https://levi-wilkerson.sentry.io/issues/5321418889/) — `Error performing request because the internet connection appears to be offline.` (338 events, ~2 users)

Related: [JW-TIME-BW](https://levi-wilkerson.sentry.io/issues/7530821381/) — same error message from the same offline condition; this fix covers it too.

## Root cause
The stack trace points at RevenueCat's `Purchases.getCustomerInfo()` (`react-native-purchases`) rejecting with the native "internet connection appears to be offline" error. In `CustomerProvider.tsx`, the `revalidate` (`getCustomerInfo`) callback caught the error and **unconditionally** called `Sentry.captureException(error)`. When a user is offline and the paywall/donations screens retry revalidation (pull-to-refresh, post-purchase, focus), this loops and floods Sentry — hence the very high event:user ratio. The error is expected and unrecoverable (the user simply has no connection), not a bug.

## Change
- New helper `src/lib/offlineError.ts` — `isOfflineError()` matches the known offline/network-lost/timeout messages.
- `Sentry.init` now has a `beforeSend` that returns `null` for offline errors, discarding them regardless of source (covers both 5B and BW, including the RN native-module path).
- `CustomerProvider.getCustomerInfo` skips `captureException` for offline errors and logs a warning instead.

## Impact
Expected offline errors are no longer reported to Sentry, eliminating the retry-loop noise. Genuine RevenueCat/network failures are still captured.

## How to verify
- Enable airplane mode and open the Supporter/Paywall screen, then pull-to-refresh / revalidate — no Sentry event is generated (a `[CustomerProvider] getCustomerInfo offline` warning appears in dev logs instead).
- `pnpm run typecheck` and `pnpm run lint` pass.