### PR TITLE
Show schedule status on Schedule screen

### DIFF
--- a/src/__tests__/scheduleStatus.test.ts
+++ b/src/__tests__/scheduleStatus.test.ts
@@ -1,0 +1,163 @@
+import moment from 'moment'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getScheduleStatusForMonth } from '@/lib/scheduleStatus'
+import { RecurringPlanFrequencies } from '@/types/timeEntry'
+import type {
+  DayPlan,
+  RecurringPlan,
+  TimeEntriesByYear,
+  TimeEntry,
+} from '@/types/timeEntry'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+
+const entry = (id: string, date: string, minutes: number): TimeEntry => ({
+  id,
+  date: moment(date).toDate(),
+  hours: Math.floor(minutes / 60),
+  minutes: minutes % 60,
+})
+
+const dayPlan = (id: string, date: string, minutes: number): DayPlan => ({
+  id,
+  date: moment(date).toDate(),
+  minutes,
+})
+
+const reportsByMonth = (entries: TimeEntry[]): TimeEntriesByYear => {
+  const reports: TimeEntriesByYear = {}
+  for (const report of entries) {
+    const date = moment(report.date)
+    const year = date.year().toString()
+    const month = date.month().toString()
+    reports[year] ??= {}
+    reports[year][month] ??= []
+    reports[year][month].push(report)
+  }
+  return reports
+}
+
+const statusFor = (args: {
+  today?: string
+  month?: number
+  year?: number
+  entries?: TimeEntry[]
+  dayPlans?: DayPlan[]
+  recurringPlans?: RecurringPlan[]
+}) =>
+  getScheduleStatusForMonth({
+    month: args.month ?? 6,
+    year: args.year ?? 2026,
+    today: moment(args.today ?? '2026-07-09').toDate(),
+    serviceReports: reportsByMonth(args.entries ?? []),
+    dayPlans: args.dayPlans ?? [],
+    recurringPlans: args.recurringPlans ?? [],
+    publisher: 'regularPioneer',
+    creditLimit: { enabled: false, customLimitHours: 0 },
+  })
+
+describe('getScheduleStatusForMonth', () => {
+  it('includes today when logged time matches planned time', () => {
+    const status = statusFor({
+      entries: [entry('today-log', '2026-07-09', 120)],
+      dayPlans: [dayPlan('today-plan', '2026-07-09', 120)],
+    })
+
+    expect(status.state).toBe('onTrack')
+    expect(status.actualMinutes).toBe(120)
+    expect(status.plannedMinutes).toBe(120)
+    expect(status.differenceMinutes).toBe(0)
+  })
+
+  it('reports behind schedule when logged time is less than planned through today', () => {
+    const status = statusFor({
+      entries: [entry('first-log', '2026-07-01', 60)],
+      dayPlans: [
+        dayPlan('first-plan', '2026-07-01', 60),
+        dayPlan('today-plan', '2026-07-09', 60),
+      ],
+    })
+
+    expect(status.state).toBe('behind')
+    expect(status.actualMinutes).toBe(60)
+    expect(status.plannedMinutes).toBe(120)
+    expect(status.differenceMinutes).toBe(-60)
+  })
+
+  it('reports ahead of schedule when today pushes logged time past planned time', () => {
+    const status = statusFor({
+      entries: [entry('today-log', '2026-07-09', 90)],
+      dayPlans: [dayPlan('today-plan', '2026-07-09', 60)],
+    })
+
+    expect(status.state).toBe('ahead')
+    expect(status.actualMinutes).toBe(90)
+    expect(status.plannedMinutes).toBe(60)
+    expect(status.differenceMinutes).toBe(30)
+  })
+
+  it('ignores later-in-month logs and plans for a current-month status', () => {
+    const status = statusFor({
+      entries: [entry('future-log', '2026-07-20', 60)],
+      dayPlans: [dayPlan('future-plan', '2026-07-20', 60)],
+    })
+
+    expect(status.state).toBe('noPlan')
+    expect(status.actualMinutes).toBe(0)
+    expect(status.plannedMinutes).toBe(0)
+  })
+
+  it('uses the full selected month when the schedule is in the past', () => {
+    const status = statusFor({
+      today: '2026-08-05',
+      entries: [entry('late-log', '2026-07-20', 60)],
+      dayPlans: [dayPlan('late-plan', '2026-07-20', 60)],
+    })
+
+    expect(status.state).toBe('onTrack')
+    expect(status.throughDay).toBe(31)
+    expect(status.actualMinutes).toBe(60)
+    expect(status.plannedMinutes).toBe(60)
+  })
+
+  it('shows full-month planned time for a future schedule that has not started', () => {
+    const status = statusFor({
+      today: '2026-07-09',
+      month: 7,
+      entries: [entry('future-log', '2026-08-20', 60)],
+      dayPlans: [
+        dayPlan('early-plan', '2026-08-02', 60),
+        dayPlan('late-plan', '2026-08-20', 90),
+      ],
+    })
+
+    expect(status.state).toBe('notStarted')
+    expect(status.throughDay).toBe(31)
+    expect(status.actualMinutes).toBe(0)
+    expect(status.plannedMinutes).toBe(150)
+  })
+
+  it('expands recurring plans through the schedule status range', () => {
+    const recurringPlan: RecurringPlan = {
+      id: 'weekly-plan',
+      startDate: moment('2026-07-02').toDate(),
+      minutes: 60,
+      recurrence: {
+        frequency: RecurringPlanFrequencies.WEEKLY,
+        interval: 1,
+        endDate: null,
+      },
+    }
+
+    const status = statusFor({
+      today: '2026-07-09',
+      entries: [entry('first-log', '2026-07-02', 60)],
+      recurringPlans: [recurringPlan],
+    })
+
+    expect(status.state).toBe('behind')
+    expect(status.plannedMinutes).toBe(120)
+    expect(status.actualMinutes).toBe(60)
+  })
+})

