### PR TITLE
fix(dates): never lazy-require an unbundled moment locale (JW-TIME-CH)

### DIFF
--- a/src/__tests__/dates.test.ts
+++ b/src/__tests__/dates.test.ts
@@ -134,6 +134,18 @@ describe('applyFormatRegion', () => {
     expect(moment.localeData().firstDayOfWeek()).toBe(3)
   })
 
+  it('never lazy-requires an unbundled locale for a region-suffixed language', () => {
+    // Regression for JW-TIME-CH: `moment.locale('ko-kr')` triggered moment's
+    // `require('./locale/ko-kr')`, an uncatchable fatal under Metro. The
+    // language must collapse to a loaded base ('ja' is imported above) or 'en'
+    // without throwing.
+    expect(() => applyFormatRegion({ language: 'ja-jp' })).not.toThrow()
+    expect(moment.locale()).toBe('ja')
+    expect(() => applyFormatRegion({ language: 'ko-kr' })).not.toThrow()
+    // 'ko' isn't imported in this test bundle, so it falls back to 'en'.
+    expect(moment.locale()).toBe('en')
+  })
+
   it('falls back to device calendar settings when Region is Auto', () => {
     device.uses24hourClock = true
     device.firstWeekday = 2 // expo MONDAY

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -93,6 +93,28 @@ const safeLocaleData = (key: string | undefined): moment.Locale | null => {
   }
 }
 
+/**
+ * Activates a moment locale without ever triggering moment's lazy
+ * `require('./locale/<key>')`. Under Metro that dynamic require throws an
+ * UNCATCHABLE fatal ("Requiring unknown module …/locale/ko-kr") for any locale
+ * file we didn't statically import in `src/lib/locales.ts` — so a device whose
+ * language resolves to a region-suffixed key (`ko-kr`, `ja-jp`, …) crashed the
+ * app at init. We only ever hand `moment.locale` a key it already loaded:
+ * the full tag, else its base language, else moment's built-in default.
+ *
+ * Returns the key moment ended up on, which is what every patch below targets.
+ */
+const safeMomentLocale = (key: string): string => {
+  const loaded = moment.locales()
+  if (loaded.includes(key)) {
+    moment.locale(key)
+  } else {
+    const language = key.split('-')[0]
+    moment.locale(loaded.includes(language) ? language : 'en')
+  }
+  return moment.locale()
+}
+
 /** First of D/M/Y appearing in a numeric pattern wins. */
 export const getDateOrderFromPattern = (pattern: string): DateOrder => {
   const d = pattern.indexOf('D')
@@ -264,10 +286,12 @@ export const getPristineLongDateFormat = (
 export const applyFormatRegion = (
   config: FormatRegionConfig
 ): ResolvedFormatSettings => {
-  // Activate the language; moment resolves missing keys (e.g. 'en-us') to a
-  // loaded parent ('en'). The resolved key is the one we patch.
-  moment.locale(config.language)
-  const activeKey = moment.locale()
+  // Activate the language. `safeMomentLocale` collapses region-suffixed keys
+  // we never bundled (`ko-kr`, `ja-jp`, …) down to their loaded base language
+  // ('ko', 'ja') or 'en', side-stepping moment's lazy `require('./locale/…')`
+  // — that dynamic require is an uncatchable fatal under Metro. The resolved
+  // key is the one we patch.
+  const activeKey = safeMomentLocale(config.language)
 
   // Reset the previous overlay so every localeData read below is pristine —
   // including the case where the chosen Region IS the active language key.


### PR DESCRIPTION
## Sentry
[JW-TIME-CH — `Error: Requiring unknown module "./locale/ko-kr".`](https://levi-wilkerson.sentry.io/issues/7555255084/) — FATAL (unhandled), ~7 users, release `1.40.0+150`.

## Root cause
`applyFormatRegion` (`src/lib/dates.ts`) activated the app's resolved language with `moment.locale(config.language)`. For a region-suffixed language key such as `ko-kr` (a Korean device) or `ja-jp`, moment doesn't have that locale registered, so it lazily calls `require('./locale/ko-kr')` (moment.js L2165). Under Metro that dynamic require is an **uncatchable** fatal — it routes through `guardedLoadModule` → `reportFatalError` — producing `Requiring unknown module "./locale/ko-kr"` and crashing the app at init.

Only base-language moment locales (`ko`, `ja`, …) are statically imported in `src/lib/locales.ts`; the region-suffixed file is never in the bundle. The existing `try/catch` in `safeLocaleData` couldn't help because the failing call was `moment.locale()` (not `localeData`), and the Metro require fatal isn't catchable anyway.

## Change
- Add `safeMomentLocale(key)`: activates a moment locale only if `moment.locales()` already contains it (full tag → base language → `'en'`), never triggering the lazy `require`. Returns the key moment landed on.
- Route `applyFormatRegion` through it instead of the raw `moment.locale(config.language)`.

This generalizes beyond Korean — every translated language whose region-suffixed moment locale isn't bundled (`ja-jp`, `ru-ru`, `vi-vn`, `uk-ua`, `sw-ke`, …) was equally exposed.

## Impact
Eliminates a fatal app-launch crash for affected-locale users (~7 reported, Korean confirmed).

## Verify
- `npx tsc --noEmit` — clean.
- `npx vitest run src/__tests__/dates.test.ts` — 18 passed, including the new regression test asserting `applyFormatRegion({ language: 'ko-kr' })` / `'ja-jp'` does not throw and collapses to a loaded base locale.