### PR TITLE
feat: share supporter status across devices via iCloud account id

### DIFF
--- a/docs/adr/0011-shared-account-id-over-icloud.md
+++ b/docs/adr/0011-shared-account-id-over-icloud.md
@@ -1,0 +1,90 @@
+# Shared account id over iCloud (multi-device Supporter, no sign-in)
+
+## Context
+
+A Supporter who installs WitnessWork on a second device (same Apple ID) does
+not get Supporter status there. Every device identifies to RevenueCat with its
+own Keychain install id (ADR 0007), so each device is a separate RevenueCat
+customer. Because these are _identified_ (not anonymous) app user ids,
+RevenueCat's restore flow applies the project's Restore Behavior — the default
+"Transfer to new App User ID" would let devices _steal_ the entitlement from
+each other, and the losing device's `SupporterSyncLapseGate` would shut off
+iCloud sync. We want simultaneous multi-device Supporter status, automatic
+lapse propagation, and — non-negotiable — no account, email, or phone number.
+
+## Decision
+
+Introduce an **account id**: the single identity all of one person's devices
+present to RevenueCat. It defaults to the device's install id and is agreed
+on through a small **account file** (`witness-work-account.json`) in the
+existing iCloud ubiquity container — same Apple ID ⇒ same container ⇒ same
+account. `AccountProvider` reconciles on launch, foreground, entitlement
+changes, and remote-change events, via a pure decision function
+(`decideAccountAction`):
+
+- **No file** → claim it with this device's id.
+- **File is ours, entitled flag agrees** → nothing.
+- **File is ours, flag disagrees** → another device purchased or lapsed:
+  re-fetch CustomerInfo (this is what makes purchase _and lapse_ propagate
+  near-real-time), then correct the file only if it was the stale side.
+- **Foreign claim, we're not entitled** → adopt: `Purchases.logIn(theirs)`,
+  persist device-locally (MMKV — never through the supporter-gated data
+  sync). The adopting device becomes the same RevenueCat customer and is a
+  Supporter seconds later, with no user action.
+- **Foreign claim, we're entitled** → claim over it if it's un-entitled (the
+  entitlement holder always wins — this migrates existing production
+  supporters automatically, whichever device claims first); leave it alone if
+  it also says entitled (two independent grants — both devices stay
+  Supporters under their own ids; no write ping-pong).
+
+The account file shares the `witness-work*.json` namespace deliberately: it's
+the only namespace the bridge writes and the only pattern its metadata query
+watches, so remote edits fire the existing `onRemoteChange` event. The sync
+engine skips it via `isAccountFilename` everywhere it parses payloads, and
+`overwriteRemoteWithLocal` re-claims it after `deleteAll`. iCloud conflict
+duplicates (`witness-work-account 2.json`) are absorbed newest-wins and
+canonicalized.
+
+When iCloud is unusable (signed out, or iCloud Drive off for the app), the
+fallback is the App Store receipt: Restore Purchases on the other device. The
+thank-you screen surfaces that hint **only** when sharing is unavailable.
+Keep the RevenueCat Restore Behavior at the default "Transfer to new App User
+ID" — "Transfer if there are no active subscriptions" would _block_ this
+legitimate fallback, since the user's other device holds an active
+subscription.
+
+## Considered options
+
+- **RevenueCat anonymous ids + restore aliasing** (RC's first-party
+  no-account path). Rejected in ADR 0007 already: anonymous ids regenerate on
+  reinstall and can't be metered; also still needs a manual restore tap.
+- **"Share between App User IDs" (legacy) restore behavior.** Aliases on
+  restore instead of transferring. Rejected: project-wide one-way door
+  (cannot be re-enabled once switched away), deprecated by RevenueCat, still
+  requires the user to find the restore button.
+- **User-visible "copy account id" + server-side share registry.** Rejected:
+  turns the app user id into a bearer credential users are encouraged to
+  share, and requires new backend state plus revocation plumbing that iCloud
+  scoping gives us for free.
+- **iCloud key-value store (`NSUbiquitousKeyValueStore`)** instead of the
+  container — survives iCloud Drive being disabled. Deferred: needs new
+  native surface + entitlement; the container path needs zero native changes.
+  Worth revisiting if the restore-hint cohort turns out to be large.
+
+## Consequences
+
+- Existing production supporters converge with no intervention: the entitled
+  device claims (or overwrites a non-entitled claim), the others adopt.
+- A device can client-side `logIn` as any known account id — a uuid is an
+  identifier, not a secret (same stance as ADR 0007). We never display it,
+  and the container file isn't document-scope public.
+- **Notes-Import still uses the per-device install id.** ww-api pins each
+  uuid to the ONE App Attest keyId that first claimed it (first-writer-wins,
+  ADR 0007), so an adopted account id would lock the second device out at
+  re-attest. Until ww-api verifies Supporter against an account id bound into
+  the signed assertion, a Supporter's _second_ device is metered as a free
+  user by the proxy. Follow-up lives in ww-api.
+- The dev "Reset purchases" tool clears the adopted id, else reconcile would
+  immediately re-adopt it.
+- Free Notes-Import credits remain per-device for adopted devices (see
+  above); once ww-api understands account ids they become per-person.

