### PR TITLE
fix(paywall): stop reporting expected offline errors to Sentry (JW-TIME-BW)

### DIFF
--- a/src/features/supporter/screens/PaywallScreen.tsx
+++ b/src/features/supporter/screens/PaywallScreen.tsx
@@ -36,6 +36,7 @@ import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import { RootStackNavigation, RootStackParamList } from '@/types/rootStack'
 import { logger } from '@/lib/logger'
 import { TranslationKey } from '@/lib/locales'
+import { isOfflineError } from '@/lib/offlineError'
 
 type Tier = 'supporter' | 'tip'
 type SupporterBilling = 'monthly' | 'annual'
@@ -537,7 +538,9 @@ const PaywallScreen = () => {
       })
       hasFetchedOfferings.current = false
       Alert.alert(i18n.t('errorFetchingOfferings'), i18n.t('tryAgainLater'))
-      Sentry.captureException(error)
+      // Offline is expected, not a bug — surface the Alert but don't page Sentry
+      // (JW-TIME-BW). Other failures still report.
+      if (!isOfflineError(error)) Sentry.captureException(error)
       throw error
     }
   }, [])
@@ -663,7 +666,9 @@ const PaywallScreen = () => {
       const cancelled = code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR
       if (!cancelled) {
         Alert.alert(i18n.t('error'), i18n.t('errorCheckingOut'))
-        Sentry.captureException(error)
+        // Offline mid-checkout is expected — the Alert already explains the
+        // network instability; don't page Sentry for it (JW-TIME-BW).
+        if (!isOfflineError(error)) Sentry.captureException(error)
       }
     }
   }, [navigation, revalidate, selectedPackage, tier])
@@ -676,7 +681,9 @@ const PaywallScreen = () => {
       }
       setCustomer(restored)
     } catch (error: unknown) {
-      Sentry.captureException(error)
+      // Offline during restore is expected — show the Alert, skip Sentry
+      // (JW-TIME-BW).
+      if (!isOfflineError(error)) Sentry.captureException(error)
       Alert.alert(i18n.t('error_restoring_account'))
     }
   }, [setCustomer])


### PR DESCRIPTION
## JW-TIME-BW — offline errors reported from the paywall flow

Rebased onto latest `main`. The shared offline infrastructure (`src/lib/offlineError.ts`, the `Sentry.init` `beforeSend` filter, and the `CustomerProvider` guard) **already landed via #382 (JW-TIME-5B)**, so this PR no longer re-adds any of it — it now contains **only the paywall-specific change**, building on the merged helper.

### Root cause
`PaywallScreen`'s `fetchOfferings`, `handlePurchase`, and `handleRestore` called `Sentry.captureException` for any RevenueCat failure. Offline is an expected, unrecoverable condition there — the in-app `Alert` already explains it — so an offline user retrying floods Sentry (13 events / ~10 users).

### Change
Guard those three call sites with the existing `isOfflineError()`; non-offline errors still report. One file: `src/features/supporter/screens/PaywallScreen.tsx` (+10/-3).

### Validation
`tsc --noEmit` clean · eslint clean. No native build.

Relation: complements #382 (5B, revalidate loop) — same helper, different call path. Sentry: JW-TIME-BW.