### PR TITLE
fix(storage): degrade AsyncStorage value writes gracefully (JW-TIME-C9)

### DIFF
--- a/src/__tests__/safeAsyncStorage.test.ts
+++ b/src/__tests__/safeAsyncStorage.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// `src/stores/mmkv` instantiates `new MMKV()` at import time, which needs a
+// React Native runtime. Stub it so we can exercise the SafeAsyncStorage
+// wrapper in isolation.
+vi.mock('react-native-mmkv', () => ({
+  MMKV: class {
+    getBoolean() {
+      return false
+    }
+    getString() {
+      return undefined
+    }
+    set() {}
+    delete() {}
+  },
+}))
+
+const setItem = vi.fn<(name: string, value: string) => Promise<void>>()
+const getItem = vi.fn<(name: string) => Promise<string | null>>()
+const removeItem = vi.fn<(name: string) => Promise<void>>()
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    setItem: (name: string, value: string) => setItem(name, value),
+    getItem: (name: string) => getItem(name),
+    removeItem: (name: string) => removeItem(name),
+    getAllKeys: () => Promise.resolve([]),
+  },
+}))
+
+import { SafeAsyncStorage } from '@/stores/mmkv'
+
+const code513 =
+  'Failed to write value.Error Domain=NSCocoaErrorDomain Code=513 ' +
+  '"You don’t have permission to save the file “abc” in the ' +
+  'folder “RCTAsyncLocalStorage_V1”." UserInfo={...}'
+
+describe('SafeAsyncStorage.setItem', () => {
+  beforeEach(() => {
+    setItem.mockReset()
+    getItem.mockReset()
+    removeItem.mockReset()
+  })
+
+  it('swallows the transient iOS Code=513 permission error', async () => {
+    setItem.mockRejectedValueOnce(new Error(code513))
+    await expect(SafeAsyncStorage.setItem('k', 'v')).resolves.toBeUndefined()
+    expect(setItem).toHaveBeenCalledWith('k', 'v')
+  })
+
+  it('swallows a bare POSIX "Operation not permitted" failure', async () => {
+    setItem.mockRejectedValueOnce(new Error('Operation not permitted'))
+    await expect(SafeAsyncStorage.setItem('k', 'v')).resolves.toBeUndefined()
+  })
+
+  it('rethrows unexpected write errors', async () => {
+    setItem.mockRejectedValueOnce(new Error('disk full: ENOSPC'))
+    await expect(SafeAsyncStorage.setItem('k', 'v')).rejects.toThrow('ENOSPC')
+  })
+
+  it('passes successful writes through', async () => {
+    setItem.mockResolvedValueOnce(undefined)
+    await expect(SafeAsyncStorage.setItem('k', 'v')).resolves.toBeUndefined()
+    expect(setItem).toHaveBeenCalledWith('k', 'v')
+  })
+
+  it('delegates reads and removals unchanged', async () => {
+    getItem.mockResolvedValueOnce('value')
+    removeItem.mockResolvedValueOnce(undefined)
+    await expect(SafeAsyncStorage.getItem('k')).resolves.toBe('value')
+    await SafeAsyncStorage.removeItem('k')
+    expect(removeItem).toHaveBeenCalledWith('k')
+  })
+})

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -95,6 +95,27 @@ Sentry.init({
   enabled: !__DEV__,
   debug: __DEV__,
   attachScreenshot: true,
+  beforeSend: (event) => {
+    /**
+     * Drop transient iOS AsyncStorage permission/IO failures
+     * (NSCocoaErrorDomain Code=513 "You don't have permission to save the file
+     * … in the folder RCTAsyncLocalStorage_V1"). These are unactionable — the
+     * OS denies the container write during backup/restore, while the
+     * data-protection class is locked, or under disk pressure — and the storage
+     * layer now degrades gracefully instead of throwing (JW-TIME-C5/C8/C9).
+     * Filtered here as defense-in-depth so any remaining AsyncStorage code path
+     * doesn't keep paging us.
+     */
+    const message = event.exception?.values?.[0]?.value ?? ''
+    if (
+      message.includes('RCTAsyncLocalStorage_V1') &&
+      (message.includes('Code=513') ||
+        message.includes("don't have permission to save"))
+    ) {
+      return null
+    }
+    return event
+  },
 })
 
 Sentry.setTag('deviceId', Constants.sessionId)

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -1,8 +1,11 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import { Category, CategoryTombstone } from '@/types/category'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 
 const initialState = {
   categories: [] as Category[],
@@ -77,7 +80,7 @@ export const useCategories = create(
     {
       name: 'categories',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
       version: 0,
     }

--- a/src/stores/contactsStore.ts
+++ b/src/stores/contactsStore.ts
@@ -1,10 +1,13 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import * as Crypto from 'expo-crypto'
 import { Contact } from '@/types/contact'
 import { CustomFieldDefinition } from '@/types/customField'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 
 const initialState = {
   contacts: [] as Contact[],
@@ -273,7 +276,7 @@ export const useContacts = create(
     {
       name: 'contacts',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
     }
   )

--- a/src/stores/conversationStore.ts
+++ b/src/stores/conversationStore.ts
@@ -1,9 +1,12 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import { Visit, VisitTombstone } from '@/types/visit'
 import * as Notifications from 'expo-notifications'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 
 const initialState = {
   // Persisted key kept as `conversations` for backward compatibility with
@@ -84,7 +87,7 @@ export const useConversations = create(
     {
       name: 'conversations',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
     }
   )

--- a/src/stores/mmkv.ts
+++ b/src/stores/mmkv.ts
@@ -32,6 +32,49 @@ export async function migrateFromAsyncStorage(): Promise<void> {
   mmkvStorage.set('hasMigratedFromAsyncStorage', true)
 }
 
+/**
+ * IOS occasionally denies writes to the AsyncStorage container with
+ * `NSCocoaErrorDomain Code=513` ("You don't have permission to save the file …
+ * in the folder RCTAsyncLocalStorage_V1"), backed by a POSIX `Operation not
+ * permitted`. This is transient — typically during backup/restore, while the
+ * data-protection class has the container locked, or under low-disk pressure —
+ * and not something the user can act on. Left unguarded, zustand-persist's
+ * value write rejects and surfaces as an unhandled rejection in Sentry
+ * (JW-TIME-C9). Swallow the expected permission/IO failure so persistence
+ * degrades gracefully (the value simply isn't persisted this cycle) instead of
+ * crashing the write. Only relevant for users still on AsyncStorage who haven't
+ * migrated to MMKV yet.
+ */
+const isExpectedStorageWriteError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    message.includes('Code=513') ||
+    message.includes("don't have permission to save") ||
+    message.includes('Operation not permitted') ||
+    message.includes('Failed to write value')
+  )
+}
+
+/**
+ * AsyncStorage wrapped so value writes that hit the transient iOS permission/IO
+ * failure above don't throw. Reads and removals pass through unchanged.
+ */
+export const SafeAsyncStorage: StateStorage = {
+  getItem: (name) => AsyncStorage.getItem(name),
+  setItem: async (name, value) => {
+    try {
+      await AsyncStorage.setItem(name, value)
+    } catch (error) {
+      if (isExpectedStorageWriteError(error)) {
+        /** Expected transient failure — skip this write, don't report. */
+        return
+      }
+      throw error
+    }
+  },
+  removeItem: (name) => AsyncStorage.removeItem(name),
+}
+
 /** MMKV storage interface for Zustand middleware */
 export const MmkvStorage: StateStorage = {
   setItem: (name, value) => {

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import { Publisher, PublisherHours } from '@/types/publisher'
@@ -8,7 +7,11 @@ import type { DateOrder, FormatRegion, TimeFormat } from '@/lib/dates'
 import Constants from 'expo-constants'
 import moment from 'moment'
 import * as Device from 'expo-device'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 import { Address } from '@/types/contact'
 import { MinuteDisplayFormat } from '@/types/timeEntry'
 import type { AssistantEvent } from '@/types/assistant'
@@ -1222,7 +1225,7 @@ export const usePreferences = create(
     {
       name: 'preferences',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
       version: 5,
       migrate: (persistedState, version) =>

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -1,7 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 import type { ProfileAvatar } from '@/types/avatar'
 
 /**
@@ -101,7 +104,7 @@ export const useProfile = create(
     {
       name: 'profile',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
       version: 0,
     }

--- a/src/stores/serviceReport.ts
+++ b/src/stores/serviceReport.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { persist, combine, createJSONStorage } from 'zustand/middleware'
 import {
@@ -22,7 +21,11 @@ import {
   normalizeRecurringPlan,
   PersistedServiceReportState,
 } from '@/lib/normalizeDate'
-import { hasMigratedFromAsyncStorage, MmkvStorage } from '@/stores/mmkv'
+import {
+  hasMigratedFromAsyncStorage,
+  MmkvStorage,
+  SafeAsyncStorage,
+} from '@/stores/mmkv'
 import * as Notifications from 'expo-notifications'
 
 const initialState = {
@@ -558,7 +561,7 @@ export const useServiceReport = create(
     {
       name: 'serviceReports',
       storage: createJSONStorage(() =>
-        hasMigratedFromAsyncStorage() ? MmkvStorage : AsyncStorage
+        hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage
       ),
       version: 4,
       migrate: (persistedState, version) =>


### PR DESCRIPTION
## Sentry
[JW-TIME-C9](https://levi-wilkerson.sentry.io/issues/7535461570/) — `Error: Failed to write value … NSCocoaErrorDomain Code=513 "You don't have permission to save the file '<hash>' in the folder 'RCTAsyncLocalStorage_V1'."` (17 events / 4 users; iOS 26.5; release 1.38.3+148)

## Root cause
For users who haven't migrated off AsyncStorage yet, the persisted zustand stores write via **raw AsyncStorage**. iOS intermittently denies the value write to the AsyncStorage container with `NSCocoaErrorDomain Code=513` (backed by POSIX `Operation not permitted` / EPERM). This is transient and unactionable — it happens during iCloud backup/restore, while the file's data-protection class has the container locked, or under low-disk pressure. The native module surfaces it as `Failed to write value`, and unguarded the `setItem` promise rejected and bubbled up as an **unhandled rejection** straight to Sentry.

## Change
- Add a `SafeAsyncStorage` adapter in `src/stores/mmkv.ts` whose `setItem` catches the expected permission/IO failure and skips the write (the value simply isn't persisted this cycle), while rethrowing any genuinely unexpected error. `getItem`/`removeItem` pass through unchanged.
- Point the 6 persisted stores (`preferences`, `profile`, `categories`, `contactsStore`, `conversationStore`, `serviceReport`) at `SafeAsyncStorage` for the not-yet-migrated branch (`hasMigratedFromAsyncStorage() ? MmkvStorage : SafeAsyncStorage`).
- Add a Sentry `beforeSend` filter for these specific RCTAsyncLocalStorage Code=513 errors as defense-in-depth.
- Add `src/__tests__/safeAsyncStorage.test.ts` covering swallow-513, swallow-EPERM, rethrow-unexpected, pass-through-success, and delegate read/remove.

## Impact
Transient iOS storage-permission failures no longer crash the persist write or page us via Sentry. Migrated (MMKV) users are unaffected. No behavior change on the happy path.

## How to verify
- `pnpm typecheck` — passes
- `pnpm lint` — clean
- `npx vitest run` — 763 tests across 55 files pass (incl. the new suite)
- The wrapper is logic-only; no native build required.

## Cluster
Part of the AsyncStorage error cluster handled by parallel PRs: **C5** (read), **C8** (write-manifest), **C9** (write-value, this PR). Changes are scoped to the value-write path to minimize conflicts.