--- a/src/features/plans/screens/ScheduleScreen.tsx
+++ b/src/features/plans/screens/ScheduleScreen.tsx
@@ -1,6 +1,10 @@
 import {
   ArrowLeft as ArrowLeftIcon,
   ArrowRight as ArrowRightIcon,
+  CalendarClock as CalendarClockIcon,
+  CircleCheck as CircleCheckIcon,
+  TrendingDown as TrendingDownIcon,
+  TrendingUp as TrendingUpIcon,
 } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { View } from 'react-native'
@@ -22,11 +26,14 @@ import {
   getEffectiveStartTimeInMinutesForRecurringPlan,
   RecurringPlan,
 } from '@/lib/recurrence'
-import { getServiceYearFromDate } from '@/lib/serviceYear'
 import { getPeriodTense } from '@/lib/projectedTotalCopy'
 import usePublisher from '@/hooks/usePublisher'
 import useProjectedTotal from '@/hooks/useProjectedTotal'
 import { useFormattedMinutes } from '@/lib/minutes'
+import {
+  getScheduleStatusForMonth,
+  type ScheduleStatusState,
+} from '@/lib/scheduleStatus'
 import { getStartTimeInMinutes } from '@/lib/normalizeDate'
 import { RootStackNavigation } from '@/types/rootStack'
 import { HomeTabStackParamList } from '@/types/homeStack'
@@ -44,12 +51,13 @@ import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import ActionButton from '@/components/ui/ActionButton'
 import IconButton from '@/components/ui/IconButton'
+import LucideIcon from '@/components/ui/LucideIcon'
 import Text from '@/components/ui/MyText'
 import XView from '@/components/ui/layout/XView'
 import SimpleProgressBar from '@/components/ui/SimpleProgressBar'
 import PlanRow from '@/components/PlanRow'
 import type { PlanListItem } from '@/components/PlanRow'
-import i18n from '@/lib/locales'
+import i18n, { type TranslationKey } from '@/lib/locales'
 
 type Props = BottomTabScreenProps<HomeTabStackParamList, 'Schedule'>
 