--- a/src/__tests__/accountFile.test.ts
+++ b/src/__tests__/accountFile.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACCOUNT_FILENAME,
+  AccountFile,
+  decideAccountAction,
+  isAccountFilename,
+  parseAccountFile,
+} from '@/lib/accountFile'
+
+const file = (overrides: Partial<AccountFile> = {}): AccountFile => ({
+  v: 1,
+  accountId: 'aaaa-1111',
+  entitled: false,
+  updatedAt: 1_700_000_000_000,
+  ...overrides,
+})
+
+describe('lib/accountFile', () => {
+  describe('isAccountFilename', () => {
+    it('matches the canonical filename', () => {
+      expect(isAccountFilename(ACCOUNT_FILENAME)).toBe(true)
+    })
+
+    it('matches iCloud conflict duplicates', () => {
+      expect(isAccountFilename('witness-work-account 2.json')).toBe(true)
+    })
+
+    it('does not match per-device sync files or legacy names', () => {
+      expect(isAccountFilename('witness-work-abc123.json')).toBe(false)
+      expect(isAccountFilename('witness-work.json')).toBe(false)
+      expect(isAccountFilename('witness-work 2.json')).toBe(false)
+    })
+  })
+
+  describe('parseAccountFile', () => {
+    it('round-trips a valid payload', () => {
+      const payload = file({ deviceName: 'iPhone 17 Pro' })
+      expect(parseAccountFile(JSON.stringify(payload))).toEqual(payload)
+    })
+
+    it.each([
+      ['not json', 'not-json{'],
+      ['null', 'null'],
+      ['wrong version', JSON.stringify({ ...file(), v: 2 })],
+      [
+        'missing accountId',
+        JSON.stringify({ ...file(), accountId: undefined }),
+      ],
+      ['empty accountId', JSON.stringify(file({ accountId: '' }))],
+      ['non-boolean entitled', JSON.stringify({ ...file(), entitled: 'yes' })],
+      ['missing updatedAt', JSON.stringify({ ...file(), updatedAt: 'now' })],
+    ])('rejects %s', (_label, json) => {
+      expect(parseAccountFile(json)).toBeNull()
+    })
+  })
+
+  describe('decideAccountAction', () => {
+    const mine = 'bbbb-2222'
+    const theirs = 'aaaa-1111'
+
+    it('claims when no file exists', () => {
+      expect(
+        decideAccountAction({ accountId: mine, entitled: false, file: null })
+      ).toEqual({ type: 'claim' })
+      expect(
+        decideAccountAction({ accountId: mine, entitled: true, file: null })
+      ).toEqual({ type: 'claim' })
+    })
+
+    it('does nothing when the file is ours and the flag agrees', () => {
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: true,
+          file: file({ accountId: mine, entitled: true }),
+        })
+      ).toEqual({ type: 'none' })
+    })
+
+    it('refreshes (not rewrites) when the file is ours but the flag disagrees — the file may be ahead of our cached CustomerInfo', () => {
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: false,
+          file: file({ accountId: mine, entitled: true }),
+        })
+      ).toEqual({ type: 'refresh' })
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: true,
+          file: file({ accountId: mine, entitled: false }),
+        })
+      ).toEqual({ type: 'refresh' })
+    })
+
+    it('adopts a foreign claim when not entitled — this is the second-device migration path', () => {
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: false,
+          file: file({ accountId: theirs, entitled: true }),
+        })
+      ).toEqual({ type: 'adopt', accountId: theirs })
+      // Even an un-entitled foreign claim is adopted, so a non-supporter
+      // household converges on one id before any purchase happens.
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: false,
+          file: file({ accountId: theirs, entitled: false }),
+        })
+      ).toEqual({ type: 'adopt', accountId: theirs })
+    })
+
+    it('claims over an un-entitled foreign claim when entitled — the entitlement holder always wins', () => {
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: true,
+          file: file({ accountId: theirs, entitled: false }),
+        })
+      ).toEqual({ type: 'claim' })
+    })
+
+    it('leaves an entitled foreign claim alone when also entitled — never adopt away from a live entitlement, never ping-pong writes', () => {
+      expect(
+        decideAccountAction({
+          accountId: mine,
+          entitled: true,
+          file: file({ accountId: theirs, entitled: true }),
+        })
+      ).toEqual({ type: 'none' })
+    })
+
+    it('converges the production migration scenario regardless of claim order', () => {
+      const supporterId = 'supporter-device'
+      const otherId = 'other-device'
+
+      // Order 1: supporter claims first; other device adopts.
+      expect(
+        decideAccountAction({
+          accountId: otherId,
+          entitled: false,
+          file: file({ accountId: supporterId, entitled: true }),
+        })
+      ).toEqual({ type: 'adopt', accountId: supporterId })
+
+      // Order 2: other device claims first; supporter overwrites…
+      expect(
+        decideAccountAction({
+          accountId: supporterId,
+          entitled: true,
+          file: file({ accountId: otherId, entitled: false }),
+        })
+      ).toEqual({ type: 'claim' })
+      // …then the other device sees the new claim and adopts (Order 1).
+    })
+  })
+})

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -38,6 +38,7 @@ import { TamaguiProvider } from 'tamagui'
 import tamaguiConfig from '../../tamagui.config'
 import ThemeProvider from '@/providers/ThemeProvider'
 import CustomerProvider from '@/providers/CustomerProvider'
