### PR TITLE
fix: prevent verbose duration layout overflow

### DIFF
--- a/src/features/plans/screens/ScheduleScreen.tsx
+++ b/src/features/plans/screens/ScheduleScreen.tsx
@@ -14,6 +14,7 @@ import { useNavigation as useRootNavigation } from '@react-navigation/native'
 import moment from 'moment'
 
 import useServiceReport from '@/stores/serviceReport'
+import { usePreferences } from '@/stores/preferences'
 import useTheme from '@/contexts/theme'
 import { getMonthsReports } from '@/lib/serviceReport'
 import {
@@ -60,6 +61,8 @@ const ScheduleScreen = ({ route }: Props) => {
   const serviceReports = useServiceReport((s) => s.serviceReports)
   const dayPlans = useServiceReport((s) => s.dayPlans)
   const recurringPlans = useServiceReport((s) => s.recurringPlans)
+  const timeDisplayFormat = usePreferences((s) => s.timeDisplayFormat)
+  const usesVerboseDurations = timeDisplayFormat === 'short'
 
   const [year, setYear] = useState(route.params?.year ?? moment().year())
   const [month, setMonth] = useState(route.params?.month ?? moment().month())
@@ -347,10 +350,16 @@ const ScheduleScreen = ({ route }: Props) => {
                 {i18n.t('projectedHoursDescription')}
               </Text>
             </View>
-            <XView style={{ flex: 1, gap: 10 }}>
+            <View
+              style={{
+                flexDirection: usesVerboseDurations ? 'column' : 'row',
+                alignItems: 'stretch',
+                gap: usesVerboseDurations ? 12 : 10,
+              }}
+            >
               <MonthScheduleSection month={month} year={year} />
               <AnnualScheduleSection month={month} year={year} />
-            </XView>
+            </View>
           </Card>
           <Card>
             <CalendarHeader
@@ -467,28 +476,36 @@ const MonthScheduleSection = (props: { month: number; year: number }) => {
   const projectedDisplay = useFormattedMinutes(result.projectedMinutes)
 
   return (
-    <View style={{ gap: 5, flex: 1 }}>
-      <XView style={{ justifyContent: 'space-between' }}>
+    <View style={{ gap: 5, flex: 1, minWidth: 0 }}>
+      <XView
+        style={{
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 8,
+        }}
+      >
         <Text
           style={{
             fontFamily: theme.fonts.semiBold,
+            flexShrink: 0,
           }}
         >
           {i18n.t('month')}
         </Text>
-        <XView>
-          <Text
-            style={{
-              fontFamily: theme.fonts.semiBold,
-              color: theme.colors.textAlt,
-              fontSize: theme.fontSize('xs'),
-            }}
-          >
-            {`${projectedDisplay.formatted} ${i18n.t(
-              'of'
-            )} ${goalHours} ${i18n.t('hours')}`}
-          </Text>
-        </XView>
+        <Text
+          style={{
+            flex: 1,
+            flexShrink: 1,
+            fontFamily: theme.fonts.semiBold,
+            color: theme.colors.textAlt,
+            fontSize: theme.fontSize('xs'),
+            textAlign: 'right',
+          }}
+        >
+          {`${projectedDisplay.formatted} ${i18n.t(
+            'of'
+          )} ${goalHours} ${i18n.t('hours')}`}
+        </Text>
       </XView>
       <SimpleProgressBar
         percentage={percentProjected}
@@ -520,20 +537,30 @@ const AnnualScheduleSection = (props: { month: number; year: number }) => {
   }
 
   return (
-    <View style={{ gap: 5, flex: 1 }}>
-      <XView style={{ justifyContent: 'space-between' }}>
+    <View style={{ gap: 5, flex: 1, minWidth: 0 }}>
+      <XView
+        style={{
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 8,
+        }}
+      >
         <Text
           style={{
             fontFamily: theme.fonts.semiBold,
+            flexShrink: 0,
           }}
         >
           {i18n.t('year')}
         </Text>
         <Text
           style={{
+            flex: 1,
+            flexShrink: 1,
             fontFamily: theme.fonts.semiBold,
             color: theme.colors.textAlt,
             fontSize: theme.fontSize('xs'),
+            textAlign: 'right',
           }}
         >
           {`${projectedDisplay.formatted} ${i18n.t(

--- a/src/features/progress/components/ProgressYearTab.tsx
+++ b/src/features/progress/components/ProgressYearTab.tsx
@@ -1,3 +1,4 @@
+import { CalendarCheck as TodayIcon } from 'lucide-react-native'
 import { useMemo } from 'react'
 import { Pressable, View } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
@@ -20,8 +21,8 @@ import i18n from '@/lib/locales'
 import YearMilestoneCard from '@/components/YearMilestoneCard'
 import ProjectedTotalCard from '@/components/ProjectedTotalCard'
 import Text from '@/components/ui/MyText'
+import LucideIcon from '@/components/ui/LucideIcon'
 import XView from '@/components/ui/layout/XView'
-import Badge from '@/components/ui/Badge'
 import { useCardStyle } from '@/components/ui/Card'
 
 interface ProgressYearTabProps {
@@ -31,6 +32,32 @@ interface ProgressYearTabProps {
   onAdjustMilestones: () => void
   /** Invoked when the user taps a month row — parent switches to Month tab. */
   onMonthPress: (month: number, year: number) => void
+}
+
+const CurrentMonthIcon = () => {
+  const theme = useTheme()
+
+  return (
+    <View
+      accessible
+      accessibilityRole='image'
+      accessibilityLabel={i18n.t('today')}
+      style={{
+        width: 16,
+        height: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <LucideIcon
+        icon={TodayIcon}
+        size={15}
+        strokeWidth={2.5}
+        color={theme.colors.accent}
+      />
+    </View>
+  )
 }
 
 /**
@@ -144,7 +171,7 @@ const MonthRow = ({
           >
             {monthYearLabel}
           </Text>
-          {isCurrent ? <Badge size='xs'>{i18n.t('today')}</Badge> : null}
+          {isCurrent ? <CurrentMonthIcon /> : null}
         </XView>
         <XView style={{ gap: 12 }}>
           <Text


### PR DESCRIPTION
## Summary
- Stack Schedule projected totals when verbose durations are enabled
- Replace the Progress Year “Today” pill with a compact icon
- Let dense milestone labels wrap onto extra rows without colliding

## Checks
- pnpm run typecheck
- pnpm run lint
- pnpm run testFinal
- pre-push: deps/lint/testFinal

Refs #388