### PR TITLE
fix(JW-TIME-CH): avoid unbundled moment region loads

### DIFF
--- a/src/__tests__/dates.test.ts
+++ b/src/__tests__/dates.test.ts
@@ -152,6 +152,16 @@ describe('applyFormatRegion', () => {
     expect(moment.locale()).toBe('en')
   })
 
+  it('never lazy-requires an unbundled region key when reading format data', () => {
+    // Regression for JW-TIME-CH: persisted/device regions like `es-es` are not
+    // separate moment bundles. Reading localeData for the full key can trigger
+    // Metro's fatal dynamic require; use an already-loaded base locale instead.
+    expect(() =>
+      applyFormatRegion({ language: 'en', region: 'es-es' })
+    ).not.toThrow()
+    expect(sample().format('L')).toBe('11/06/2026')
+  })
+
   it('falls back to device calendar settings when Region is Auto', () => {
     device.uses24hourClock = true
     device.firstWeekday = 2 // expo MONDAY

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -87,8 +87,15 @@ export interface ResolvedFormatSettings {
 
 const safeLocaleData = (key: string | undefined): moment.Locale | null => {
   if (!key) return null
+  const loaded = moment.locales()
+  const safeKey = loaded.includes(key)
+    ? key
+    : loaded.includes(key.split('-')[0])
+      ? key.split('-')[0]
+      : null
+  if (!safeKey) return null
   try {
-    return moment.localeData(key) ?? null
+    return moment.localeData(safeKey) ?? null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
Fixes a production crash from Sentry issue JW-TIME-CH: https://levi-wilkerson.sentry.io/issues/7555255084/

## Impact
Spanish/region-suffixed locale settings can hit Moment's dynamic locale loader under Metro and fatally crash with `Requiring unknown module "./locale/es-es"`.

## Fix
- Only read Moment locale data for locale keys already bundled in the app.
- Fall back from unbundled region-specific keys like `es-es` to an already-loaded base locale like `es`.
- Added a regression test for unbundled format-region keys.

## Verification
- `corepack pnpm exec vitest run src/__tests__/dates.test.ts` → 29 tests passed
- `corepack pnpm run typecheck` → passed
- `corepack pnpm run lint` → passed

*Created by Sprig AI*