@@ -61,9 +69,6 @@ const ScheduleScreen = ({ route }: Props) => {
   const serviceReports = useServiceReport((s) => s.serviceReports)
   const dayPlans = useServiceReport((s) => s.dayPlans)
   const recurringPlans = useServiceReport((s) => s.recurringPlans)
-  const timeDisplayFormat = usePreferences((s) => s.timeDisplayFormat)
-  const usesVerboseDurations = timeDisplayFormat === 'short'
-
   const [year, setYear] = useState(route.params?.year ?? moment().year())
   const [month, setMonth] = useState(route.params?.month ?? moment().month())
   const [calendarViewMode, setCalendarViewMode] =
@@ -331,36 +336,7 @@ const ScheduleScreen = ({ route }: Props) => {
               </Text>
             </Button>
           )}
-          <Card style={{ gap: 10 }}>
-            <View style={{ gap: 4 }}>
-              <Text
-                style={{
-                  fontFamily: theme.fonts.bold,
-                  fontSize: theme.fontSize('xl'),
-                }}
-              >
-                {i18n.t('projectedHoursTitle')}
-              </Text>
-              <Text
-                style={{
-                  color: theme.colors.textAlt,
-                  fontSize: theme.fontSize('sm'),
-                }}
-              >
-                {i18n.t('projectedHoursDescription')}
-              </Text>
-            </View>
-            <View
-              style={{
-                flexDirection: usesVerboseDurations ? 'column' : 'row',
-                alignItems: 'stretch',
-                gap: usesVerboseDurations ? 12 : 10,
-              }}
-            >
-              <MonthScheduleSection month={month} year={year} />
-              <AnnualScheduleSection month={month} year={year} />
-            </View>
-          </Card>
+          <ScheduleStatusCard month={month} year={year} />
           <Card>
             <CalendarHeader
               viewMode={calendarViewMode}
@@ -462,118 +438,172 @@ const navButtonStyle = (theme: ReturnType<typeof useTheme>) => ({
   paddingVertical: 5,
 })
 
