### PR TITLE
feat(service-reports): reenable Hourglass and NW Publisher report submission

### DIFF
--- a/src/__tests__/submitLinks.test.ts
+++ b/src/__tests__/submitLinks.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildHourglassLink,
+  buildNwPublisherLink,
+} from '@/features/service-reports/lib/submitLinks'
+
+/**
+ * Formats validated against the examples provided by each app's support team:
+ *
+ * NW Publisher:
+ * https://nwpublisher.com/report/sharedInMinistry=true:hours=50:bibleStudies=8:credit=17:remarks=bethel+work
+ *
+ * Hourglass:
+ * https://app.hourglass-app.com/report/submit?month=<m>&year=<y>&minutes=<min>[&studies=][&remarks=]
+ */
+describe('buildNwPublisherLink', () => {
+  it('matches the exact example format from NW Publisher support', () => {
+    expect(
+      buildNwPublisherLink({
+        sharedInMinistry: true,
+        hours: 50,
+        bibleStudies: 8,
+        credit: 17,
+        remarks: 'bethel work',
+      })
+    ).toBe(
+      'https://nwpublisher.com/report/sharedInMinistry=true:hours=50:bibleStudies=8:credit=17:remarks=bethel+work'
+    )
+  })
+
+  it('always includes the sharedInMinistry bool, even when false', () => {
+    expect(buildNwPublisherLink({ sharedInMinistry: false })).toBe(
+      'https://nwpublisher.com/report/sharedInMinistry=false'
+    )
+  })
+
+  it('omits variables that are zero, null, or undefined instead of sending 0', () => {
+    expect(
+      buildNwPublisherLink({
+        sharedInMinistry: true,
+        hours: 0,
+        credit: 0,
+        bibleStudies: null,
+        remarks: '',
+      })
+    ).toBe('https://nwpublisher.com/report/sharedInMinistry=true')
+  })
+
+  it('supports decimal hours', () => {
+    expect(buildNwPublisherLink({ sharedInMinistry: true, hours: 12.5 })).toBe(
+      'https://nwpublisher.com/report/sharedInMinistry=true:hours=12.5'
+    )
+  })
+
+  it('replaces spaces in remarks with + and strips colons', () => {
+    const link = buildNwPublisherLink({
+      sharedInMinistry: true,
+      remarks: 'LDC: 5 hours',
+    })
+    expect(link).toBe(
+      'https://nwpublisher.com/report/sharedInMinistry=true:remarks=LDC-+5+hours'
+    )
+    // Colons only ever appear as the pair delimiter.
+    const afterPath = link.replace('https://nwpublisher.com/report/', '')
+    for (const pair of afterPath.split(':')) {
+      expect(pair).toMatch(/^[a-zA-Z]+=[^:]*$/)
+    }
+  })
+
+  it('converts multi-line remarks into +-separated words', () => {
+    expect(
+      buildNwPublisherLink({
+        sharedInMinistry: true,
+        remarks: 'line one\nline two',
+      })
+    ).toBe(
+      'https://nwpublisher.com/report/sharedInMinistry=true:remarks=line+one+line+two'
+    )
+  })
+})
+
+describe('buildHourglassLink', () => {
+  it('includes the required month, year, and minutes query params', () => {
+    expect(buildHourglassLink({ month: 8, year: 2026, minutes: 3000 })).toBe(
+      'https://app.hourglass-app.com/report/submit?month=8&year=2026&minutes=3000'
+    )
+  })
+
+  it('appends optional studies and url-encoded remarks', () => {
+    expect(
+      buildHourglassLink({
+        month: 1,
+        year: 2026,
+        minutes: 1,
+        studies: 4,
+        remarks: 'Credit overage in the amount of 5 hours.',
+      })
+    ).toBe(
+      'https://app.hourglass-app.com/report/submit?month=1&year=2026&minutes=1&studies=4&remarks=Credit%20overage%20in%20the%20amount%20of%205%20hours.'
+    )
+  })
+
+  it('omits studies when zero or null', () => {
+    expect(
+      buildHourglassLink({ month: 12, year: 2025, minutes: 600, studies: 0 })
+    ).toBe(
+      'https://app.hourglass-app.com/report/submit?month=12&year=2025&minutes=600'
+    )
+    expect(
+      buildHourglassLink({ month: 12, year: 2025, minutes: 600, studies: null })
+    ).toBe(
+      'https://app.hourglass-app.com/report/submit?month=12&year=2025&minutes=600'
+    )
+  })
+
+  it('sends minutes=0 for a checkbox publisher who did not share', () => {
+    expect(buildHourglassLink({ month: 3, year: 2026, minutes: 0 })).toBe(
+      'https://app.hourglass-app.com/report/submit?month=3&year=2026&minutes=0'
+    )
+  })
+})

