### PR TITLE
feat(notes-import): don't charge for an Empty Import, surfaced via Scribe

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,8 +85,12 @@ An Import whose source is arbitrary free text the User pastes or shares (handwri
 _Avoid_: "AI import" in user copy where it implies the in-app Assistant (the Assistant is rule-based and unrelated); "paste import" (Notes Import also covers shared/picked text).
 
 **Import Credit**:
-The unit metering free Notes Import usage. A non-**Supporter** gets a fixed number of Import Credits (5); a Supporter is unlimited. One Credit is consumed per distinct source text (identified by content hash) the first time it is parsed — follow-up refinements of that same text and re-imports of an already-seen text cost nothing.
+The unit metering free Notes Import usage. A non-**Supporter** gets a fixed number of Import Credits (5); a Supporter is unlimited. One Credit is consumed per distinct source text (identified by content hash) the first time it is parsed — follow-up refinements of that same text and re-imports of an already-seen text cost nothing. An **Empty Import** also costs nothing, up to an anti-abuse limit past which repeated Empty Imports begin consuming Credits again.
 _Avoid_: "token" (tokens are the LLM's internal cost unit, separate), "import count" (Credit carries the per-distinct-source and Supporter-exemption semantics).
+
+**Empty Import**:
+A **Notes Import** that completes successfully but produces zero records — no contacts, visits, time entries, and no detected Publisher (the `isEmptyPreview` predicate; produced Categories and Warnings alone do not count as records). The import ran correctly; the pasted text simply held nothing to bring in. An Empty Import does not consume an **Import Credit**, so a User's Credits are never spent on a paste that yields nothing — subject to an anti-abuse limit, beyond which further Empty Imports within the window consume a Credit again (a **Supporter**, being unmetered, is exempt from the limit entirely). Distinct from an **Import Warning**, which flags a produced record; an Empty Import produces no records at all.
+_Avoid_: "failed import" (an Empty Import succeeded — nothing errored), "import attempt", "non-valid import" (nothing invalid happened).
 
 **Import Warning**:
 A model-emitted flag on a Notes Import about an assumption, ambiguity, or low-confidence guess. Carries a severity (info / warning / error) and optionally targets one specific produced record so the preview can highlight that contact, visit, or time entry. An error-severity Warning marks data unsafe to commit and is deselected by default in the preview.

--- a/docs/adr/0012-notes-import-empty-imports-uncharged.md
+++ b/docs/adr/0012-notes-import-empty-imports-uncharged.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+---
+
+# Empty Notes Imports do not consume an Import Credit
+
+## Context
+
+An **Import Credit** was charged unconditionally after any successful Notes Import model run; the server never inspected the result. A paste that produced zero records — an **Empty Import** — still decremented the User's meter, even though nothing was brought in. This wastes a non-Supporter's fixed lifetime credits (5) on nothing and reads as punitive. The wrinkle: an Empty Import still costs a real (paid) third-party LLM call, so simply making empties free creates an unbounded free-LLM abuse vector — a User's credit count never drops on empties, so the existing pre-flight `limit_reached` wall never engages.
+
+## Decision
+
+The credit charge moves to _after_ emptiness is known. Emptiness is the existing `isEmptyPreview` predicate (zero contacts, visits, time entries, and no detected Publisher — produced Categories and Warnings do not count as records), extracted to a module shared by client and `ww-api` so the two cannot drift. In `computeCommit`/`recordUsage` (so both the streaming and legacy paths inherit it):
+
+- **Non-empty** → charge, as before.
+- **Empty, within a rolling 7-day / 5-attempt window** → do not charge; record the empty run's timestamp in the index Durable Object.
+- **Empty, past the window** → charge the Credit again (soft degrade) and set `emptyCharged: true` on the `done` payload; the client renders a fixed, translatable Scribe AI turn telling the User this empty one counted.
+- **Supporter** → unmetered and untracked, exempt entirely.
+
+Pre-flight `checkCredit` is unchanged: a free User at 0 credits is still blocked before the model runs. The grace only protects the _remaining_ credits of a still-credited User from being spent on empties. Every empty run counts toward the window; Empty Imports are not written to `hash_record`, so each is a fresh count and a later re-paste of fixed text flows normally.
+
+## Considered options
+
+- **Hard block past the window** — rejected: locks out a legitimate User with genuinely messy notes and introduces a brand-new user-facing error state. Soft degrade reverts only to today's behavior, which needs no new error.
+- **Calendar-aligned (weekly/monthly) window** — rejected: a reset boundary is gameable, and the window is invisible so calendar alignment buys no user comprehension.
+- **Cap Supporters too** — rejected: soft degrade is toothless for the unmetered (nothing to charge), and a hard cap would punish paying, App-Attest-verified accounts for a threat that doesn't yet exist. Add a runaway ceiling if logs ever show one.
+- **Dedup empties by content hash** — rejected: each distinct paste is a real LLM call; the unit being rate-limited is empty _calls_, not empty _texts_.
+
+## Consequences
+
+- The only credit error a User can ever see remains the existing `limit_reached`; the anti-abuse limit is otherwise invisible.
+- A determined free abuser gets at most (5 window empties + remaining lifetime credits) free empty calls before the wall; a Supporter is uncapped by design (accepted, monitorable).
+- The billing notice must be canned client copy from `en-US.json`, never LLM-generated `assistantMessage`, so it stays deterministic and localizable.

--- a/src/features/notes-import/hooks/useNotesImportManager.ts
+++ b/src/features/notes-import/hooks/useNotesImportManager.ts
@@ -279,7 +279,7 @@ export const useNotesImportManager = create<NotesImportManagerState>(
           // has values to show on the next conversation — and after a restart.
           set({ credits: res.credits })
           persistCredits(res.credits)
-          putParsedResult(hash, res.result, Date.now())
+          putParsedResult(hash, res.result, Date.now(), res.emptyCharged)
           patchRuntime(hash, { phase: 'done', running: false, error: null })
         })
         .catch((e) => {

--- a/src/features/notes-import/lib/notesImportClient.ts
+++ b/src/features/notes-import/lib/notesImportClient.ts
@@ -51,17 +51,28 @@ export interface NotesImportResponse {
   result: NotesImportResult
   contentHash: string
   refinement: boolean
+  /**
+   * The run produced no records (an Empty Import) AND still charged an Import
+   * Credit because the anti-abuse empty window was exhausted (ADR 0012). Drives
+   * the composer's fixed Scribe AI "this one counted" notice. A within-window
+   * free empty — or any non-empty run — is false.
+   */
+  emptyCharged: boolean
   credits: NotesImportCredits
 }
 
-interface NotesImportWireResponse extends Omit<NotesImportResponse, 'credits'> {
+interface NotesImportWireResponse
+  extends Omit<NotesImportResponse, 'credits' | 'emptyCharged'> {
   credits: NotesImportCreditsWire
+  /** Absent on older proxy payloads → normalized to false. */
+  emptyCharged?: boolean
 }
 
 const normalizeNotesImportResponse = (
   response: NotesImportWireResponse
 ): NotesImportResponse => ({
   ...response,
+  emptyCharged: response.emptyCharged ?? false,
   credits: normalizeNotesImportCredits(response.credits, {
     unlimitedImports: DEV_IMPORTS_UNLIMITED,
   }),

--- a/src/features/notes-import/lib/notesImportLedger.test.ts
+++ b/src/features/notes-import/lib/notesImportLedger.test.ts
@@ -115,6 +115,7 @@ describe('ledgerEntryTitle', () => {
     notesText: 'Visited Maria',
     provisionalTitle: 'Visited Maria',
     result: result(),
+    emptyCharged: false,
     history: [],
     summary: 'Three return visits',
     commit: null,
@@ -212,6 +213,16 @@ describe('migrateLedgerEntry', () => {
     expect(e?.state).toBe('ready')
     expect(e?.activeRun).toBeNull()
   })
+
+  it('defaults emptyCharged to false on legacy rows and preserves true', () => {
+    expect(
+      migrateLedgerEntry({ hash: 'a', result: result() }, 1)?.emptyCharged
+    ).toBe(false)
+    expect(
+      migrateLedgerEntry({ hash: 'b', result: result(), emptyCharged: true }, 1)
+        ?.emptyCharged
+    ).toBe(true)
+  })
 })
 
 describe('isPrunableLedgerEntry', () => {
@@ -235,6 +246,7 @@ describe('ledger lifecycle transitions (pure)', () => {
     notesText: 'Visited Maria\nmore',
     provisionalTitle: 'Visited Maria',
     result: result({ summary: 'Maria visit' }),
+    emptyCharged: false,
     history: [{ role: 'assistant', text: 'reply 0', at: 5 }],
     summary: 'Maria visit',
     commit: null,
@@ -348,6 +360,20 @@ describe('ledger lifecycle transitions (pure)', () => {
       expect(e.history).toEqual([])
       expect(e.createdAt).toBe(70)
       expect(e.parsedAt).toBe(70)
+    })
+
+    it('carries emptyCharged from the parse, defaulting false (ADR 0012)', () => {
+      expect(putParsedTransition(null, result(), 70).emptyCharged).toBe(false)
+      expect(putParsedTransition(null, result(), 70, true).emptyCharged).toBe(
+        true
+      )
+    })
+
+    it('clears a prior emptyCharged notice on a subsequent (refinement) re-parse', () => {
+      const charged = readyEntry({ emptyCharged: true })
+      // A refinement never charges an empty, so it re-parses with the default.
+      const e = putParsedTransition(charged, result({ summary: 'S' }), 80)
+      expect(e.emptyCharged).toBe(false)
     })
   })
 
@@ -634,6 +660,7 @@ describe('readyImportCount', () => {
     notesText: 'n',
     provisionalTitle: 'n',
     result: result(),
+    emptyCharged: false,
     history: [],
     summary: '',
     commit: null,
@@ -670,6 +697,7 @@ describe('viewed / unread dot', () => {
     notesText: 'n',
     provisionalTitle: 'n',
     result: result(),
+    emptyCharged: false,
     history: [],
     summary: '',
     commit: null,

--- a/src/features/notes-import/lib/notesImportLedger.ts
+++ b/src/features/notes-import/lib/notesImportLedger.ts
@@ -70,6 +70,13 @@ export interface NotesImportLedgerEntry {
   /** The model's full structured output; null while Working with no result yet. */
   result: NotesImportResult | null
   /**
+   * The latest parse produced no records AND was charged an Import Credit
+   * anyway because the anti-abuse empty window was exhausted (ADR 0012). Drives
+   * the composer's fixed Scribe AI "this one counted" notice. False for a free
+   * within-window empty and for any non-empty parse; reset on every re-parse.
+   */
+  emptyCharged: boolean
+  /**
    * Finalized conversation messages preceding the live result, oldest first:
    * every superseded AI reply and every refinement instruction. Excludes the
    * original notes (round-0 user message — renders from `notesText`) and the
@@ -242,6 +249,7 @@ export const migrateLedgerEntry = (
     notesText,
     provisionalTitle,
     result,
+    emptyCharged: o.emptyCharged === true,
     history: sanitizeHistory(o.history),
     summary,
     commit,
@@ -289,6 +297,9 @@ export const beginWorkingTransition = (
     provisionalTitle:
       provisionalTitleFromNotes(notesText) || existing?.provisionalTitle || '',
     result: existing?.result ?? null,
+    // Preserve the prior notice while the cached result is still on screen; a
+    // successful re-parse overwrites it (refinements never charge an empty).
+    emptyCharged: existing?.emptyCharged ?? false,
     // A refinement folds into the same row; its conversation thread carries over.
     history: existing?.history ?? [],
     summary: existing?.summary ?? '',
@@ -313,13 +324,17 @@ export const beginWorkingTransition = (
 export const putParsedTransition = (
   existing: NotesImportLedgerEntry | null,
   result: NotesImportResult,
-  parsedAtMs: number
+  parsedAtMs: number,
+  emptyCharged = false
 ): NotesImportLedgerEntry => ({
   hash: existing?.hash ?? '',
   state: 'ready',
   notesText: existing?.notesText ?? '',
   provisionalTitle: existing?.provisionalTitle ?? '',
   result,
+  // Per-parse: a refinement re-parse (never an empty charge) rebuilds this entry
+  // and so clears any prior notice.
+  emptyCharged,
   // The prior turns persist; only the live `result` advances to the new reply.
   history: existing?.history ?? [],
   summary: result.summary ?? existing?.summary ?? '',
@@ -557,10 +572,14 @@ export const replaceLedgerHistory = (
 export const putParsedResult = (
   hash: string,
   result: NotesImportResult,
-  parsedAtMs: number
+  parsedAtMs: number,
+  emptyCharged = false
 ): void => {
   const existing = getLedgerEntry(hash)
-  writeEntry({ ...putParsedTransition(existing, result, parsedAtMs), hash })
+  writeEntry({
+    ...putParsedTransition(existing, result, parsedAtMs, emptyCharged),
+    hash,
+  })
 }
 
 /** Records the accepted commit (for undo) and moves the row to **Done**. */

--- a/src/features/notes-import/screens/NotesImportComposerScreen.tsx
+++ b/src/features/notes-import/screens/NotesImportComposerScreen.tsx
@@ -765,6 +765,11 @@ const NotesImportComposerScreen = ({ renderSupporterCta }: Props) => {
         <View style={{ gap: 14 }}>
           {aiHeader(i18n.t('notesImport_emptyTitle'))}
           {!!result.assistantMessage && aiMessage(result.assistantMessage)}
+          {/* Past the free-empty window, an empty parse still costs a credit
+              (ADR 0012). Scribe AI owns the message so the user is told in-voice,
+              not via a system banner. Within-window empties leave this false. */}
+          {activeEntry.emptyCharged &&
+            aiMessage(i18n.t('notesImport_emptyChargedNotice'))}
         </View>
       ) : (
         <View style={{ gap: 14 }}>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1090,6 +1090,7 @@
   "notesImport_takeHome": "Take me home",
   "notesImport_emptyTitle": "Nothing to import",
   "notesImport_emptyBody": "Scribe AI couldn't find any Contacts, Visits, or Time Entries in that text. Try adding more detail and importing again.",
+  "notesImport_emptyChargedNotice": "Heads up — I've come up empty a few times recently, so this attempt counted toward your imports. The next paste with real details won't be wasted.",
   "notesImport_errorTitle": "Import didn't finish",
   "notesImport_error": "Something went wrong. Please try again.",
   "notesImport_modelError": "Scribe AI couldn't make sense of those notes. Try rephrasing or adding detail, then import again.",


### PR DESCRIPTION
Wires the app to the ww-api Empty Import change ([ww-api#4](https://github.com/leviFrosty/ww-api/pull/4)): an import that finds nothing no longer spends an Import Credit, so the meter simply doesn't tick. Past the anti-abuse window the server soft-degrades and returns `emptyCharged`, which the composer turns into a fixed, in-voice **Scribe AI** notice that this attempt counted — not a system banner.

`emptyCharged` rides the run response (normalized to false for older payloads) and is persisted per-parse on the ledger entry (reset on every re-parse, since a refinement never charges an empty). Adds the `Empty Import` glossary entry + ADR 0012. 953 tests / lint / typecheck green.