### PR TITLE
fix(storage): degrade transient AsyncStorage read failures gracefully (JW-TIME-C5)

### DIFF
--- a/src/__tests__/guardedAsyncStorage.test.ts
+++ b/src/__tests__/guardedAsyncStorage.test.ts
@@ -35,7 +35,7 @@ vi.mock('@sentry/react-native', () => ({
   addBreadcrumb: (...args: unknown[]) => addBreadcrumb(...args),
 }))
 
-import { GuardedAsyncStorage } from '@/stores/mmkv'
+import { GuardedAsyncStorage, isTransientStorageReadError } from '@/stores/mmkv'
 
 describe('GuardedAsyncStorage', () => {
   beforeEach(() => {
@@ -62,7 +62,7 @@ describe('GuardedAsyncStorage', () => {
     expect(addBreadcrumb).toHaveBeenCalledTimes(1)
   })
 
-  it('passes reads and removes straight through', async () => {
+  it('passes successful reads and removes straight through', async () => {
     getItem.mockResolvedValueOnce('value')
     removeItem.mockResolvedValueOnce(undefined)
 
@@ -71,5 +71,43 @@ describe('GuardedAsyncStorage', () => {
 
     expect(getItem).toHaveBeenCalledWith('k')
     expect(removeItem).toHaveBeenCalledWith('k')
+    expect(addBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('degrades transient read failures to a cache-miss (JW-TIME-C5)', async () => {
+    // iOS NSCocoaErrorDomain 257 (device locked) read rejection.
+    getItem.mockRejectedValueOnce(
+      new Error(
+        'Failed to read storage file.Error Domain=NSCocoaErrorDomain Code=257 "The file “manifest.json” couldn’t be opened because you don’t have permission to view it."'
+      )
+    )
+
+    await expect(GuardedAsyncStorage.getItem('k')).resolves.toBeNull()
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows non-transient read errors', async () => {
+    getItem.mockRejectedValueOnce(new Error('boom'))
+    await expect(GuardedAsyncStorage.getItem('k')).rejects.toThrow('boom')
+  })
+})
+
+describe('isTransientStorageReadError', () => {
+  it('matches iOS file-protection / locked-device read failures', () => {
+    expect(
+      isTransientStorageReadError(new Error('Failed to read storage file'))
+    ).toBe(true)
+    expect(
+      isTransientStorageReadError(new Error('NSCocoaErrorDomain Code=513'))
+    ).toBe(true)
+    expect(
+      isTransientStorageReadError(new Error('Operation not permitted'))
+    ).toBe(true)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isTransientStorageReadError(new Error('boom'))).toBe(false)
+    expect(isTransientStorageReadError(undefined)).toBe(false)
+    expect(isTransientStorageReadError(null)).toBe(false)
   })
 })

--- a/src/stores/mmkv.ts
+++ b/src/stores/mmkv.ts
@@ -8,8 +8,37 @@ export const mmkvStorage = new MMKV()
 export const hasMigratedFromAsyncStorage = () =>
   mmkvStorage.getBoolean('hasMigratedFromAsyncStorage')
 
+/**
+ * Returns true for transient native AsyncStorage read failures we can't act on
+ * — chiefly iOS file-protection errors (NSCocoaErrorDomain 257/513, POSIX
+ * EPERM "Operation not permitted") raised when the device is locked, plus
+ * generic "Failed to read storage file" IO errors. These are expected, recover
+ * on the next read, and should degrade to a cache-miss rather than crash
+ * hydration or spam Sentry. See JW-TIME-C5.
+ */
+export function isTransientStorageReadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return (
+    /Failed to read storage file/i.test(message) ||
+    /NSCocoaErrorDomain Code=(?:257|513)/.test(message) ||
+    /don.?t have permission to view it/i.test(message) ||
+    /Operation not permitted/i.test(message)
+  )
+}
+
 export async function migrateFromAsyncStorage(): Promise<void> {
-  const asyncStorageKeys = await AsyncStorage.getAllKeys()
+  let asyncStorageKeys: readonly string[]
+  try {
+    asyncStorageKeys = await AsyncStorage.getAllKeys()
+  } catch (error) {
+    // Transient locked-device / IO read failure: leave the migration flag
+    // unset so it retries on a later launch instead of crashing hydration.
+    // See JW-TIME-C5.
+    if (isTransientStorageReadError(error)) {
+      return
+    }
+    throw error
+  }
 
   for (const key of asyncStorageKeys) {
     try {
@@ -48,8 +77,10 @@ export async function migrateFromAsyncStorage(): Promise<void> {
  * surfacing to the user and Sentry. We drop a breadcrumb for visibility but do
  * not re-throw. The dropped write is recovered by the next persist cycle.
  *
- * Reads/removes are passed through unchanged (the read path is handled
- * separately). See Sentry JW-TIME-C8 (and the C5/C9 AsyncStorage cluster).
+ * Reads are guarded the same way: a transient locked-device read
+ * (NSCocoaErrorDomain Code=257, JW-TIME-C5) degrades to a cache-miss (`null`)
+ * so hydration doesn't crash; non-transient read errors still throw. Removes
+ * pass through unchanged. See Sentry JW-TIME-C8 / JW-TIME-C5.
  */
 export const GuardedAsyncStorage: StateStorage = {
   setItem: async (name, value) => {
@@ -65,7 +96,22 @@ export const GuardedAsyncStorage: StateStorage = {
       // Transient write failure (e.g. device locked). Skip rather than throw.
     }
   },
-  getItem: (name) => AsyncStorage.getItem(name),
+  getItem: async (name) => {
+    try {
+      return await AsyncStorage.getItem(name)
+    } catch (error) {
+      if (isTransientStorageReadError(error)) {
+        Sentry.addBreadcrumb({
+          category: 'storage',
+          level: 'warning',
+          message: 'AsyncStorage.getItem failed; treating as cache-miss',
+          data: { key: name, error: String(error) },
+        })
+        return null
+      }
+      throw error
+    }
+  },
   removeItem: (name) => AsyncStorage.removeItem(name),
 }
 


### PR DESCRIPTION
## JW-TIME-C5 — transient AsyncStorage read failures crash hydration

Rebased onto latest `main`. **Reworked to extend the merged `GuardedAsyncStorage` write-guard (#384) instead of introducing a parallel `SafeAsyncStorage` adapter** — no duplicated adapter, no duplicate test file, no per-store changes (stores already use `GuardedAsyncStorage` on main).

### Root cause
Before the MMKV migration completes, zustand persist hydrates from raw AsyncStorage. On iOS a locked-device read fails with `NSCocoaErrorDomain Code=257` (file protection); `migrateFromAsyncStorage()`'s `getAllKeys()` was unguarded, crashing hydration and surfacing to Sentry (26 events / ~4 users).

### Change (only `src/stores/mmkv.ts` + its test)
- `GuardedAsyncStorage.getItem` now degrades transient read failures to a cache-miss (`null`) and rethrows non-transient errors.
- `migrateFromAsyncStorage()` guards `getAllKeys()` so a transient failure leaves the migration flag unset to retry next launch.
- Adds `isTransientStorageReadError()` + 4 tests into the existing `guardedAsyncStorage.test.ts` (7/7 pass).

### Validation
`tsc --noEmit` clean · eslint clean · storage tests 7/7. No native build.

Completes the AsyncStorage cluster: writes #384 (merged, C8/C9), reads here (C5). Sentry: JW-TIME-C5.