--- a/src/features/service-reports/hooks/useMonthReportData.ts
+++ b/src/features/service-reports/hooks/useMonthReportData.ts
@@ -26,6 +26,11 @@ export type MonthReportData = {
   /** Whole-hour credit time over the cap (rendered into notes). */
   creditOverageHours: number
   studies: number | null
+  /**
+   * Minutes value for Hourglass submission: total adjusted minutes for hourly
+   * publishers, or 1/0 (shared / didn't share) for checkbox-mode publishers.
+   */
+  hourglassMinutes: number
   /** Notes string with the raw credit breakdown and credit overage. */
   notes: string
   /** Last-month-only flag (kept for nwpublisher submission gating). */
@@ -103,6 +108,8 @@ const useMonthReportData = (
   const hours = Math.floor(adjusted.standard / 60)
   const credit = Math.max(0, Math.floor(adjusted.value / 60) - hours)
   const creditOverageHours = Math.floor(adjusted.creditOverage / 60)
+  const hourglassMinutes =
+    entryMode === 'checkbox' ? (sharedInMinistry ? 1 : 0) : adjusted.value
 
   const notes = useMemo(() => {
     if (month === undefined || year === undefined) return ''
@@ -177,6 +184,7 @@ const useMonthReportData = (
     credit,
     creditOverageHours,
     studies,
+    hourglassMinutes,
     notes,
     isLastMonth,
     showHours: entryMode !== 'checkbox',

--- a/src/features/service-reports/lib/submitLinks.ts
+++ b/src/features/service-reports/lib/submitLinks.ts
@@ -1,0 +1,82 @@
+import links from '@/constants/links'
+
+export type NwPublisherReport = {
+  sharedInMinistry: boolean
+  /** Whole or decimal hours of standard time (excludes credit). */
+  hours?: number
+  /** Whole-hour credit time. */
+  credit?: number
+  bibleStudies?: number | null
+  remarks?: string
+}
+
+/**
+ * Builds the NW Publisher universal link, per NW Publisher support:
+ *
+ * https://nwpublisher.com/report/sharedInMinistry=true:hours=50:bibleStudies=8:credit=17:remarks=bethel+work
+ *
+ * - Colon-delimited `key=value` pairs; keys are case-sensitive.
+ * - Every variable is optional; omit rather than sending 0.
+ * - `remarks` uses `+` for spaces and cannot contain colons (the delimiter).
+ * - NW Publisher only accepts the previous month's report — callers gate on that;
+ *   the link itself carries no month.
+ */
+export const buildNwPublisherLink = (report: NwPublisherReport): string => {
+  const parts = [`sharedInMinistry=${report.sharedInMinistry}`]
+
+  if (report.hours) {
+    parts.push(`hours=${report.hours}`)
+  }
+  if (report.bibleStudies) {
+    parts.push(`bibleStudies=${report.bibleStudies}`)
+  }
+  if (report.credit) {
+    parts.push(`credit=${report.credit}`)
+  }
+  if (report.remarks) {
+    const remarks = encodeURI(report.remarks.replaceAll(':', '-'))
+      .replaceAll('%20', '+')
+      .replaceAll('%0A', '+')
+    parts.push(`remarks=${remarks}`)
+  }
+
+  return `${links.nwpublisherSubmitReport}${parts.join(':')}`
+}
+
+export type HourglassReport = {
+  /** 1-indexed month (January = 1), unlike JS/moment's 0-indexed months. */
+  month: number
+  year: number
+  /**
+   * Total ministry minutes. Checkbox-mode publishers send 1 to indicate sharing
+   * in the ministry.
+   */
+  minutes: number
+  studies?: number | null
+  remarks?: string
+}
+
+/**
+ * Builds the Hourglass universal link, per Hourglass support:
+ *
+ * https://app.hourglass-app.com/report/submit?month=8&year=2026&minutes=3000
+ *
+ * - `month`, `year`, `minutes` are required query params.
+ * - `studies` and `remarks` are optional; omitted when empty.
+ */
+export const buildHourglassLink = (report: HourglassReport): string => {
+  const params = [
+    `month=${report.month}`,
+    `year=${report.year}`,
+    `minutes=${report.minutes}`,
+  ]
+
+  if (report.studies) {
+    params.push(`studies=${report.studies}`)
+  }
+  if (report.remarks) {
+    params.push(`remarks=${encodeURIComponent(report.remarks)}`)
+  }
+
+  return `${links.hourglassBase}${params.join('&')}`
+}

--- a/src/features/service-reports/screens/ServiceReportViewScreen.tsx
+++ b/src/features/service-reports/screens/ServiceReportViewScreen.tsx
@@ -24,6 +24,11 @@ import useTheme from '@/contexts/theme'
 import i18n, { _i18n } from '@/lib/locales'
 import Haptics from '@/lib/haptics'
 import useMonthReportData from '@/features/service-reports/hooks/useMonthReportData'
+import {
+  buildHourglassLink,
+  buildNwPublisherLink,
+} from '@/features/service-reports/lib/submitLinks'
+import { openURL } from '@/lib/links'
 import { useHandwritingFonts } from '@/features/service-reports/lib/handwritingFont'
 import useUser from '@/hooks/useUser'
 import { RootStackParamList } from '@/types/rootStack'
@@ -142,21 +147,68 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
         image: 'square.and.arrow.up',
         imageColor: theme.colors.text,
       },
+      {
+        id: 'hourglass',
+        title: i18n.t('hourglass'),
+        image: 'hourglass',
+        imageColor: theme.colors.text,
+      },
+      {
+        id: 'nwpublisher',
+        title: i18n.t('nwPublisher'),
+        subtitle: data.isLastMonth
+          ? undefined
+          : i18n.t('nwPublisherOnlyAllowsLastMonth'),
+        image: 'globe.americas',
+        imageColor: theme.colors.text,
+        attributes: { disabled: !data.isLastMonth },
+      },
     ],
-    [theme.colors.text]
+    [theme.colors.text, data.isLastMonth]
   )
 
   const handleShareAction = useCallback(
     async (action: string) => {
-      const message = data.reportAsString()
       if (action === 'copy') {
         Haptics.success()
-        await Clipboard.setStringAsync(message)
-      } else if (action === 'share') {
-        await Share.share({ message })
+        await Clipboard.setStringAsync(data.reportAsString())
+        return
+      }
+      if (action === 'share') {
+        await Share.share({ message: data.reportAsString() })
+        return
+      }
+
+      const remarks =
+        data.creditOverageHours > 0
+          ? i18n.t('creditOverageInTheAmountOf', {
+              count: data.creditOverageHours,
+            })
+          : undefined
+
+      if (action === 'hourglass') {
+        await openURL(
+          buildHourglassLink({
+            month: month + 1,
+            year,
+            minutes: data.hourglassMinutes,
+            studies: data.studies,
+            remarks,
+          })
+        )
+      } else if (action === 'nwpublisher' && data.isLastMonth) {
+        await openURL(
+          buildNwPublisherLink({
+            sharedInMinistry: data.sharedInMinistry,
+            hours: data.showHours ? data.hours : undefined,
+            credit: data.credit,
+            bibleStudies: data.studies,
+            remarks,
+          })
+        )
       }
     },
-    [data]
+    [data, month, year]
   )
 
   return (


### PR DESCRIPTION
Adds Hourglass and NW Publisher submit actions back to the report view's share menu. Link construction lives in pure builders (`src/features/service-reports/lib/submitLinks.ts`) with unit tests asserting the exact formats confirmed by both support teams; NW Publisher is disabled in the menu unless viewing last month's report.