-const MonthScheduleSection = (props: { month: number; year: number }) => {
-  const theme = useTheme()
-  const { monthlyGoalHours: goalHours } = usePublisher()
-
-  const { projection: result } = useProjectedTotal(
-    { kind: 'month', month: props.month, year: props.year },
-    goalHours * 60
-  )
-
-  const projectedHours = result.projectedMinutes / 60
-  const percentProjected = goalHours > 0 ? projectedHours / goalHours : 0
-  const projectedDisplay = useFormattedMinutes(result.projectedMinutes)
-
-  return (
-    <View style={{ gap: 5, flex: 1, minWidth: 0 }}>
-      <XView
-        style={{
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 8,
-        }}
-      >
-        <Text
-          style={{
-            fontFamily: theme.fonts.semiBold,
-            flexShrink: 0,
-          }}
-        >
-          {i18n.t('month')}
-        </Text>
-        <Text
-          style={{
-            flex: 1,
-            flexShrink: 1,
-            fontFamily: theme.fonts.semiBold,
-            color: theme.colors.textAlt,
-            fontSize: theme.fontSize('xs'),
-            textAlign: 'right',
-          }}
-        >
-          {`${projectedDisplay.formatted} ${i18n.t(
-            'of'
-          )} ${goalHours} ${i18n.t('hours')}`}
-        </Text>
-      </XView>
-      <SimpleProgressBar
-        percentage={percentProjected}
-        color={theme.colors.accent}
-        animated={false}
-      />
-    </View>
-  )
+const STATUS_TITLE_KEYS: Record<ScheduleStatusState, TranslationKey> = {
+  ahead: 'scheduleStatus.ahead',
+  behind: 'scheduleStatus.behind',
+  onTrack: 'scheduleStatus.onTrack',
+  noPlan: 'scheduleStatus.noPlan',
+  notStarted: 'scheduleStatus.upcoming',
 }
 
-const AnnualScheduleSection = (props: { month: number; year: number }) => {
+const ScheduleStatusCard = (props: { month: number; year: number }) => {
   const { month, year } = props
   const theme = useTheme()
-  const { annualGoalHours, hasAnnualGoal } = usePublisher()
-  const serviceYear = getServiceYearFromDate(moment().month(month).year(year))
+  const serviceReports = useServiceReport((s) => s.serviceReports)
+  const dayPlans = useServiceReport((s) => s.dayPlans)
+  const recurringPlans = useServiceReport((s) => s.recurringPlans)
+  const { role, overrideCreditLimit, customCreditLimitHours } = usePreferences()
 
-  const { projection: result } = useProjectedTotal(
-    { kind: 'serviceYear', serviceYear },
-    annualGoalHours * 60
+  const status = getScheduleStatusForMonth({
+    month,
+    year,
+    serviceReports,
+    dayPlans,
+    recurringPlans,
+    publisher: role,
+    creditLimit: {
+      enabled: overrideCreditLimit,
+      customLimitHours: customCreditLimitHours,
+    },
+  })
+
+  const actualDisplay = useFormattedMinutes(status.actualMinutes)
+  const plannedDisplay = useFormattedMinutes(status.plannedMinutes)
+  const differenceDisplay = useFormattedMinutes(
+    Math.abs(status.differenceMinutes)
   )
 
-  const projectedHours = result.projectedMinutes / 60
-  const percentProjected =
-    annualGoalHours > 0 ? projectedHours / annualGoalHours : 0
-  const projectedDisplay = useFormattedMinutes(result.projectedMinutes)
-
-  if (!hasAnnualGoal) {
-    return null
-  }
+  const statusColor = (() => {
+    switch (status.state) {
+      case 'ahead':
+      case 'onTrack':
+        return theme.colors.accent
+      case 'behind':
+        return theme.colors.warn
+      default:
+        return theme.colors.textAlt
+    }
+  })()
+  const iconBackground = (() => {
+    switch (status.state) {
+      case 'ahead':
+      case 'onTrack':
+        return theme.colors.accentTranslucent
+      case 'behind':
+        return theme.colors.warnTranslucent
+      default:
+        return theme.colors.backgroundLighter
+    }
+  })()
+  const StatusIcon = (() => {
+    switch (status.state) {
+      case 'ahead':
+        return TrendingUpIcon
+      case 'behind':
+        return TrendingDownIcon
+      case 'onTrack':
+        return CircleCheckIcon
+      default:
+        return CalendarClockIcon
+    }
+  })()
+  const statusMeta = (() => {
+    switch (status.state) {
+      case 'ahead':
+        return `+${differenceDisplay.formatted}`
+      case 'behind':
+        return `-${differenceDisplay.formatted}`
+      case 'onTrack':
+        return i18n.t('scheduleStatus.matched')
+      case 'noPlan':
+        return i18n.t('scheduleStatus.noPlannedTime')
+      case 'notStarted':
+        return i18n.t('scheduleStatus.notStarted')
+    }
+  })()
+  const progress =
+    status.plannedMinutes > 0
+      ? Math.max(0, status.actualMinutes / status.plannedMinutes)
+      : status.actualMinutes > 0
+        ? 1
+        : 0
 
   return (
-    <View style={{ gap: 5, flex: 1, minWidth: 0 }}>
-      <XView
-        style={{
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 8,
-        }}
-      >
-        <Text
+    <Card style={{ gap: 12 }}>
+      <XView style={{ alignItems: 'center', gap: 12 }}>
+        <View
           style={{
-            fontFamily: theme.fonts.semiBold,
-            flexShrink: 0,
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: iconBackground,
           }}
         >
-          {i18n.t('year')}
-        </Text>
-        <Text
-          style={{
-            flex: 1,
-            flexShrink: 1,
-            fontFamily: theme.fonts.semiBold,
-            color: theme.colors.textAlt,
-            fontSize: theme.fontSize('xs'),
-            textAlign: 'right',
-          }}
-        >
-          {`${projectedDisplay.formatted} ${i18n.t(
-            'of'
-          )} ${annualGoalHours} ${i18n.t('hours')}`}
-        </Text>
+          <LucideIcon icon={StatusIcon} color={statusColor} size={22} />
+        </View>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text
+            style={{
+              fontFamily: theme.fonts.bold,
+              fontSize: theme.fontSize('xl'),
+              color: statusColor,
+            }}
+          >
+            {i18n.t(STATUS_TITLE_KEYS[status.state])}
+          </Text>
+          <Text
+            style={{
+              color: theme.colors.textAlt,
+              fontFamily: theme.fonts.semiBold,
+            }}
+          >
+            {statusMeta}
+          </Text>
+        </View>
       </XView>
+
       <SimpleProgressBar
-        percentage={percentProjected}
-        color={theme.colors.accent}
+        percentage={progress}
+        color={statusColor}
+        height={10}
         animated={false}
       />
-    </View>
+
+      <XView style={{ justifyContent: 'space-between', gap: 12 }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text
+            style={{
+              color: theme.colors.textAlt,
+              fontSize: theme.fontSize('xs'),
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+            }}
+          >
+            {i18n.t('actual')}
+          </Text>
+          <Text style={{ fontFamily: theme.fonts.semiBold }}>
+            {actualDisplay.formatted}
+          </Text>
+        </View>
+        <View style={{ flex: 1, gap: 2, alignItems: 'flex-end' }}>
+          <Text
+            style={{
+              color: theme.colors.textAlt,
+              fontSize: theme.fontSize('xs'),
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+            }}
+          >
+            {i18n.t('planned')}
+          </Text>
+          <Text style={{ fontFamily: theme.fonts.semiBold }}>
+            {plannedDisplay.formatted}
+          </Text>
+        </View>
+      </XView>
+    </Card>
   )
 }
 

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -265,23 +265,20 @@ export const resolveDayPlanWinner = (
   return { source: 'recurring', plan: winner, minutes, isCredit }
 }
 
-export const plannedMinutesToCurrentDayForMonth = (
+export const plannedMinutesThroughDayForMonth = (
   month: number,
   year: number,
+  throughDay: number,
   dayPlans: DayPlan[],
   recurringPlans: RecurringPlan[]
 ) => {
-  const selectedMonth = moment().month(month).year(year)
-
-  const dayOfMonth = selectedMonth.isBefore(moment(), 'month')
-    ? selectedMonth.daysInMonth()
-    : moment().date()
+  const selectedMonth = moment({ year, month, date: 1 }).startOf('month')
+  const dayOfMonth = Math.max(
+    0,
+    Math.min(throughDay, selectedMonth.daysInMonth())
+  )
 
   let count = 0
-
-  if (selectedMonth.isAfter(moment(), 'month')) {
-    return 0
-  }
 
   Array(dayOfMonth)
     .fill(1)
@@ -303,6 +300,32 @@ export const plannedMinutesToCurrentDayForMonth = (
     })
 
   return count
+}
+
+export const plannedMinutesToCurrentDayForMonth = (
+  month: number,
+  year: number,
+  dayPlans: DayPlan[],
+  recurringPlans: RecurringPlan[]
+) => {
+  const currentDay = moment()
+  const selectedMonth = moment({ year, month, date: 1 }).startOf('month')
+
+  if (selectedMonth.isAfter(currentDay, 'month')) {
+    return 0
+  }
+
+  const dayOfMonth = selectedMonth.isBefore(currentDay, 'month')
+    ? selectedMonth.daysInMonth()
+    : currentDay.date()
+
+  return plannedMinutesThroughDayForMonth(
+    month,
+    year,
+    dayOfMonth,
+    dayPlans,
+    recurringPlans
+  )
 }
 
 /**

--- a/src/lib/scheduleStatus.ts
+++ b/src/lib/scheduleStatus.ts
@@ -1,0 +1,121 @@
+import moment from 'moment'
+
+import {
+  adjustedMinutesForSpecificMonth,
+  getMonthsReports,
+} from '@/lib/serviceReport'
+import { plannedMinutesThroughDayForMonth } from '@/lib/recurrence'
+import { momentStoredDate, normalizeDateForStorage } from '@/lib/normalizeDate'
+import type { Publisher } from '@/types/publisher'
+import type {
+  DayPlan,
+  RecurringPlan,
+  TimeEntriesByYear,
+} from '@/types/timeEntry'
+
+export type ScheduleStatusState =
+  | 'ahead'
+  | 'behind'
+  | 'onTrack'
+  | 'noPlan'
+  | 'notStarted'
+
+export type ScheduleStatus = {
+  state: ScheduleStatusState
+  actualMinutes: number
+  plannedMinutes: number
+  differenceMinutes: number
+  throughDay: number
+}
+
+type ScheduleStatusInput = {
+  month: number
+  year: number
+  today?: Date
+  serviceReports: TimeEntriesByYear
+  dayPlans: DayPlan[]
+  recurringPlans: RecurringPlan[]
+  publisher: Publisher
+  creditLimit: {
+    enabled: boolean
+    customLimitHours: number
+  }
+}
+
+/**
+ * Compares logged progress with planned schedule progress for a selected month.
+ * Current months are evaluated through today (inclusive), so today's Time
+ * Entries immediately move the schedule status. Past and future months use the
+ * full month; future months remain not-started but still show planned time.
+ */
+export const getScheduleStatusForMonth = ({
+  month,
+  year,
+  today = new Date(),
+  serviceReports,
+  dayPlans,
+  recurringPlans,
+  publisher,
+  creditLimit,
+}: ScheduleStatusInput): ScheduleStatus => {
+  const todayMoment = moment(today)
+  const selectedMonth = moment({ year, month, date: 1 }).startOf('month')
+
+  const isFutureMonth = selectedMonth.isAfter(todayMoment, 'month')
+  const isCurrentMonth = selectedMonth.isSame(todayMoment, 'month')
+  const throughDay = isCurrentMonth
+    ? todayMoment.date()
+    : selectedMonth.daysInMonth()
+
+  const plannedMinutes = plannedMinutesThroughDayForMonth(
+    month,
+    year,
+    throughDay,
+    dayPlans,
+    recurringPlans
+  )
+
+  const throughDate = momentStoredDate(
+    normalizeDateForStorage(
+      selectedMonth.clone().date(Math.max(throughDay, 1)).toDate()
+    )
+  )
+  const reportsThroughDay = getMonthsReports(
+    serviceReports,
+    month,
+    year
+  ).filter((report) =>
+    momentStoredDate(report.date).isSameOrBefore(throughDate, 'day')
+  )
+
+  const actualMinutes = isFutureMonth
+    ? 0
+    : adjustedMinutesForSpecificMonth(
+        reportsThroughDay,
+        month,
+        year,
+        publisher,
+        {
+          enabled: creditLimit.enabled,
+          customLimitHours: creditLimit.customLimitHours,
+        }
+      ).value
+
+  const differenceMinutes = actualMinutes - plannedMinutes
+
+  const state: ScheduleStatusState = (() => {
+    if (isFutureMonth) return 'notStarted'
+    if (plannedMinutes === 0 && actualMinutes === 0) return 'noPlan'
+    if (differenceMinutes > 0) return 'ahead'
+    if (differenceMinutes < 0) return 'behind'
+    return 'onTrack'
+  })()
+
+  return {
+    state,
+    actualMinutes,
+    plannedMinutes,
+    differenceMinutes,
+    throughDay,
+  }
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1247,6 +1247,16 @@
   "plannedHours": "planned",
   "projectedHoursTitle": "Projected Hours",
   "projectedHoursDescription": "Combines hours you've already logged with hours you have planned. Aim to reach 100% of your goal.",
+  "scheduleStatus": {
+    "ahead": "Ahead",
+    "behind": "Behind",
+    "onTrack": "On track",
+    "noPlan": "No plan",
+    "upcoming": "Upcoming",
+    "matched": "Matched",
+    "noPlannedTime": "No planned time",
+    "notStarted": "Not started"
+  },
   "planDay": "Plan Day",
   "weekly": "Weekly",
   "bi-weekly": "Bi-Weekly",


### PR DESCRIPTION
Closes #391.

Replaces the Schedule screen projected-hours card with an ahead/behind/on-track schedule status based on logged time versus planned time through the relevant range.