+import AccountProvider from '@/providers/AccountProvider'
 import { ToastProvider, ToastViewport } from '@tamagui/toast'
 import {
   hasMigratedFromAsyncStorage,
@@ -576,51 +577,55 @@ export default function App() {
   try {
     return (
       <CustomerProvider>
-        <SupporterStoreSync />
-        <SupporterSyncDefault />
-        <SupporterSyncLapseGate />
-        <AppIconSync />
-        <ThemeProvider>
-          <SafeAreaProvider>
-            <GestureHandlerRootView style={{ flex: 1 }}>
-              <NavigationContainer
-                key={devRemountKey}
-                ref={navigationRef}
-                linking={linking}
-              >
-                {/*
-                 * ToastProvider must wrap TamaguiProvider — TamaguiProvider
-                 * mounts its own PortalProvider internally, and tamagui Sheets
-                 * (with `modal`) render their content via that portal host.
-                 * If ToastProvider sat inside TamaguiProvider, portaled sheet
-                 * content would render outside the toast context and
-                 * useToastController() would return an empty default, so
-                 * toast.show inside a Sheet (e.g. SelectedDateSheet on the
-                 * Progress screen) would throw "show is not a function".
-                 * ToastViewport stays inside TamaguiProvider since it's a
-                 * styled component that needs the Tamagui theme.
-                 */}
-                <ToastProvider>
-                  <TamaguiProvider
-                    defaultTheme={
-                      colorScheme ? colorScheme : systemColorScheme || undefined
-                    }
-                    config={tamaguiConfig}
-                  >
-                    <StatusBar />
-                    <ToastViewport />
-                    <ConfettiProvider>
-                      <AnimationViewProvider>
-                        <DeepLinkListeners />
-                        <RootStackComponent />
-                      </AnimationViewProvider>
-                    </ConfettiProvider>
-                  </TamaguiProvider>
-                </ToastProvider>
-              </NavigationContainer>
-            </GestureHandlerRootView>
-          </SafeAreaProvider>
-        </ThemeProvider>
+        <AccountProvider>
+          <SupporterStoreSync />
+          <SupporterSyncDefault />
+          <SupporterSyncLapseGate />
+          <AppIconSync />
+          <ThemeProvider>
+            <SafeAreaProvider>
+              <GestureHandlerRootView style={{ flex: 1 }}>
+                <NavigationContainer
+                  key={devRemountKey}
+                  ref={navigationRef}
+                  linking={linking}
+                >
+                  {/*
+                   * ToastProvider must wrap TamaguiProvider — TamaguiProvider
+                   * mounts its own PortalProvider internally, and tamagui Sheets
+                   * (with `modal`) render their content via that portal host.
+                   * If ToastProvider sat inside TamaguiProvider, portaled sheet
+                   * content would render outside the toast context and
+                   * useToastController() would return an empty default, so
+                   * toast.show inside a Sheet (e.g. SelectedDateSheet on the
+                   * Progress screen) would throw "show is not a function".
+                   * ToastViewport stays inside TamaguiProvider since it's a
+                   * styled component that needs the Tamagui theme.
+                   */}
+                  <ToastProvider>
+                    <TamaguiProvider
+                      defaultTheme={
+                        colorScheme
+                          ? colorScheme
+                          : systemColorScheme || undefined
+                      }
+                      config={tamaguiConfig}
+                    >
+                      <StatusBar />
+                      <ToastViewport />
+                      <ConfettiProvider>
+                        <AnimationViewProvider>
+                          <DeepLinkListeners />
+                          <RootStackComponent />
+                        </AnimationViewProvider>
+                      </ConfettiProvider>
+                    </TamaguiProvider>
+                  </ToastProvider>
+                </NavigationContainer>
+              </GestureHandlerRootView>
+            </SafeAreaProvider>
+          </ThemeProvider>
+        </AccountProvider>
       </CustomerProvider>
     )
   } catch (error) {

--- a/src/app/sync/iCloudSync.ts
+++ b/src/app/sync/iCloudSync.ts
@@ -11,6 +11,8 @@ import { useProfile } from '@/stores/profile'
 import { useSupporter } from '@/features/supporter/stores/supporter'
 import { buildPayload, parsePayload, SyncPayload } from '@/app/sync/payload'
 import { mergePayload } from '@/app/sync/merge'
+import { isAccountFilename } from '@/lib/accountFile'
+import { reclaimAccountFile } from '@/lib/account'
 import { logger } from '@/lib/logger'
 import * as Sentry from '@sentry/react-native'
 import * as Device from 'expo-device'
@@ -89,6 +91,10 @@ function filenameForDevice(deviceId: string): string {
  * duplicates `witness-work 2.json`, `witness-work 3.json`, etc. These can still
  * contain valuable data (one of ours had 23KB stranded in `witness-work
  * 4.json`), so the reader absorbs them and then deletes them.
+ *
+ * The account file (`witness-work-account.json`, ADR 0011) shares the sync
+ * namespace but is NOT a sync payload — every reader must skip it via
+ * `isAccountFilename` before parsing.
  */
 function isLegacyFilename(filename: string): boolean {
   return !filename.startsWith(`${SYNC_FILE_PREFIX}-`)
@@ -392,6 +398,9 @@ export async function overwriteRemoteWithLocal(): Promise<void> {
     logger.error(`${tag()} failed to clear remote before overwrite`, e)
     Sentry.captureException(e, { tags: { iCloudSync: 'overwrite' } })
   }
+  // deleteAll also removed the account file (same namespace); re-claim it so
+  // another device can't win the empty-file race before the next reconcile.
+  void reclaimAccountFile(useSupporter.getState().isSupporter)
   await push('overwrite-remote')
 }
 
@@ -418,6 +427,7 @@ export async function peekRemotePayload(): Promise<SyncPayload | null> {
     const files = await ICloudBridge.readAll()
     const payloads: SyncPayload[] = []
     for (const file of files) {
+      if (isAccountFilename(file.filename)) continue
       const parsed = parsePayload(file.json)
       if (parsed) payloads.push(parsed)
     }
@@ -818,6 +828,7 @@ async function pullAndMergeInner(reason: string): Promise<boolean> {
   const legacyFilenames: string[] = []
   for (const file of files) {
     if (file.filename === ownFilename) continue
+    if (isAccountFilename(file.filename)) continue
     const parsed = parsePayload(file.json)
     if (!parsed) {
       logger.warn(`${tag()} pullAndMerge: skipping invalid file`, {

--- a/src/contexts/account.ts
+++ b/src/contexts/account.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react'
+
+export type AccountCtx = {
+  /**
+   * The stable cross-device identity (ADR 0011): RevenueCat app user id and
+   * ww-proxy uuid. Null only if id resolution failed at boot.
+   */
+  accountId: string | null
+  /**
+   * Whether Supporter status can reach the user's other devices automatically
+   * (signed into iCloud + ubiquity container reachable). When false, the only
+   * path is Restore Purchases on the other device — surface the hint.
+   */
+  iCloudSharingAvailable: boolean
+}
+
+export const AccountContext = createContext<AccountCtx | null>(null)

--- a/src/features/notes-import/lib/notesImportClient.ts
+++ b/src/features/notes-import/lib/notesImportClient.ts
@@ -314,6 +314,12 @@ export const requestNotesImport = async ({
   context,
   refinement,
 }: RequestNotesImportArgs): Promise<NotesImportResponse> => {
+  // Install id, NOT the shared account id (ADR 0011): ww-api pins each uuid
+  // to the ONE App Attest keyId that first claimed it, so a second device
+  // sending an adopted account id would be locked out at re-attest. Until
+  // ww-api verifies Supporter against an account id, a device that adopted a
+  // foreign account id is metered here under its own install id — meaning
+  // its RevenueCat entitlement is not visible to the proxy's supporter check.
   const uuid = getOrCreateInstallId()
   const contentHash = await notesContentHash(notesText)
   try {
@@ -383,6 +389,7 @@ const kickoffNotesImport = async ({
   context,
   refinement,
 }: RequestNotesImportArgs): Promise<NotesImportKickoffResponse> => {
+  // Same identity rule as `requestNotesImport` — see the comment there.
   const uuid = getOrCreateInstallId()
   const contentHash = await notesContentHash(notesText)
   try {

--- a/src/features/supporter/screens/PaywallScreen.tsx
+++ b/src/features/supporter/screens/PaywallScreen.tsx
@@ -37,6 +37,7 @@ import { RootStackNavigation, RootStackParamList } from '@/types/rootStack'
 import { logger } from '@/lib/logger'
 import { TranslationKey } from '@/lib/locales'
 import { isOfflineError } from '@/lib/offlineError'
+import { clearAdoptedAccountId } from '@/lib/account'
 
 type Tier = 'supporter' | 'tip'
 type SupporterBilling = 'monthly' | 'annual'
@@ -620,6 +621,9 @@ const PaywallScreen = () => {
               const freshId = `dev-reset-${Date.now()}-${Math.random()
                 .toString(36)
                 .slice(2, 10)}`
+              // Also drop any iCloud-adopted account id, otherwise the next
+              // account reconcile would immediately log back in as it.
+              clearAdoptedAccountId()
               logger.log('[Paywall] dev reset — logging in as', { freshId })
               const { customerInfo } = await Purchases.logIn(freshId)
               setCustomer(customerInfo)

--- a/src/features/supporter/screens/PaywallThankYouScreen.tsx
+++ b/src/features/supporter/screens/PaywallThankYouScreen.tsx
@@ -7,9 +7,11 @@ import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import Wrapper from '@/components/ui/layout/Wrapper'
 import Text from '@/components/ui/MyText'
 import ActionButton from '@/components/ui/ActionButton'
+import Card from '@/components/ui/Card'
 import SupporterBenefits from '@/components/SupporterBenefits'
 import SupporterBadge from '@/components/SupporterBadge'
 import useIsSupporter from '@/hooks/useIsSupporter'
+import useAccount from '@/hooks/useAccount'
 import { RootStackNavigation, RootStackParamList } from '@/types/rootStack'
 import useAnimation from '@/hooks/useAnimation'
 import useFireworks from '@/hooks/useFireworks'
@@ -40,6 +42,7 @@ const PaywallThankYouScreen = () => {
   const navigation = useNavigation<RootStackNavigation>()
   const route = useRoute<RouteProp<RootStackParamList, 'Thank You'>>()
   const { isSupporter } = useIsSupporter()
+  const { iCloudSharingAvailable } = useAccount()
   // Prefer the just-purchased tier from nav params over the current supporter
   // state. A lifetime supporter who sends a one-time tip is still
   // `isSupporter === true`, but the screen tone should match what they
@@ -125,6 +128,32 @@ const PaywallThankYouScreen = () => {
         </View>
 
         {showSupporterCelebration && <SupporterBenefits />}
+
+        {/*
+         * With iCloud reachable, Supporter status reaches the user's other
+         * devices automatically (ADR 0011) — say nothing. Only when it can't
+         * (signed out, or iCloud Drive disabled for WitnessWork) does the
+         * user have something to do, so only then surface the manual path.
+         */}
+        {showSupporterCelebration && !iCloudSharingAvailable && (
+          <Card style={{ marginTop: 15 }}>
+            <Text
+              style={{
+                fontFamily: theme.fonts.semiBold,
+              }}
+            >
+              {i18n.t('thankYou_multiDeviceTitle')}
+            </Text>
+            <Text
+              style={{
+                fontSize: theme.fontSize('sm'),
+                color: theme.colors.textAlt,
+              }}
+            >
+              {i18n.t('thankYou_multiDeviceBody')}
+            </Text>
+          </Card>
+        )}
       </ScrollView>
       <View
         style={{

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react'
+import { AccountContext } from '@/contexts/account'
+
+const useAccount = () => {
+  const context = useContext(AccountContext)
+
+  if (!context) {
+    throw new Error('useAccount must be used within an AccountProvider')
+  }
+
+  return context
+}
+
+export default useAccount

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,0 +1,135 @@
+import { Platform } from 'react-native'
+import { MMKV } from 'react-native-mmkv'
+import * as Device from 'expo-device'
+import * as ICloudBridge from '../../modules/icloud-bridge'
+import { getOrCreateInstallId } from '@/lib/installId'
+import {
+  ACCOUNT_FILENAME,
+  AccountFile,
+  isAccountFilename,
+  parseAccountFile,
+} from '@/lib/accountFile'
+import { logger } from '@/lib/logger'
+
+/**
+ * Effectful half of the account model (ADR 0011) — id persistence and the
+ * account file's iCloud IO. The pure payload/decision layer lives in
+ * `@/lib/accountFile`; the reconcile loop that drives both lives in
+ * `AccountProvider`.
+ *
+ * The account id defaults to this device's install id (ADR 0007) and is
+ * replaced only when the device adopts another device's claim from iCloud. The
+ * adopted id is persisted device-locally (MMKV, not preferences — it must never
+ * round-trip through the supporter-gated data sync it unlocks).
+ */
+
+let _store: MMKV | null = null
+const store = (): MMKV => (_store ??= new MMKV({ id: 'account' }))
+const ADOPTED_KEY = 'adoptedAccountId'
+
+let _cached: string | null = null
+
+/**
+ * The identity this app presents everywhere: RevenueCat app user id and the
+ * ww-proxy (Notes-Import) uuid. Resolves to the adopted shared account id when
+ * this device has joined another device's claim, else the install id.
+ */
+export const getOrCreateAccountId = (): string => {
+  if (_cached) return _cached
+  const adopted = store().getString(ADOPTED_KEY)
+  if (adopted) {
+    _cached = adopted
+    return adopted
+  }
+  const installId = getOrCreateInstallId()
+  _cached = installId
+  return installId
+}
+
+/** Persist a foreign claim as this device's account id. */
+export const adoptAccountId = (accountId: string): void => {
+  store().set(ADOPTED_KEY, accountId)
+  _cached = accountId
+}
+
+/**
+ * Dev-tools only (paywall "Reset purchases"): drop the adopted id so the device
+ * falls back to its install id on next resolution.
+ */
+export const clearAdoptedAccountId = (): void => {
+  store().delete(ADOPTED_KEY)
+  _cached = null
+}
+
+/**
+ * Reads the account file from the ubiquity container. Also absorbs iCloud
+ * conflict duplicates (`witness-work-account 2.json`): the newest payload wins,
+ * losers are deleted, and a winner that lived under a duplicate name is
+ * rewritten to the canonical filename — all best-effort.
+ *
+ * Rejects when iCloud is unavailable (signed out, or iCloud Drive disabled for
+ * the app) — callers treat that as "sharing unavailable", not an error.
+ */
+export const readAccountFile = async (): Promise<AccountFile | null> => {
+  const files = await ICloudBridge.readAll()
+  const candidates = files
+    .filter((f) => isAccountFilename(f.filename))
+    .map((f) => ({ filename: f.filename, payload: parseAccountFile(f.json) }))
+    .filter(
+      (c): c is { filename: string; payload: AccountFile } => c.payload !== null
+    )
+  if (candidates.length === 0) return null
+
+  let best = candidates[0]
+  for (const c of candidates) {
+    if (c.payload.updatedAt > best.payload.updatedAt) best = c
+  }
+
+  for (const c of candidates) {
+    if (c.filename === best.filename || c.filename === ACCOUNT_FILENAME) {
+      continue
+    }
+    void ICloudBridge.deleteFile(c.filename).catch(() => {})
+  }
+  if (best.filename !== ACCOUNT_FILENAME) {
+    try {
+      await ICloudBridge.write(ACCOUNT_FILENAME, JSON.stringify(best.payload))
+      await ICloudBridge.deleteFile(best.filename)
+    } catch (e) {
+      logger.warn('[Account] failed to canonicalize account file', e)
+    }
+  }
+  return best.payload
+}
+
+/** Claims (or re-claims) the account file for `accountId`. */
+export const writeAccountFile = async (
+  accountId: string,
+  entitled: boolean
+): Promise<void> => {
+  const payload: AccountFile = {
+    v: 1,
+    accountId,
+    entitled,
+    updatedAt: Date.now(),
+    deviceName: Device.modelName ?? undefined,
+  }
+  await ICloudBridge.write(ACCOUNT_FILENAME, JSON.stringify(payload))
+}
+
+/**
+ * Best-effort re-claim after a flow that wipes the whole sync namespace
+ * (`overwriteRemoteWithLocal`). Not load-bearing — every device keeps its
+ * adopted id locally, so the next reconcile pass re-claims the same id even
+ * without this — but re-writing immediately closes the window where a fresh
+ * device could claim first.
+ */
+export const reclaimAccountFile = async (entitled: boolean): Promise<void> => {
+  if (Platform.OS !== 'ios') return
+  if (!ICloudBridge.isAvailable()) return
+  try {
+    await writeAccountFile(getOrCreateAccountId(), entitled)
+  } catch (e) {
+    logger.warn('[Account] reclaim after remote wipe failed', e)
+  }
+}

--- a/src/lib/accountFile.ts
+++ b/src/lib/accountFile.ts
@@ -1,0 +1,116 @@
+/**
+ * Account model (ADR 0011): one person = one Apple ID = one **account id**
+ * shared by all of their devices, with no sign-in. Each device starts life with
+ * its own Keychain install id (ADR 0007); the account file in the iCloud
+ * ubiquity container is how devices agree on a single id, so RevenueCat sees
+ * them as one customer and Supporter status (and its lapse) propagates
+ * automatically.
+ *
+ * This module is the pure data layer — file payload shape, parser, and the
+ * reconcile decision — kept free of native imports so it stays unit-testable.
+ * The effectful layer (Keychain/MMKV/iCloud IO) lives in `@/lib/account`.
+ */
+
+/**
+ * The account file lives inside the sync-file namespace (`witness-work*.json`)
+ * on purpose: it's the only namespace the iCloud bridge will write, and the
+ * only pattern its metadata query watches — so remote edits to this file fire
+ * the same `onRemoteChange` event the app already listens to. The data-sync
+ * engine must skip it when merging (see `isAccountFilename` checks in
+ * `iCloudSync.ts`).
+ */
+export const ACCOUNT_FILENAME = 'witness-work-account.json'
+
+/**
+ * Matches the canonical account file AND any iCloud conflict duplicates
+ * (`witness-work-account 2.json`, …) so both the sync engine's skip and the
+ * account reader's duplicate cleanup cover the whole family.
+ */
+export const isAccountFilename = (filename: string): boolean =>
+  filename.startsWith('witness-work-account')
+
+export type AccountFile = {
+  v: 1
+  /**
+   * The account id every device on this Apple ID should identify with — used as
+   * both the RevenueCat app user id and the ww-proxy identity.
+   */
+  accountId: string
+  /**
+   * Whether the writing device held an active Supporter entitlement under
+   * `accountId` at write time. Consulted for two things: breaking the
+   * (vanishingly rare) entitled-vs-entitled tie without a network call, and
+   * detecting cross-device entitlement changes (see `refresh` action). A stale
+   * value self-corrects — see `decideAccountAction`.
+   */
+  entitled: boolean
+  updatedAt: number
+  deviceName?: string
+}
+
+export const parseAccountFile = (json: string): AccountFile | null => {
+  try {
+    const parsed: unknown = JSON.parse(json)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const candidate = parsed as Record<string, unknown>
+    if (candidate.v !== 1) return null
+    if (typeof candidate.accountId !== 'string' || !candidate.accountId) {
+      return null
+    }
+    if (typeof candidate.entitled !== 'boolean') return null
+    if (typeof candidate.updatedAt !== 'number') return null
+    return candidate as AccountFile
+  } catch {
+    return null
+  }
+}
+
+export type AccountAction =
+  /** Write (or overwrite) the account file with this device's id + flag. */
+  | { type: 'claim' }
+  /** Log in to RevenueCat as the file's id and persist it as ours. */
+  | { type: 'adopt'; accountId: string }
+  /**
+   * The file is ours but its entitled flag disagrees with our cached
+   * CustomerInfo — another device changed entitlement state (purchase or
+   * lapse). Re-fetch CustomerInfo, then correct the flag if the file was the
+   * stale side.
+   */
+  | { type: 'refresh' }
+  | { type: 'none' }
+
+/**
+ * The whole cross-device agreement in one pure function. Invariants that make
+ * it converge without ping-ponging writes:
+ *
+ * - An **entitled** device never gives up its id (adopting could silently drop a
+ *   live entitlement). It claims over an un-entitled file and leaves an
+ *   entitled foreign claim alone — if two devices are genuinely entitled under
+ *   different ids (two independent grants, e.g. a Lifetime Supporter promo plus
+ *   a subscription), both stay Supporters under their own ids and the file
+ *   settles on whichever claimed first.
+ * - An **un-entitled** device always adopts a foreign claim, entitled or not.
+ *   Adopting a lapsed id is fine: the flag mismatch surfaces as `refresh` on
+ *   the next pass and the file gets corrected, at which point a genuinely
+ *   entitled device (if any) claims over it.
+ * - Flag disagreement on our own id triggers `refresh`, not a blind rewrite — the
+ *   file may be _ahead_ of our cached CustomerInfo (the other device just
+ *   purchased or lapsed), so we re-fetch before deciding who was stale.
+ */
+export const decideAccountAction = (input: {
+  /** This device's current account id (adopted shared id ?? install id). */
+  accountId: string
+  /** Active Supporter entitlement under `accountId`, per cached CustomerInfo. */
+  entitled: boolean
+  file: AccountFile | null
+}): AccountAction => {
+  const { accountId, entitled, file } = input
+  if (!file) return { type: 'claim' }
+  if (file.accountId === accountId) {
+    if (file.entitled !== entitled) return { type: 'refresh' }
+    return { type: 'none' }
+  }
+  if (!entitled) return { type: 'adopt', accountId: file.accountId }
+  if (!file.entitled) return { type: 'claim' }
+  return { type: 'none' }
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -932,6 +932,8 @@
   "supporterBenefitsTitle": "What's included",
   "thankYou_benefitsIntro": "Here's what your support unlocks as a little thank-you.",
   "thankYou_oneTimeDescription": "Your one-time donation is deeply appreciated and helps keep WitnessWork running.",
+  "thankYou_multiDeviceTitle": "Using WitnessWork on another device?",
+  "thankYou_multiDeviceBody": "iCloud isn't available on this device, so your Supporter status can't reach your other devices automatically. On each other device, open Donate and tap Restore Purchases to activate it there.",
   "monthlySupporterExplainer": "Monthly supporters receive the Supporter badge and every perk below. One-time donations are warmly appreciated too, but don't grant ongoing Supporter status.",
   "grantsSupporterStatus": "Grants Supporter status",
   "oneTimeNoSupporterNote": "One-time — a warmly welcomed gift, but doesn't grant ongoing Supporter status.",

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -1,0 +1,229 @@
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { AppState, Platform } from 'react-native'
+import Purchases from 'react-native-purchases'
+import * as Sentry from '@sentry/react-native'
+import _ from 'lodash'
+import * as ICloudBridge from '../../modules/icloud-bridge'
+import { AccountContext, AccountCtx } from '@/contexts/account'
+import useCustomer from '@/hooks/useCustomer'
+import { supporterSinceDate } from '@/lib/supporterSince'
+import { decideAccountAction } from '@/lib/accountFile'
+import {
+  adoptAccountId,
+  getOrCreateAccountId,
+  readAccountFile,
+  writeAccountFile,
+} from '@/lib/account'
+import { logger } from '@/lib/logger'
+import { isOfflineError } from '@/lib/offlineError'
+
+interface Props {}
+
+/**
+ * Keeps this device's account id in agreement with the user's other devices
+ * (ADR 0011). Runs the reconcile pass — read the iCloud account file, then
+ * claim / adopt / refresh per `decideAccountAction` — whenever entitlement
+ * state, iCloud availability, or the remote file changes, and on foreground.
+ *
+ * This is what makes Supporter multi-device work with no sign-in: the device
+ * that holds the entitlement claims its id; every other device on the same
+ * Apple ID adopts it via `Purchases.logIn`, becoming the same RevenueCat
+ * customer, so the entitlement (and later its lapse) applies everywhere.
+ *
+ * Must live inside `CustomerProvider`: adoption replaces the active RevenueCat
+ * user, and the fresh CustomerInfo has to land in customer state immediately.
+ */
+const AccountProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
+  const { customer, ready, setCustomer } = useCustomer()
+  const [accountId, setAccountId] = useState<string | null>(() => {
+    try {
+      return getOrCreateAccountId()
+    } catch (error) {
+      logger.error('[Account] account id resolution failed', error)
+      Sentry.captureException(error)
+      return null
+    }
+  })
+  // Optimistic until the first reconcile probes the container: `isAvailable`
+  // only proves iCloud sign-in; iCloud Drive being disabled for the app
+  // surfaces as a readAll rejection and flips this false.
+  const [iCloudSharingAvailable, setICloudSharingAvailable] = useState(
+    () => Platform.OS === 'ios' && ICloudBridge.isAvailable()
+  )
+
+  // Latest customer state for event-driven reconciles without resubscribing.
+  const customerRef = useRef(customer)
+  const readyRef = useRef(ready)
+  useEffect(() => {
+    customerRef.current = customer
+    readyRef.current = ready
+  }, [customer, ready])
+
+  const inFlightRef = useRef(false)
+  const queuedReasonRef = useRef<string | null>(null)
+
+  const reconcile = useCallback(
+    async (reason: string): Promise<void> => {
+      if (Platform.OS !== 'ios') return
+      if (!readyRef.current) return
+      // Entitlement truth isn't known until the initial CustomerInfo lands;
+      // acting on the transient "no customer" state could mis-claim.
+      if (customerRef.current === null) return
+      if (accountId === null) return
+
+      if (inFlightRef.current) {
+        // Coalesce: one queued follow-up is enough — it re-reads everything.
+        queuedReasonRef.current ??= reason
+        return
+      }
+      inFlightRef.current = true
+      try {
+        if (!ICloudBridge.isAvailable()) {
+          setICloudSharingAvailable(false)
+          return
+        }
+
+        // Don't trust an early empty directory listing — claiming before the
+        // container materializes would shadow another device's real claim.
+        const scanned = await ICloudBridge.waitForInitialScan(5000)
+
+        let file
+        try {
+          file = await readAccountFile()
+        } catch (error) {
+          // Signed in but container unreachable (iCloud Drive off for the
+          // app) — expected for a minority of users, not an error.
+          logger.warn('[Account] account file unreadable', {
+            reason,
+            error: (error as Error).message,
+          })
+          setICloudSharingAvailable(false)
+          return
+        }
+        setICloudSharingAvailable(true)
+
+        const mine = getOrCreateAccountId()
+        const entitled = supporterSinceDate(customerRef.current) !== null
+        const action = decideAccountAction({ accountId: mine, entitled, file })
+
+        switch (action.type) {
+          case 'claim': {
+            if (!file && !scanned) {
+              // Empty listing before the initial scan finished is not proof
+              // of absence. Skip; the next trigger retries.
+              logger.log('[Account] claim deferred (initial scan incomplete)')
+              return
+            }
+            await writeAccountFile(mine, entitled)
+            logger.log('[Account] claimed account file', { reason, entitled })
+            Sentry.addBreadcrumb({
+              category: 'account',
+              message: `claim (${reason})`,
+              level: 'info',
+            })
+            return
+          }
+          case 'adopt': {
+            const { customerInfo } = await Purchases.logIn(action.accountId)
+            adoptAccountId(action.accountId)
+            setAccountId(action.accountId)
+            setCustomer(customerInfo)
+            logger.log('[Account] adopted shared account id', { reason })
+            Sentry.addBreadcrumb({
+              category: 'account',
+              message: `adopt (${reason})`,
+              level: 'info',
+            })
+            return
+          }
+          case 'refresh': {
+            // The file disagrees with our cached entitlement for our own id —
+            // another device purchased or lapsed. Fetch the truth, then
+            // correct the file only if IT was the stale side.
+            Purchases.invalidateCustomerInfoCache()
+            const info = await Purchases.getCustomerInfo()
+            setCustomer(info)
+            const entitledNow = supporterSinceDate(info) !== null
+            if (file && entitledNow !== file.entitled) {
+              await writeAccountFile(mine, entitledNow)
+            }
+            logger.log('[Account] refreshed entitlement from remote flag', {
+              reason,
+              entitledNow,
+            })
+            return
+          }
+          case 'none':
+            return
+        }
+      } catch (error) {
+        // Offline logIn/getCustomerInfo is expected and retried on the next
+        // trigger; anything else is worth a report.
+        if (isOfflineError(error)) {
+          logger.warn('[Account] reconcile offline', { reason })
+        } else {
+          logger.error('[Account] reconcile failed', error)
+          Sentry.captureException(error)
+        }
+      } finally {
+        inFlightRef.current = false
+        const queued = queuedReasonRef.current
+        queuedReasonRef.current = null
+        if (queued) void reconcile(queued)
+      }
+    },
+    [accountId, setCustomer]
+  )
+
+  // Boot + entitlement transitions (purchase, restore, lapse, adoption).
+  const customerKnown = customer !== null
+  const entitled = supporterSinceDate(customer) !== null
+  useEffect(() => {
+    void reconcile('customer-state')
+  }, [reconcile, ready, customerKnown, entitled])
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return
+
+    // Same echo-burst problem the sync engine has: iCloud re-stamps mtimes as
+    // a write replicates, producing trailing notifications ~500ms apart.
+    const debouncedReconcile = _.debounce(
+      (reason: string) => void reconcile(reason),
+      500,
+      { leading: true, trailing: true }
+    )
+    const remoteSub = ICloudBridge.addRemoteChangeListener(() => {
+      debouncedReconcile('remote-change')
+    })
+    const availabilitySub = ICloudBridge.addAvailabilityChangeListener((e) => {
+      setICloudSharingAvailable(e.available)
+      if (e.available) void reconcile('icloud-available')
+    })
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void reconcile('foreground')
+    })
+
+    return () => {
+      remoteSub.remove()
+      availabilitySub.remove()
+      appStateSub.remove()
+      debouncedReconcile.cancel()
+    }
+  }, [reconcile])
+
+  const context: AccountCtx = { accountId, iCloudSharingAvailable }
+
+  return (
+    <AccountContext.Provider value={context}>
+      {children}
+    </AccountContext.Provider>
+  )
+}
+
+export default AccountProvider

--- a/src/providers/CustomerProvider.tsx
+++ b/src/providers/CustomerProvider.tsx
@@ -11,7 +11,7 @@ import Purchases, { CustomerInfo, LOG_LEVEL } from 'react-native-purchases'
 import * as Sentry from '@sentry/react-native'
 import { logger } from '@/lib/logger'
 import { isOfflineError } from '@/lib/offlineError'
-import { getOrCreateInstallId } from '@/lib/installId'
+import { getOrCreateAccountId } from '@/lib/account'
 
 interface Props {}
 
@@ -63,15 +63,16 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       return
     }
 
-    // Resolve the stable Keychain install id. We identify the RevenueCat user as
-    // this id so entitlements correlate with the identity the Notes-Import proxy
-    // meters (ADR 0007). If it can't resolve, stay anonymous rather than passing
-    // an empty id.
-    let installId: string | undefined
+    // Resolve the stable account id: the iCloud-adopted shared id when this
+    // device has joined another device's claim (ADR 0011), else the Keychain
+    // install id (ADR 0007). Identifying RevenueCat as this id keeps
+    // entitlements correlated with the identity the Notes-Import proxy meters.
+    // If it can't resolve, stay anonymous rather than passing an empty id.
+    let accountId: string | undefined
     try {
-      installId = getOrCreateInstallId()
+      accountId = getOrCreateAccountId()
     } catch (error) {
-      logger.error('[CustomerProvider] install id resolution failed', error)
+      logger.error('[CustomerProvider] account id resolution failed', error)
       Sentry.captureException(error)
     }
 
@@ -79,11 +80,11 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       if (__DEV__) Purchases.setLogLevel(LOG_LEVEL.DEBUG)
       // Configure anonymously, THEN identify via logIn — NOT configure({
       // appUserID }) directly. Calling logIn from an anonymous user aliases that
-      // user's purchases onto installId, so an existing supporter (whose
+      // user's purchases onto accountId, so an existing supporter (whose
       // entitlement is filed under their old anonymous id) keeps Supporter status
       // automatically, with no manual "Restore Purchases". A direct
       // configure({ appUserID }) would leave those anonymous purchases stranded.
-      // logIn is idempotent (a no-op once installId is already the active user),
+      // logIn is idempotent (a no-op once accountId is already the active user),
       // so running it on every launch is safe.
       Purchases.configure({ apiKey })
       logger.log('[CustomerProvider] Purchases.configure completed')
@@ -104,13 +105,13 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       setCustomer(info)
     }
 
-    // Identify (migrating any anonymous purchases onto installId) and seed
+    // Identify (migrating any anonymous purchases onto accountId) and seed
     // customer state. logIn resolves with the post-migration CustomerInfo;
-    // getCustomerInfo is the anonymous path when there's no install id.
+    // getCustomerInfo is the anonymous path when there's no account id.
     // Best-effort: on failure (usually offline) fall back to cached CustomerInfo
     // so existing entitlements still render, and logIn retries next launch.
-    const identify = installId
-      ? Purchases.logIn(installId).then(({ customerInfo, created }) => {
+    const identify = accountId
+      ? Purchases.logIn(accountId).then(({ customerInfo, created }) => {
           logger.log('[CustomerProvider] Purchases.logIn completed', {
             created,
           })
@@ -119,14 +120,14 @@ const CustomerProvider: React.FC<PropsWithChildren<Props>> = ({ children }) => {
       : Purchases.getCustomerInfo().then(seedCustomer)
 
     identify.catch((error) => {
-      if (installId && !isOfflineError(error)) {
+      if (accountId && !isOfflineError(error)) {
         logger.warn('[CustomerProvider] Purchases.logIn failed', error)
         Sentry.captureException(error)
       } else {
         logger.warn('[CustomerProvider] initial customer info failed', error)
       }
       // Last-resort fall back to whatever CustomerInfo the SDK has cached.
-      if (installId) {
+      if (accountId) {
         Purchases.getCustomerInfo()
           .then(seedCustomer)
           .catch(() => {})


### PR DESCRIPTION
Adds an **account id** (ADR 0011): all devices on one Apple ID converge on a single RevenueCat identity via a small claim file (`witness-work-account.json`) in the existing ubiquity container. New `AccountProvider` + `useAccount()` reconcile claim/adopt/refresh (pure logic in `@/lib/accountFile`, unit-tested); `CustomerProvider` and the paywall dev-reset now go through `getOrCreateAccountId()`. The sync engine skips the account file when merging and re-claims it after `deleteAll`. The thank-you screen shows a "Restore Purchases on your other device" hint only when iCloud can't carry the id.

Existing production supporters migrate automatically — entitled device claims, others adopt on next launch. Notes-Import deliberately stays on the install id (ww-api's uuid→keyId pin; see ADR consequences) — follow-up in ww-api. **Ops note:** keep RevenueCat Restore Behavior on the default "Transfer to new App User ID". Needs a two-physical-device pass before release: purchase on A → B unlocks; lapse propagation; iCloud-signed-out hint.