### PR TITLE
feat: add monthly goal overrides

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -12,6 +12,7 @@ It's a project deployed to Cloudflare workers. Read the documentation within tha
 - **Never destroy unstaged work.** `git checkout/restore <path>`, `git reset --hard`, `git clean` discard working-tree changes with no recoverable trace. Run `git status` + `git diff <path>` before any destructive path-level git op; undo your _own_ edits with `git stash` (recoverable), and treat files dirtied outside this session as off-limits.
 - **JW sensitivities.** No "magic" word or magic-wand iconography in i18n/copy.
 - **Translations.** `src/locales/en-US.json` is the source of truth; other locales are human-approved only — don't edit them without asking.
+- **Forms in sheets.** Do not add a Cancel button to a form presented in a dismissible sheet. Tapping outside the sheet or pulling it down already cancels; keep the explicit Save/Submit action and any meaningful reset/destructive action.
 - **Commits.** Rebase, never merge-commit; amend over `fix:` follow-ups. Husky pre-commit hooks stay on — no `--no-verify` unless told. Branch names are bare `[feature-name]` (no `agent/` or `feature/` prefix).
 
 ## Orientation

--- a/src/__tests__/assistantState.test.ts
+++ b/src/__tests__/assistantState.test.ts
@@ -13,6 +13,7 @@ import type { AssistantEvent } from '@/lib/assistantRecommendation'
 describe('computeRecommendationInputsHash', () => {
   const base = {
     loggedAdjustedMinutes: 600,
+    monthlyGoalMinutes: 3000,
     dayPlanFingerprints: ['2026-05-15:120', '2026-05-20:120'],
     recurringPlanFingerprints: ['rp-1:weekly'],
     conversationDayKeys: ['2026-05-18'],
@@ -29,6 +30,12 @@ describe('computeRecommendationInputsHash', () => {
   it('changes when logged minutes change', () => {
     expect(computeRecommendationInputsHash(base)).not.toBe(
       computeRecommendationInputsHash({ ...base, loggedAdjustedMinutes: 660 })
+    )
+  })
+
+  it('changes when the effective Monthly Goal changes', () => {
+    expect(computeRecommendationInputsHash(base)).not.toBe(
+      computeRecommendationInputsHash({ ...base, monthlyGoalMinutes: 3600 })
     )
   })
 

--- a/src/__tests__/monthlyGoalCelebration.test.ts
+++ b/src/__tests__/monthlyGoalCelebration.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { didCrossMonthlyGoal } from '@/features/service-reports/lib/monthlyGoalCelebration'
+import { monthlyGoalKey } from '@/lib/monthlyGoals'
+
+const target = { year: 2026, month: 6 }
+
+describe('Monthly Goal crossing', () => {
+  it('uses the goal override belonging to the Time Entry month', () => {
+    const monthlyGoalOverrides = {
+      [monthlyGoalKey(target)]: 60,
+      [monthlyGoalKey({ year: 2026, month: 7 })]: 40,
+    }
+
+    expect(
+      didCrossMonthlyGoal({
+        beforeMinutes: 49 * 60,
+        afterMinutes: 55 * 60,
+        baseGoalHours: 50,
+        monthlyGoalOverrides,
+        target,
+      })
+    ).toBe(false)
+
+    expect(
+      didCrossMonthlyGoal({
+        beforeMinutes: 59 * 60,
+        afterMinutes: 60 * 60,
+        baseGoalHours: 50,
+        monthlyGoalOverrides,
+        target,
+      })
+    ).toBe(true)
+  })
+
+  it('does not repeat the crossing after the effective goal was already met', () => {
+    expect(
+      didCrossMonthlyGoal({
+        beforeMinutes: 60 * 60,
+        afterMinutes: 61 * 60,
+        baseGoalHours: 50,
+        monthlyGoalOverrides: { [monthlyGoalKey(target)]: 60 },
+        target,
+      })
+    ).toBe(false)
+  })
+})

--- a/src/__tests__/monthlyGoalStore.test.ts
+++ b/src/__tests__/monthlyGoalStore.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock(
+  '@react-native-async-storage/async-storage',
+  () => import('@/__tests__/mocks/asyncStorage')
+)
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { version: '1.0.0' } },
+}))
+vi.mock('expo-device', () => ({ DeviceType: { TABLET: 2 }, deviceType: 1 }))
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'en-US' }],
+}))
+vi.mock('@/lib/locales', () => ({
+  default: { t: (k: string) => k },
+}))
+vi.mock('@/shaders/registry', () => ({
+  DEFAULT_SHADER_ID: 'holographic',
+}))
+
+import { PREFERENCE_DEFAULTS, usePreferences } from '@/stores/preferences'
+
+describe('Monthly Goal preference actions', () => {
+  beforeEach(() => {
+    usePreferences.setState({
+      ...PREFERENCE_DEFAULTS,
+      role: 'regularPioneer',
+      monthlyGoalOverrides: {},
+      preferenceUpdatedAt: {},
+    })
+  })
+
+  it('saves nonnegative decimal hours for one exact calendar month', () => {
+    usePreferences
+      .getState()
+      .setMonthlyGoalOverride({ year: 2026, month: 10 }, 60.5)
+
+    expect(usePreferences.getState().monthlyGoalOverrides).toEqual({
+      '2026-11': 60.5,
+    })
+  })
+
+  it('allows a zero-hour override', () => {
+    usePreferences
+      .getState()
+      .setMonthlyGoalOverride({ year: 2026, month: 10 }, 0)
+
+    expect(usePreferences.getState().monthlyGoalOverrides['2026-11']).toBe(0)
+  })
+
+  it('removes the override when saving the Publisher-derived base goal', () => {
+    usePreferences.setState({ monthlyGoalOverrides: { '2026-11': 60 } })
+
+    usePreferences
+      .getState()
+      .setMonthlyGoalOverride({ year: 2026, month: 10 }, 50)
+
+    expect(usePreferences.getState().monthlyGoalOverrides).toEqual({})
+  })
+
+  it('uses the current custom Publisher goal as the removable base', () => {
+    usePreferences.setState({
+      role: 'custom',
+      publisherHours: {
+        ...PREFERENCE_DEFAULTS.publisherHours,
+        custom: 72.5,
+      },
+      monthlyGoalOverrides: { '2026-11': 80 },
+    })
+
+    usePreferences
+      .getState()
+      .setMonthlyGoalOverride({ year: 2026, month: 10 }, 72.5)
+
+    expect(usePreferences.getState().monthlyGoalOverrides).toEqual({})
+  })
+
+  it('clears only the selected calendar month', () => {
+    usePreferences.setState({
+      monthlyGoalOverrides: { '2026-11': 60, '2026-12': 70 },
+    })
+
+    usePreferences
+      .getState()
+      .clearMonthlyGoalOverride({ year: 2026, month: 10 })
+
+    expect(usePreferences.getState().monthlyGoalOverrides).toEqual({
+      '2026-12': 70,
+    })
+  })
+
+  it('rejects negative and nonfinite goals', () => {
+    expect(() =>
+      usePreferences
+        .getState()
+        .setMonthlyGoalOverride({ year: 2026, month: 10 }, -0.5)
+    ).toThrow(RangeError)
+    expect(() =>
+      usePreferences
+        .getState()
+        .setMonthlyGoalOverride({ year: 2026, month: 10 }, Number.NaN)
+    ).toThrow(RangeError)
+
+    expect(usePreferences.getState().monthlyGoalOverrides).toEqual({})
+  })
+})

--- a/src/__tests__/monthlyGoals.test.ts
+++ b/src/__tests__/monthlyGoals.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { monthlyGoalKey, resolveMonthlyGoalHours } from '@/lib/monthlyGoals'
+
+describe('Monthly Goal resolution', () => {
+  it('keys an exact zero-based calendar month as YYYY-MM', () => {
+    expect(monthlyGoalKey({ year: 2026, month: 0 })).toBe('2026-01')
+    expect(monthlyGoalKey({ year: 2026, month: 10 })).toBe('2026-11')
+  })
+
+  it('rejects an invalid calendar month', () => {
+    expect(() => monthlyGoalKey({ year: 2026, month: -1 })).toThrow(RangeError)
+    expect(() => monthlyGoalKey({ year: 2026, month: 12 })).toThrow(RangeError)
+    expect(() => monthlyGoalKey({ year: 2026, month: 1.5 })).toThrow(RangeError)
+  })
+
+  it('resolves the exact month override and otherwise uses the base goal', () => {
+    const overrides = { '2026-11': 60.5 }
+
+    expect(
+      resolveMonthlyGoalHours(50, overrides, { year: 2026, month: 10 })
+    ).toBe(60.5)
+    expect(
+      resolveMonthlyGoalHours(50, overrides, { year: 2026, month: 9 })
+    ).toBe(50)
+    expect(
+      resolveMonthlyGoalHours(50, overrides, { year: 2027, month: 10 })
+    ).toBe(50)
+  })
+
+  it('supports a zero-hour override and ignores malformed persisted goals', () => {
+    expect(
+      resolveMonthlyGoalHours(50, { '2026-11': 0 }, { year: 2026, month: 10 })
+    ).toBe(0)
+    expect(
+      resolveMonthlyGoalHours(
+        50,
+        { '2026-11': Number.NaN },
+        { year: 2026, month: 10 }
+      )
+    ).toBe(50)
+    expect(
+      resolveMonthlyGoalHours(50, { '2026-11': -1 }, { year: 2026, month: 10 })
+    ).toBe(50)
+  })
+})

--- a/src/__tests__/preferencesPersistMigration.test.ts
+++ b/src/__tests__/preferencesPersistMigration.test.ts
@@ -470,3 +470,119 @@ describe('preferences persist migrate v4 → v5 (startOfWeek 0 → Auto)', () =>
     expect(migrated.offDays).toEqual([0, 6])
   })
 })
+
+describe('preferences persist migrate v5 → v6 (Monthly Goal overrides)', () => {
+  it('converts serialized Date entries to YYYY-MM keys and preserves decimal hours', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        oneOffGoalHours: [
+          { month: '2026-11-01T00:00:00.000Z', hours: 60.5 },
+          { month: '2027-01-15T12:00:00.000Z', hours: 42.25 },
+        ],
+      },
+      5
+    )
+
+    expect(migrated.monthlyGoalOverrides).toEqual({
+      '2026-11': 60.5,
+      '2027-01': 42.25,
+    })
+    expect(migrated).not.toHaveProperty('oneOffGoalHours')
+  })
+
+  it('uses the last valid duplicate for a month and filters malformed, negative, and nonfinite entries', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        oneOffGoalHours: [
+          { month: '2026-11-01T00:00:00.000Z', hours: 55 },
+          { month: 'not-a-date', hours: 70 },
+          { month: '2026-12-01T00:00:00.000Z', hours: -1 },
+          { month: '2027-01-01T00:00:00.000Z', hours: Number.NaN },
+          { month: '2026-11-28T00:00:00.000Z', hours: 65.75 },
+          null,
+        ],
+      },
+      5
+    )
+
+    expect(migrated.monthlyGoalOverrides).toEqual({ '2026-11': 65.75 })
+  })
+
+  it('also supports an in-memory Date value', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        oneOffGoalHours: [{ month: new Date(2026, 6, 15), hours: 30.5 }],
+      },
+      5
+    )
+
+    expect(migrated.monthlyGoalOverrides).toEqual({ '2026-07': 30.5 })
+  })
+
+  it('renames the iCloud LWW timestamp key', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        oneOffGoalHours: [],
+        preferenceUpdatedAt: {
+          oneOffGoalHours: 1700000000000,
+          role: 1700000001000,
+        },
+      },
+      5
+    )
+
+    expect(migrated.preferenceUpdatedAt.monthlyGoalOverrides).toBe(
+      1700000000000
+    )
+    expect(migrated.preferenceUpdatedAt.role).toBe(1700000001000)
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('oneOffGoalHours')
+  })
+
+  it('prefers and sanitizes the canonical map when both shapes coexist', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        oneOffGoalHours: [{ month: '2026-11-01T00:00:00.000Z', hours: 60 }],
+        monthlyGoalOverrides: {
+          '2026-11': 70.5,
+          'bad-key': 80,
+          '2026-12': -10,
+        },
+        preferenceUpdatedAt: {
+          oneOffGoalHours: 1,
+          monthlyGoalOverrides: 2,
+        },
+      },
+      5
+    )
+
+    expect(migrated.monthlyGoalOverrides).toEqual({ '2026-11': 70.5 })
+    expect(migrated.preferenceUpdatedAt.monthlyGoalOverrides).toBe(2)
+    expect(migrated.preferenceUpdatedAt).not.toHaveProperty('oneOffGoalHours')
+  })
+
+  it('is idempotent on an already-v6 state', () => {
+    const v5State = {
+      oneOffGoalHours: [{ month: '2026-11-01T00:00:00.000Z', hours: 60 }],
+    }
+    const v6State = migratePreferencesPersistedState(v5State, 5)
+    const v6Again = migratePreferencesPersistedState(v6State, 6)
+
+    expect(JSON.stringify(v6Again)).toEqual(JSON.stringify(v6State))
+  })
+
+  it('chains cleanly from v0 through all preference migrations', () => {
+    const migrated = migratePreferencesPersistedState(
+      {
+        publisher: 'regularPioneer',
+        excludedWeekdays: [0, 6],
+        oneOffGoalHours: [{ month: '2026-11-01T00:00:00.000Z', hours: 60 }],
+      },
+      0
+    )
+
+    expect(migrated.role).toBe('regularPioneer')
+    expect(migrated.offDays).toEqual([0, 6])
+    expect(migrated.monthlyGoalOverrides).toEqual({ '2026-11': 60 })
+    expect(migrated).not.toHaveProperty('oneOffGoalHours')
+  })
+})

--- a/src/__tests__/widgetReportMonthlyGoal.test.ts
+++ b/src/__tests__/widgetReportMonthlyGoal.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => import('@/__tests__/mocks/logger'))
+vi.mock('@/lib/locales', () => ({
+  default: { t: (key: string) => key },
+}))
+vi.mock('@/stores/preferences', () => ({
+  usePreferences: () => ({ timeDisplayFormat: 'decimal' }),
+}))
+
+import { buildReport, type BuildReportArgs } from '@/app/widgets/buildReport'
+import { monthlyGoalKey } from '@/lib/monthlyGoals'
+import type { PublisherHours } from '@/types/publisher'
+
+const publisherHours: PublisherHours = {
+  publisher: 0,
+  regularAuxiliary: 30,
+  regularPioneer: 50,
+  circuitOverseer: 50,
+  specialPioneer: 100,
+  custom: 50,
+}
+
+const baseArgs = (): BuildReportArgs => ({
+  serviceReports: {
+    2026: {
+      6: [
+        {
+          id: 'july-entry',
+          date: new Date(2026, 6, 5, 12),
+          hours: 30,
+          minutes: 0,
+          credit: false,
+        },
+      ],
+    },
+  },
+  publisher: 'regularPioneer',
+  publisherHours,
+  monthlyGoalOverrides: {},
+  overrideCreditLimit: false,
+  customCreditLimitHours: 55,
+  timeDisplayFormat: 'decimal',
+  dayPlans: [],
+  recurringPlans: [],
+  conversations: [],
+})
+
+describe('widget Monthly Goal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 9, 12))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the override for the current calendar month', () => {
+    const args = baseArgs()
+    args.monthlyGoalOverrides = {
+      [monthlyGoalKey({ year: 2026, month: 6 })]: 60,
+    }
+
+    const report = buildReport(args)
+
+    expect(report.goalHours).toBe(60)
+    expect(report.progress).toBe(0.5)
+  })
+
+  it('ignores overrides belonging to another month', () => {
+    const args = baseArgs()
+    args.monthlyGoalOverrides = {
+      [monthlyGoalKey({ year: 2026, month: 7 })]: 60,
+    }
+
+    const report = buildReport(args)
+
+    expect(report.goalHours).toBe(50)
+    expect(report.progress).toBe(0.6)
+  })
+})

--- a/src/app/sync/__tests__/payloadFieldRenames.test.ts
+++ b/src/app/sync/__tests__/payloadFieldRenames.test.ts
@@ -158,6 +158,50 @@ describe('normalizeLegacyPayloadFieldNames', () => {
     expect(d.preferencesStore.updatedAt.tenureStartDate).toBe(2)
     expect(d.preferencesStore.updatedAt).not.toHaveProperty('pioneerStartDate')
   })
+
+  it('converts legacy one-off goal Dates to the canonical Monthly Goal map', () => {
+    const d = makePayload(
+      {
+        oneOffGoalHours: [
+          { month: '2026-11-01T00:00:00.000Z', hours: 55 },
+          { month: '2026-11-25T00:00:00.000Z', hours: 60.5 },
+          { month: '2026-12-01T00:00:00.000Z', hours: -1 },
+          { month: 'invalid', hours: 70 },
+        ],
+      },
+      { oneOffGoalHours: 1700000010000 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.monthlyGoalOverrides).toEqual({
+      '2026-11': 60.5,
+    })
+    expect(d.preferencesStore.values).not.toHaveProperty('oneOffGoalHours')
+    expect(d.preferencesStore.updatedAt.monthlyGoalOverrides).toBe(
+      1700000010000
+    )
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('oneOffGoalHours')
+  })
+
+  it('prefers canonical Monthly Goal overrides when a payload carries both shapes', () => {
+    const d = makePayload(
+      {
+        oneOffGoalHours: [{ month: '2026-11-01T00:00:00.000Z', hours: 60 }],
+        monthlyGoalOverrides: { '2026-11': 70 },
+      },
+      { oneOffGoalHours: 1, monthlyGoalOverrides: 2 }
+    )
+
+    normalizeLegacyPayloadFieldNames(d)
+
+    expect(d.preferencesStore.values.monthlyGoalOverrides).toEqual({
+      '2026-11': 70,
+    })
+    expect(d.preferencesStore.values).not.toHaveProperty('oneOffGoalHours')
+    expect(d.preferencesStore.updatedAt.monthlyGoalOverrides).toBe(2)
+    expect(d.preferencesStore.updatedAt).not.toHaveProperty('oneOffGoalHours')
+  })
 })
 
 describe('normalizeLegacyPayloadFieldNames — profile-field routing (wave-3)', () => {

--- a/src/app/sync/payloadFieldRenames.ts
+++ b/src/app/sync/payloadFieldRenames.ts
@@ -18,6 +18,9 @@
  * - `preferencesStore.values.pioneerStartDate` → `tenureStartDate` (wave-4 rename
  *   — the glossary's **Tenure Start Date** is canonical; the legacy name was
  *   misleading because regular auxiliary's tenure was also stored here)
+ * - `preferencesStore.values.oneOffGoalHours` → `monthlyGoalOverrides` (legacy `{
+ *   month: Date, hours }[]` entries become a `YYYY-MM` keyed map;
+ *   malformed/negative goals are discarded and the last valid duplicate wins)
  * - The matching keys inside `preferencesStore.updatedAt`
  * - `preferencesStore.values.{name,avatar,customAvatarBackground,hasCompletedProfileSetup}`
  *   → `profileStore.values.<same>` (wave-3 store split). Older peer devices
@@ -65,14 +68,57 @@ export function normalizeLegacyPayloadFieldNames(d: any): void {
     renameKey(prefs.values, 'meetingWeekdays', 'meetingDays')
     renameKey(prefs.values, 'publisher', 'role')
     renameKey(prefs.values, 'pioneerStartDate', 'tenureStartDate')
+    migrateLegacyMonthlyGoalOverrides(prefs.values)
     renameKey(prefs.updatedAt, 'excludedWeekdays', 'offDays')
     renameKey(prefs.updatedAt, 'meetingWeekdays', 'meetingDays')
     renameKey(prefs.updatedAt, 'publisher', 'role')
     renameKey(prefs.updatedAt, 'pioneerStartDate', 'tenureStartDate')
+    renameKey(prefs.updatedAt, 'oneOffGoalHours', 'monthlyGoalOverrides')
   }
 
   routeLegacyProfileFields(d)
   collapseLdcFlagOnServiceReports(d?.serviceReportStore?.serviceReports)
+}
+
+/**
+ * Payloads have already passed through JSON, so legacy Date values arrive as
+ * ISO strings. Extract their written year/month directly to avoid time-zone
+ * month drift. This mirrors the preferences persist migration while keeping
+ * this wire-normalization module import-free.
+ */
+function migrateLegacyMonthlyGoalOverrides(
+  values: Record<string, unknown> | undefined
+): void {
+  if (!values || typeof values !== 'object' || !('oneOffGoalHours' in values)) {
+    return
+  }
+
+  if (!('monthlyGoalOverrides' in values)) {
+    const overrides: Record<string, number> = {}
+    const legacy = values.oneOffGoalHours
+    if (Array.isArray(legacy)) {
+      for (const item of legacy) {
+        if (!item || typeof item !== 'object') continue
+        const { month, hours } = item as {
+          month?: unknown
+          hours?: unknown
+        }
+        if (
+          typeof month !== 'string' ||
+          typeof hours !== 'number' ||
+          !Number.isFinite(hours) ||
+          hours < 0
+        ) {
+          continue
+        }
+        const match = /^(\d{4})-(0[1-9]|1[0-2])/.exec(month)
+        if (match) overrides[`${match[1]}-${match[2]}`] = hours
+      }
+    }
+    values.monthlyGoalOverrides = overrides
+  }
+
+  delete values.oneOffGoalHours
 }
 
 /**

--- a/src/app/widgets/buildReport.ts
+++ b/src/app/widgets/buildReport.ts
@@ -20,6 +20,10 @@ import {
   TimeEntriesByYear,
 } from '@/types/timeEntry'
 import { Visit } from '@/types/visit'
+import {
+  resolveMonthlyGoalHours,
+  type MonthlyGoalOverrides,
+} from '@/lib/monthlyGoals'
 
 export type ReportMode = 'hours' | 'checkbox'
 
@@ -78,6 +82,7 @@ export type BuildReportArgs = {
   serviceReports: TimeEntriesByYear
   publisher: Publisher
   publisherHours: PublisherHours
+  monthlyGoalOverrides: MonthlyGoalOverrides
   overrideCreditLimit: boolean
   customCreditLimitHours: number
   timeDisplayFormat: MinuteDisplayFormat
@@ -186,7 +191,11 @@ export function buildReport(args: BuildReportArgs): ReportFields {
     }
   )
 
-  const goalHours = args.publisherHours[args.publisher]
+  const goalHours = resolveMonthlyGoalHours(
+    args.publisherHours[args.publisher],
+    args.monthlyGoalOverrides,
+    { month, year }
+  )
   const goalMinutes = goalHours * 60
   const progress = goalProgress({
     minutes: adjusted.value,

--- a/src/app/widgets/snapshot.ts
+++ b/src/app/widgets/snapshot.ts
@@ -2,6 +2,7 @@ import { Contact } from '@/types/contact'
 import { Visit } from '@/types/visit'
 import { StalenessBreakpoints } from '@/types/staleness'
 import { Publisher, PublisherHours } from '@/types/publisher'
+import type { MonthlyGoalOverrides } from '@/lib/monthlyGoals'
 import {
   DayPlan,
   MinuteDisplayFormat,
@@ -146,6 +147,7 @@ export type BuildSnapshotArgs = {
   serviceReports: TimeEntriesByYear
   publisher: Publisher
   publisherHours: PublisherHours
+  monthlyGoalOverrides: MonthlyGoalOverrides
   overrideCreditLimit: boolean
   customCreditLimitHours: number
   timeDisplayFormat: MinuteDisplayFormat
@@ -184,6 +186,7 @@ export function buildWidgetSnapshot(args: BuildSnapshotArgs): WidgetSnapshot {
     serviceReports: args.serviceReports,
     publisher: args.publisher,
     publisherHours: args.publisherHours,
+    monthlyGoalOverrides: args.monthlyGoalOverrides,
     overrideCreditLimit: args.overrideCreditLimit,
     customCreditLimitHours: args.customCreditLimitHours,
     timeDisplayFormat: args.timeDisplayFormat,

--- a/src/app/widgets/widgetSync.ts
+++ b/src/app/widgets/widgetSync.ts
@@ -66,6 +66,7 @@ function pushSnapshot(reason: string): void {
       serviceReports: sr.serviceReports,
       publisher: prefs.role,
       publisherHours: prefs.publisherHours,
+      monthlyGoalOverrides: prefs.monthlyGoalOverrides,
       overrideCreditLimit: prefs.overrideCreditLimit,
       customCreditLimitHours: prefs.customCreditLimitHours,
       timeDisplayFormat: prefs.timeDisplayFormat,

--- a/src/components/AssistantSection.tsx
+++ b/src/components/AssistantSection.tsx
@@ -156,6 +156,7 @@ const AssistantSection = ({
     () =>
       computeRecommendationInputsHash({
         loggedAdjustedMinutes: projection.loggedMinutes,
+        monthlyGoalMinutes: Math.round(monthlyGoalHours * 60),
         // Resolved credit-ness is part of each plan's fingerprint: a plan's
         // Type (or its Category's credit flag) changes the projection, so it
         // must re-arm a dismissed recommendation.
@@ -178,6 +179,7 @@ const AssistantSection = ({
       }),
     [
       projection.loggedMinutes,
+      monthlyGoalHours,
       dayPlans,
       recurringPlans,
       categories,

--- a/src/components/ProjectedTotalCard.tsx
+++ b/src/components/ProjectedTotalCard.tsx
@@ -20,6 +20,7 @@ import useProjectedTotal from '@/hooks/useProjectedTotal'
 import { formatMinutes } from '@/lib/minutes'
 import { usePreferences } from '@/stores/preferences'
 import AssistantSection from '@/components/AssistantSection'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
 
 type Props = {
   scope: ProjectedTotalScope
@@ -33,11 +34,17 @@ type Props = {
 
 const ProjectedTotalCard = ({ scope, showAssistant = false }: Props) => {
   const theme = useTheme()
-  const { monthlyGoalHours, annualGoalHours } = usePublisher()
+  const { annualGoalHours } = usePublisher()
   const { timeDisplayFormat } = usePreferences()
   const formatHours = (minutes: number) =>
     formatMinutes(minutes, timeDisplayFormat).formatted
 
+  const fallbackToday = new Date()
+  const monthTarget =
+    scope.kind === 'month'
+      ? { month: scope.month, year: scope.year }
+      : { month: fallbackToday.getMonth(), year: fallbackToday.getFullYear() }
+  const { effectiveGoalHours: monthlyGoalHours } = useMonthlyGoal(monthTarget)
   const goalHours = scope.kind === 'month' ? monthlyGoalHours : annualGoalHours
 
   const { projection: result, today } = useProjectedTotal(scope, goalHours * 60)

--- a/src/components/PublisherTypeSelector.tsx
+++ b/src/components/PublisherTypeSelector.tsx
@@ -1,4 +1,5 @@
-import { Pressable, TextInput as RNTextInput, View } from 'react-native'
+import { Alert, Pressable, TextInput as RNTextInput, View } from 'react-native'
+import moment from 'moment'
 import useTheme from '@/contexts/theme'
 import Text from '@/components/ui/MyText'
 import i18n from '@/lib/locales'
@@ -8,6 +9,7 @@ import Select, { SelectData } from '@/components/ui/Select'
 import TextInput from '@/components/ui/TextInput'
 import { Publisher } from '@/types/publisher'
 import { useRef, useState } from 'react'
+import { monthlyGoalKey } from '@/lib/monthlyGoals'
 
 const PublisherTypeSelector = () => {
   const theme = useTheme()
@@ -38,15 +40,59 @@ const PublisherTypeSelector = () => {
     },
   ]
 
-  const { publisherHours, role, setRole, set } = usePreferences()
+  const { publisherHours, role, monthlyGoalOverrides, setRole, set } =
+    usePreferences()
   const [goalHours, setGoalHours] = useState(publisherHours.custom.toString())
   const customHoursInput = useRef<RNTextInput>(null)
+
+  const handleRoleChange = (nextRole: Publisher) => {
+    if (nextRole === role) return
+
+    const now = moment()
+    const currentMonthKey = monthlyGoalKey({
+      year: now.year(),
+      month: now.month(),
+    })
+    const futureOverrideKeys = Object.keys(monthlyGoalOverrides).filter(
+      (key) => key >= currentMonthKey
+    )
+
+    if (futureOverrideKeys.length === 0) {
+      setRole(nextRole)
+      return
+    }
+
+    Alert.alert(
+      i18n.t('monthGoalEditor.roleChangeTitle'),
+      i18n.t('monthGoalEditor.roleChangeDescription'),
+      [
+        { text: i18n.t('cancel'), style: 'cancel' },
+        {
+          text: i18n.t('monthGoalEditor.keepGoals'),
+          onPress: () => setRole(nextRole),
+        },
+        {
+          text: i18n.t('monthGoalEditor.resetFutureGoals'),
+          style: 'destructive',
+          onPress: () => {
+            const pastOverrides = Object.fromEntries(
+              Object.entries(monthlyGoalOverrides).filter(
+                ([key]) => key < currentMonthKey
+              )
+            )
+            set({ monthlyGoalOverrides: pastOverrides })
+            setRole(nextRole)
+          },
+        },
+      ]
+    )
+  }
 
   return (
     <View>
       <Select
         data={items}
-        onChange={({ value }) => setRole(value)}
+        onChange={({ value }) => handleRoleChange(value)}
         value={role}
         style={{ marginBottom: 10 }}
       />
@@ -106,6 +152,17 @@ const PublisherTypeSelector = () => {
               })}
         </Text>
       )}
+      {role !== publishers[0] ? (
+        <Text
+          style={{
+            marginTop: 6,
+            fontSize: 12,
+            color: theme.colors.textAlt,
+          }}
+        >
+          {i18n.t('defaultMonthlyGoal_description')}
+        </Text>
+      ) : null}
     </View>
   )
 }

--- a/src/components/TiltableCard.tsx
+++ b/src/components/TiltableCard.tsx
@@ -10,7 +10,7 @@ import Animated, {
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import type { TiltShaderContext } from '@/shaders/types'
 
-interface Props {
+export interface TiltableCardProps {
   /** Disables the tilt gesture (e.g. in previews). */
   disabled?: boolean
   /** Max tilt in degrees at the corners. */
@@ -39,7 +39,7 @@ const TiltableCard = ({
   style,
   renderOverlay,
   overlayBorderRadius = 15,
-}: PropsWithChildren<Props>) => {
+}: PropsWithChildren<TiltableCardProps>) => {
   const touchTiltX = useSharedValue(0)
   const touchTiltY = useSharedValue(0)
   const pressScale = useSharedValue(1)

--- a/src/features/plans/components/ScheduleInsights.tsx
+++ b/src/features/plans/components/ScheduleInsights.tsx
@@ -1,0 +1,642 @@
+import {
+  CalendarRange as CalendarRangeIcon,
+  CalendarClock as CalendarClockIcon,
+  ChevronRight as ChevronRightIcon,
+  CircleCheck as CircleCheckIcon,
+  TrendingDown as TrendingDownIcon,
+  TrendingUp as TrendingUpIcon,
+  X as XIcon,
+} from 'lucide-react-native'
+import moment from 'moment'
+import { useEffect, useRef, useState } from 'react'
+import { Pressable, StatusBar, useWindowDimensions, View } from 'react-native'
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated'
+import { FullWindowOverlay } from 'react-native-screens'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import IconButton from '@/components/ui/IconButton'
+import LucideIcon, { type AppIcon } from '@/components/ui/LucideIcon'
+import Text from '@/components/ui/MyText'
+import SimpleProgressBar from '@/components/ui/SimpleProgressBar'
+import TiltableCard from '@/components/TiltableCard'
+import useTheme from '@/contexts/theme'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import i18n, { type TranslationKey } from '@/lib/locales'
+import { calculateMonthlyPlannedMinutesOptimized } from '@/lib/recurrence'
+import {
+  getScheduleStatusForMonth,
+  type ScheduleStatusState,
+} from '@/lib/scheduleStatus'
+import { useFormattedMinutes } from '@/lib/minutes'
+import { usePreferences } from '@/stores/preferences'
+import useServiceReport from '@/stores/serviceReport'
+
+type InsightKind = 'pace' | 'goal'
+type OriginRect = { x: number; y: number; width: number; height: number }
+
+const STATUS_TITLE_KEYS: Record<ScheduleStatusState, TranslationKey> = {
+  ahead: 'scheduleStatus.ahead',
+  behind: 'scheduleStatus.behind',
+  onTrack: 'scheduleStatus.onTrack',
+  noPlan: 'scheduleStatus.noPlan',
+  notStarted: 'scheduleStatus.upcoming',
+}
+
+const MORPH_SPRING = { damping: 20, stiffness: 180, mass: 0.7 }
+const EXPANDED_MARGIN = 16
+const EXPANDED_HEIGHT = 310
+
+const InsightStat = ({ label, value }: { label: string; value: string }) => {
+  const theme = useTheme()
+  return (
+    <View
+      style={{
+        flex: 1,
+        gap: 4,
+        padding: 12,
+        borderRadius: theme.numbers.borderRadiusMd,
+        backgroundColor: theme.colors.backgroundLighter,
+      }}
+    >
+      <Text
+        style={{
+          color: theme.colors.textAlt,
+          fontSize: theme.fontSize('xs'),
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        style={{
+          color: theme.colors.text,
+          fontFamily: theme.fonts.semiBold,
+          fontSize: theme.fontSize('lg'),
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  )
+}
+
+const ScheduleInsightOverlay = ({
+  origin,
+  open,
+  onClose,
+  kind,
+  statusTitle,
+  statusMeta,
+  statusIcon,
+  statusColor,
+  statusProgress,
+  actual,
+  pacePlanned,
+  plannedPercent,
+  monthPlanned,
+  goal,
+  leftToPlan,
+  goalProgress,
+  isCurrentMonth,
+  onEditGoal,
+}: {
+  origin: OriginRect | null
+  open: boolean
+  onClose: () => void
+  kind: InsightKind
+  statusTitle: string
+  statusMeta: string
+  statusIcon: AppIcon
+  statusColor: string
+  statusProgress: number
+  actual: string
+  pacePlanned: string
+  plannedPercent: number
+  monthPlanned: string
+  goal: string
+  leftToPlan: string
+  goalProgress: number
+  isCurrentMonth: boolean
+  onEditGoal?: () => void
+}) => {
+  const theme = useTheme()
+  const insets = useSafeAreaInsets()
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions()
+  const progress = useSharedValue(0)
+
+  const targetWidth = windowWidth - EXPANDED_MARGIN * 2
+  const targetHeight = Math.min(
+    EXPANDED_HEIGHT,
+    windowHeight - insets.top - insets.bottom - EXPANDED_MARGIN * 2
+  )
+  const targetX = EXPANDED_MARGIN
+  const targetY = Math.max(
+    insets.top + EXPANDED_MARGIN,
+    (windowHeight - targetHeight) / 2
+  )
+
+  useEffect(() => {
+    if (!origin) return
+    progress.value = withSpring(open ? 1 : 0, MORPH_SPRING)
+  }, [open, origin, progress])
+
+  const containerStyle = useAnimatedStyle(() => {
+    if (!origin) return {}
+    return {
+      left: interpolate(progress.value, [0, 1], [origin.x, targetX]),
+      top: interpolate(progress.value, [0, 1], [origin.y, targetY]),
+      width: interpolate(progress.value, [0, 1], [origin.width, targetWidth]),
+      height: interpolate(
+        progress.value,
+        [0, 1],
+        [origin.height, targetHeight]
+      ),
+      borderRadius: theme.numbers.borderRadiusLg,
+    }
+  })
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0, 1], [0, 0.5]),
+  }))
+  const contentStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0.35, 1], [0, 1], 'clamp'),
+  }))
+  const surfaceStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0, 0.15], [0, 1], 'clamp'),
+  }))
+
+  if (!origin) return null
+
+  const isPace = kind === 'pace'
+  const detailIcon = isPace ? statusIcon : CalendarRangeIcon
+  const detailColor = isPace ? statusColor : theme.colors.accent
+  const detailTitle = isPace
+    ? i18n.t('scheduleInsights.schedulePace')
+    : i18n.t('scheduleInsights.goalPlanned')
+
+  return (
+    <FullWindowOverlay>
+      {open ? <StatusBar barStyle='light-content' animated /> : null}
+      <View
+        pointerEvents={open ? 'auto' : 'none'}
+        accessibilityElementsHidden={!open}
+        importantForAccessibility={open ? 'auto' : 'no-hide-descendants'}
+        style={{ flex: 1 }}
+      >
+        <Pressable onPress={onClose} style={{ flex: 1 }}>
+          <Animated.View
+            style={[{ flex: 1, backgroundColor: '#000' }, backdropStyle]}
+          />
+        </Pressable>
+        <Animated.View
+          style={[{ position: 'absolute', overflow: 'hidden' }, containerStyle]}
+        >
+          <Animated.View
+            style={[
+              {
+                position: 'absolute',
+                width: targetWidth,
+                height: targetHeight,
+                backgroundColor: theme.colors.card,
+              },
+              surfaceStyle,
+            ]}
+          />
+          <Animated.View
+            style={[
+              {
+                position: 'absolute',
+                width: targetWidth,
+                height: targetHeight,
+                padding: 20,
+                gap: 18,
+              },
+              contentStyle,
+            ]}
+          >
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+              }}
+            >
+              <View
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}
+              >
+                <View
+                  style={{
+                    width: 38,
+                    height: 38,
+                    borderRadius: 19,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: theme.colors.backgroundLighter,
+                  }}
+                >
+                  <LucideIcon icon={detailIcon} color={detailColor} size={20} />
+                </View>
+                <Text
+                  accessibilityRole='header'
+                  style={{
+                    color: theme.colors.text,
+                    fontFamily: theme.fonts.bold,
+                    fontSize: theme.fontSize('xl'),
+                  }}
+                >
+                  {detailTitle}
+                </Text>
+              </View>
+              <IconButton icon={XIcon} size='lg' onPress={onClose} />
+            </View>
+
+            <View style={{ gap: 8 }}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                }}
+              >
+                <Text
+                  style={{
+                    color: detailColor,
+                    fontFamily: theme.fonts.bold,
+                    fontSize: theme.fontSize('2xl'),
+                  }}
+                >
+                  {isPace
+                    ? statusTitle
+                    : i18n.t('scheduleInsights.percentPlanned', {
+                        percent: plannedPercent,
+                      })}
+                </Text>
+                {isPace ? (
+                  <Text
+                    style={{
+                      color: theme.colors.textAlt,
+                      fontFamily: theme.fonts.semiBold,
+                    }}
+                  >
+                    {statusMeta}
+                  </Text>
+                ) : null}
+              </View>
+              {!isPace ? (
+                <Button
+                  noTransform
+                  accessibilityRole={onEditGoal ? 'button' : undefined}
+                  onPress={
+                    onEditGoal
+                      ? () => {
+                          onClose()
+                          setTimeout(onEditGoal, 150)
+                        }
+                      : undefined
+                  }
+                >
+                  <View
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Text
+                      style={{
+                        color: theme.colors.textAlt,
+                        fontFamily: theme.fonts.semiBold,
+                        fontSize: theme.fontSize('sm'),
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                      }}
+                    >
+                      {i18n.t('scheduleInsights.monthlyGoal')}
+                    </Text>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: 6,
+                      }}
+                    >
+                      <Text
+                        style={{
+                          color: theme.colors.textAlt,
+                          fontFamily: theme.fonts.semiBold,
+                        }}
+                      >
+                        {goal}
+                      </Text>
+                      {onEditGoal ? (
+                        <LucideIcon
+                          icon={ChevronRightIcon}
+                          color={theme.colors.textAlt}
+                          size={12}
+                        />
+                      ) : null}
+                    </View>
+                  </View>
+                </Button>
+              ) : null}
+              <SimpleProgressBar
+                percentage={isPace ? statusProgress : goalProgress}
+                color={detailColor}
+                height={10}
+                animated={false}
+              />
+            </View>
+
+            <View style={{ flexDirection: 'row', gap: 10 }}>
+              {isPace ? (
+                <>
+                  <InsightStat label={i18n.t('actual')} value={actual} />
+                  <InsightStat label={i18n.t('planned')} value={pacePlanned} />
+                </>
+              ) : (
+                <>
+                  <InsightStat label={i18n.t('planned')} value={monthPlanned} />
+                  <InsightStat
+                    label={i18n.t('scheduleInsights.leftToPlan')}
+                    value={leftToPlan}
+                  />
+                </>
+              )}
+            </View>
+
+            {isPace ? (
+              <Text
+                style={{
+                  color: theme.colors.textAlt,
+                  fontSize: theme.fontSize('sm'),
+                  lineHeight: 19,
+                }}
+              >
+                {i18n.t(
+                  isCurrentMonth
+                    ? 'scheduleInsights.paceDescriptionCurrent'
+                    : 'scheduleInsights.paceDescriptionMonth'
+                )}
+              </Text>
+            ) : null}
+          </Animated.View>
+        </Animated.View>
+      </View>
+    </FullWindowOverlay>
+  )
+}
+
+const ScheduleInsights = ({
+  month,
+  year,
+  onEditGoal,
+}: {
+  month: number
+  year: number
+  onEditGoal?: () => void
+}) => {
+  const theme = useTheme()
+  const serviceReports = useServiceReport((s) => s.serviceReports)
+  const dayPlans = useServiceReport((s) => s.dayPlans)
+  const recurringPlans = useServiceReport((s) => s.recurringPlans)
+  const { role, overrideCreditLimit, customCreditLimitHours } = usePreferences()
+  const { effectiveGoalHours } = useMonthlyGoal({ month, year })
+  const paceRef = useRef<View>(null)
+  const goalRef = useRef<View>(null)
+  const [detailKind, setDetailKind] = useState<InsightKind>('pace')
+  const [detailOpen, setDetailOpen] = useState(false)
+  const [origin, setOrigin] = useState<OriginRect | null>(null)
+
+  const status = getScheduleStatusForMonth({
+    month,
+    year,
+    serviceReports,
+    dayPlans,
+    recurringPlans,
+    publisher: role,
+    creditLimit: {
+      enabled: overrideCreditLimit,
+      customLimitHours: customCreditLimitHours,
+    },
+  })
+  const monthPlannedMinutes = calculateMonthlyPlannedMinutesOptimized(
+    month,
+    year,
+    dayPlans,
+    recurringPlans
+  )
+  const goalMinutes = Math.round(effectiveGoalHours * 60)
+  const plannedPercent =
+    goalMinutes > 0 ? Math.round((monthPlannedMinutes / goalMinutes) * 100) : 0
+  const goalProgress =
+    goalMinutes > 0 ? Math.max(0, monthPlannedMinutes / goalMinutes) : 0
+  const leftToPlanMinutes = Math.max(0, goalMinutes - monthPlannedMinutes)
+  const statusProgress =
+    status.plannedMinutes > 0
+      ? Math.max(0, status.actualMinutes / status.plannedMinutes)
+      : status.actualMinutes > 0
+        ? 1
+        : 0
+
+  const actualDisplay = useFormattedMinutes(status.actualMinutes)
+  const pacePlannedDisplay = useFormattedMinutes(status.plannedMinutes)
+  const differenceDisplay = useFormattedMinutes(
+    Math.abs(status.differenceMinutes)
+  )
+  const monthPlannedDisplay = useFormattedMinutes(monthPlannedMinutes)
+  const goalDisplay = useFormattedMinutes(goalMinutes)
+  const leftToPlanDisplay = useFormattedMinutes(leftToPlanMinutes)
+  const isCurrentMonth = moment({ year, month }).isSame(moment(), 'month')
+
+  const statusColor = (() => {
+    switch (status.state) {
+      case 'ahead':
+      case 'onTrack':
+        return theme.colors.accent
+      case 'behind':
+        return theme.colors.warn
+      default:
+        return theme.colors.textAlt
+    }
+  })()
+  const statusIcon: AppIcon = (() => {
+    switch (status.state) {
+      case 'ahead':
+        return TrendingUpIcon
+      case 'behind':
+        return TrendingDownIcon
+      case 'onTrack':
+        return CircleCheckIcon
+      default:
+        return CalendarClockIcon
+    }
+  })()
+  const statusTitle = i18n.t(STATUS_TITLE_KEYS[status.state])
+  const statusMeta = (() => {
+    switch (status.state) {
+      case 'ahead':
+        return `+${differenceDisplay.formatted}`
+      case 'behind':
+        return `-${differenceDisplay.formatted}`
+      case 'onTrack':
+        return i18n.t('scheduleStatus.matched')
+      case 'noPlan':
+        return i18n.t('scheduleStatus.noPlannedTime')
+      case 'notStarted':
+        return i18n.t('scheduleStatus.notStarted')
+    }
+  })()
+
+  const openDetail = (kind: InsightKind) => {
+    const ref = kind === 'pace' ? paceRef : goalRef
+    ref.current?.measureInWindow((x, y, width, height) => {
+      setOrigin({ x, y, width, height })
+      setDetailKind(kind)
+      setDetailOpen(true)
+    })
+  }
+
+  const cards = [
+    {
+      kind: 'pace' as const,
+      ref: paceRef,
+      icon: statusIcon,
+      color: statusColor,
+      tint: theme.colors.backgroundLighter,
+      value: statusTitle,
+      label: statusMeta,
+    },
+    {
+      kind: 'goal' as const,
+      ref: goalRef,
+      icon: CalendarRangeIcon,
+      color: theme.colors.text,
+      iconColor: theme.colors.textAlt,
+      tint: theme.colors.backgroundLighter,
+      value: i18n.t('scheduleInsights.percentPlanned', {
+        percent: plannedPercent,
+      }),
+      label: i18n.t('scheduleInsights.ofGoal', {
+        goal: goalDisplay.formatted,
+      }),
+    },
+  ]
+
+  return (
+    <>
+      <View style={{ flexDirection: 'row', gap: 10 }}>
+        {cards.map((card) => (
+          <View
+            key={card.kind}
+            ref={card.ref}
+            collapsable={false}
+            accessible
+            accessibilityRole='button'
+            accessibilityLabel={`${card.value}. ${card.label}`}
+            accessibilityHint={i18n.t('scheduleInsights.tapForDetails')}
+            onAccessibilityTap={() => openDetail(card.kind)}
+            style={{ flex: 1 }}
+          >
+            <TiltableCard onTap={() => openDetail(card.kind)} maxTilt={5}>
+              <Card
+                style={{
+                  minHeight: 102,
+                  padding: 12,
+                  gap: 10,
+                  borderWidth: 1,
+                  borderColor: theme.colors.border,
+                }}
+              >
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <View
+                    style={{
+                      width: 30,
+                      height: 30,
+                      borderRadius: 15,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: card.tint,
+                    }}
+                  >
+                    <LucideIcon
+                      icon={card.icon}
+                      color={'iconColor' in card ? card.iconColor : card.color}
+                      size={16}
+                    />
+                  </View>
+                  <LucideIcon
+                    icon={ChevronRightIcon}
+                    color={theme.colors.textAlt}
+                    size={12}
+                  />
+                </View>
+                <View style={{ gap: 1 }}>
+                  <Text
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    style={{
+                      color: card.color,
+                      fontFamily: theme.fonts.bold,
+                      fontSize: theme.fontSize('lg'),
+                    }}
+                  >
+                    {card.value}
+                  </Text>
+                  <Text
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    style={{
+                      color: theme.colors.textAlt,
+                      fontFamily: theme.fonts.semiBold,
+                      fontSize: theme.fontSize('sm'),
+                    }}
+                  >
+                    {card.label}
+                  </Text>
+                </View>
+              </Card>
+            </TiltableCard>
+          </View>
+        ))}
+      </View>
+
+      <ScheduleInsightOverlay
+        origin={origin}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        kind={detailKind}
+        statusTitle={statusTitle}
+        statusMeta={statusMeta}
+        statusIcon={statusIcon}
+        statusColor={statusColor}
+        statusProgress={statusProgress}
+        actual={actualDisplay.formatted}
+        pacePlanned={pacePlannedDisplay.formatted}
+        plannedPercent={plannedPercent}
+        monthPlanned={monthPlannedDisplay.formatted}
+        goal={goalDisplay.formatted}
+        leftToPlan={leftToPlanDisplay.formatted}
+        goalProgress={goalProgress}
+        isCurrentMonth={isCurrentMonth}
+        onEditGoal={onEditGoal}
+      />
+    </>
+  )
+}
+
+export default ScheduleInsights

--- a/src/features/plans/screens/ScheduleScreen.tsx
+++ b/src/features/plans/screens/ScheduleScreen.tsx
@@ -1,10 +1,6 @@
 import {
   ArrowLeft as ArrowLeftIcon,
   ArrowRight as ArrowRightIcon,
-  CalendarClock as CalendarClockIcon,
-  CircleCheck as CircleCheckIcon,
-  TrendingDown as TrendingDownIcon,
-  TrendingUp as TrendingUpIcon,
 } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { View } from 'react-native'
@@ -18,7 +14,6 @@ import { useNavigation as useRootNavigation } from '@react-navigation/native'
 import moment from 'moment'
 
 import useServiceReport from '@/stores/serviceReport'
-import { usePreferences } from '@/stores/preferences'
 import useTheme from '@/contexts/theme'
 import { getMonthsReports } from '@/lib/serviceReport'
 import {
@@ -29,11 +24,6 @@ import {
 import { getPeriodTense } from '@/lib/projectedTotalCopy'
 import usePublisher from '@/hooks/usePublisher'
 import useProjectedTotal from '@/hooks/useProjectedTotal'
-import { useFormattedMinutes } from '@/lib/minutes'
-import {
-  getScheduleStatusForMonth,
-  type ScheduleStatusState,
-} from '@/lib/scheduleStatus'
 import { getStartTimeInMinutes } from '@/lib/normalizeDate'
 import { RootStackNavigation } from '@/types/rootStack'
 import { HomeTabStackParamList } from '@/types/homeStack'
@@ -51,13 +41,14 @@ import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import ActionButton from '@/components/ui/ActionButton'
 import IconButton from '@/components/ui/IconButton'
-import LucideIcon from '@/components/ui/LucideIcon'
 import Text from '@/components/ui/MyText'
 import XView from '@/components/ui/layout/XView'
-import SimpleProgressBar from '@/components/ui/SimpleProgressBar'
 import PlanRow from '@/components/PlanRow'
 import type { PlanListItem } from '@/components/PlanRow'
-import i18n, { type TranslationKey } from '@/lib/locales'
+import i18n from '@/lib/locales'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import MonthGoalEditorSheet from '@/features/service-reports/components/MonthGoalEditorSheet'
+import ScheduleInsights from '@/features/plans/components/ScheduleInsights'
 
 type Props = BottomTabScreenProps<HomeTabStackParamList, 'Schedule'>
 
@@ -74,6 +65,7 @@ const ScheduleScreen = ({ route }: Props) => {
   const [calendarViewMode, setCalendarViewMode] =
     useState<CalendarViewMode>('planned')
   const [showPastPlans, setShowPastPlans] = useState(false)
+  const [goalEditorOpen, setGoalEditorOpen] = useState(false)
   const [selectedDateSheet, setSelectedDateSheet] =
     useState<SelectedDateSheetState>({
       open: false,
@@ -86,6 +78,14 @@ const ScheduleScreen = ({ route }: Props) => {
     [month, year]
   )
   const isCurrentMonth = month === moment().month() && year === moment().year()
+  const isPastMonth = selectedMonth.isBefore(moment(), 'month')
+  const {
+    baseGoalHours,
+    effectiveGoalHours,
+    setOverride: setMonthlyGoalOverride,
+    clearOverride: clearMonthlyGoalOverride,
+  } = useMonthlyGoal({ month, year })
+  const { annualGoalHours, hasAnnualGoal } = usePublisher()
 
   const thisMonthsReports = useMemo(
     () => getMonthsReports(serviceReports, month, year),
@@ -336,7 +336,15 @@ const ScheduleScreen = ({ route }: Props) => {
               </Text>
             </Button>
           )}
-          <ScheduleStatusCard month={month} year={year} />
+          <ScheduleInsights
+            month={month}
+            year={year}
+            onEditGoal={
+              baseGoalHours > 0 && !isPastMonth
+                ? () => setGoalEditorOpen(true)
+                : undefined
+            }
+          />
           <Card>
             <CalendarHeader
               viewMode={calendarViewMode}
@@ -426,6 +434,19 @@ const ScheduleScreen = ({ route }: Props) => {
         onNavigateToRecurringPlan={handleNavigateToRecurringPlan}
         onEditTimeReport={handleEditTimeReport}
       />
+      {baseGoalHours > 0 && !isPastMonth ? (
+        <MonthGoalEditorSheet
+          open={goalEditorOpen}
+          onOpenChange={setGoalEditorOpen}
+          month={month}
+          year={year}
+          regularGoalHours={baseGoalHours}
+          effectiveGoalHours={effectiveGoalHours}
+          annualGoalHours={hasAnnualGoal ? annualGoalHours : null}
+          onSaveGoal={setMonthlyGoalOverride}
+          onUseRegularGoal={clearMonthlyGoalOverride}
+        />
+      ) : null}
     </View>
   )
 }
@@ -438,175 +459,6 @@ const navButtonStyle = (theme: ReturnType<typeof useTheme>) => ({
   paddingVertical: 5,
 })
 
-const STATUS_TITLE_KEYS: Record<ScheduleStatusState, TranslationKey> = {
-  ahead: 'scheduleStatus.ahead',
-  behind: 'scheduleStatus.behind',
-  onTrack: 'scheduleStatus.onTrack',
-  noPlan: 'scheduleStatus.noPlan',
-  notStarted: 'scheduleStatus.upcoming',
-}
-
-const ScheduleStatusCard = (props: { month: number; year: number }) => {
-  const { month, year } = props
-  const theme = useTheme()
-  const serviceReports = useServiceReport((s) => s.serviceReports)
-  const dayPlans = useServiceReport((s) => s.dayPlans)
-  const recurringPlans = useServiceReport((s) => s.recurringPlans)
-  const { role, overrideCreditLimit, customCreditLimitHours } = usePreferences()
-
-  const status = getScheduleStatusForMonth({
-    month,
-    year,
-    serviceReports,
-    dayPlans,
-    recurringPlans,
-    publisher: role,
-    creditLimit: {
-      enabled: overrideCreditLimit,
-      customLimitHours: customCreditLimitHours,
-    },
-  })
-
-  const actualDisplay = useFormattedMinutes(status.actualMinutes)
-  const plannedDisplay = useFormattedMinutes(status.plannedMinutes)
-  const differenceDisplay = useFormattedMinutes(
-    Math.abs(status.differenceMinutes)
-  )
-
-  const statusColor = (() => {
-    switch (status.state) {
-      case 'ahead':
-      case 'onTrack':
-        return theme.colors.accent
-      case 'behind':
-        return theme.colors.warn
-      default:
-        return theme.colors.textAlt
-    }
-  })()
-  const iconBackground = (() => {
-    switch (status.state) {
-      case 'ahead':
-      case 'onTrack':
-        return theme.colors.accentTranslucent
-      case 'behind':
-        return theme.colors.warnTranslucent
-      default:
-        return theme.colors.backgroundLighter
-    }
-  })()
-  const StatusIcon = (() => {
-    switch (status.state) {
-      case 'ahead':
-        return TrendingUpIcon
-      case 'behind':
-        return TrendingDownIcon
-      case 'onTrack':
-        return CircleCheckIcon
-      default:
-        return CalendarClockIcon
-    }
-  })()
-  const statusMeta = (() => {
-    switch (status.state) {
-      case 'ahead':
-        return `+${differenceDisplay.formatted}`
-      case 'behind':
-        return `-${differenceDisplay.formatted}`
-      case 'onTrack':
-        return i18n.t('scheduleStatus.matched')
-      case 'noPlan':
-        return i18n.t('scheduleStatus.noPlannedTime')
-      case 'notStarted':
-        return i18n.t('scheduleStatus.notStarted')
-    }
-  })()
-  const progress =
-    status.plannedMinutes > 0
-      ? Math.max(0, status.actualMinutes / status.plannedMinutes)
-      : status.actualMinutes > 0
-        ? 1
-        : 0
-
-  return (
-    <Card style={{ gap: 12 }}>
-      <XView style={{ alignItems: 'center', gap: 12 }}>
-        <View
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: iconBackground,
-          }}
-        >
-          <LucideIcon icon={StatusIcon} color={statusColor} size={22} />
-        </View>
-        <View style={{ flex: 1, gap: 2 }}>
-          <Text
-            style={{
-              fontFamily: theme.fonts.bold,
-              fontSize: theme.fontSize('xl'),
-              color: statusColor,
-            }}
-          >
-            {i18n.t(STATUS_TITLE_KEYS[status.state])}
-          </Text>
-          <Text
-            style={{
-              color: theme.colors.textAlt,
-              fontFamily: theme.fonts.semiBold,
-            }}
-          >
-            {statusMeta}
-          </Text>
-        </View>
-      </XView>
-
-      <SimpleProgressBar
-        percentage={progress}
-        color={statusColor}
-        height={10}
-        animated={false}
-      />
-
-      <XView style={{ justifyContent: 'space-between', gap: 12 }}>
-        <View style={{ flex: 1, gap: 2 }}>
-          <Text
-            style={{
-              color: theme.colors.textAlt,
-              fontSize: theme.fontSize('xs'),
-              textTransform: 'uppercase',
-              letterSpacing: 0.5,
-            }}
-          >
-            {i18n.t('actual')}
-          </Text>
-          <Text style={{ fontFamily: theme.fonts.semiBold }}>
-            {actualDisplay.formatted}
-          </Text>
-        </View>
-        <View style={{ flex: 1, gap: 2, alignItems: 'flex-end' }}>
-          <Text
-            style={{
-              color: theme.colors.textAlt,
-              fontSize: theme.fontSize('xs'),
-              textTransform: 'uppercase',
-              letterSpacing: 0.5,
-            }}
-          >
-            {i18n.t('planned')}
-          </Text>
-          <Text style={{ fontFamily: theme.fonts.semiBold }}>
-            {plannedDisplay.formatted}
-          </Text>
-        </View>
-      </XView>
-    </Card>
-  )
-}
-
 const MonthAssistantCard = ({
   month,
   year,
@@ -614,7 +466,10 @@ const MonthAssistantCard = ({
   month: number
   year: number
 }) => {
-  const { monthlyGoalHours } = usePublisher()
+  const { effectiveGoalHours: monthlyGoalHours } = useMonthlyGoal({
+    month,
+    year,
+  })
 
   const { projection, today } = useProjectedTotal(
     { kind: 'month', month, year },

--- a/src/features/profile/components/ProfileCard.tsx
+++ b/src/features/profile/components/ProfileCard.tsx
@@ -17,7 +17,7 @@ import useIsSupporter from '@/hooks/useIsSupporter'
 import Card from '@/components/ui/Card'
 import Text from '@/components/ui/MyText'
 import Avatar from '@/components/ui/Avatar'
-import TiltableCard from '@/features/profile/components/TiltableCard'
+import TiltableCard from '@/components/TiltableCard'
 import ProfileDetailOverlay, {
   OriginRect,
 } from '@/features/profile/components/ProfileDetailOverlay'

--- a/src/features/progress/components/ProgressMonthTab.tsx
+++ b/src/features/progress/components/ProgressMonthTab.tsx
@@ -66,6 +66,7 @@ const ProgressMonthTab = ({
             monthsReports={thisMonthsReports}
             showReportButton
             hideTitle
+            allowGoalEditing
           />
           <ProjectedTotalCard scope={scope} />
         </View>

--- a/src/features/progress/components/ProgressYearTab.tsx
+++ b/src/features/progress/components/ProgressYearTab.tsx
@@ -24,6 +24,7 @@ import Text from '@/components/ui/MyText'
 import LucideIcon from '@/components/ui/LucideIcon'
 import XView from '@/components/ui/layout/XView'
 import { useCardStyle } from '@/components/ui/Card'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
 
 interface ProgressYearTabProps {
   /** End year of the service year (Sep 1 of `year - 1` → Aug 31 of `year`). */
@@ -79,13 +80,15 @@ const MonthRow = ({
 }) => {
   const theme = useTheme()
   const cardStyle = useCardStyle()
-  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
-    usePreferences()
+  const { role, overrideCreditLimit, customCreditLimitHours } = usePreferences()
   const serviceReports = useServiceReport((s) => s.serviceReports)
   const dayPlans = useServiceReport((s) => s.dayPlans)
   const recurringPlans = useServiceReport((s) => s.recurringPlans)
 
-  const goalHours = publisherHours[role]
+  const { effectiveGoalHours: goalHours, isOverridden } = useMonthlyGoal({
+    month,
+    year,
+  })
 
   const monthsReports = useMemo(
     () => getMonthsReports(serviceReports, month, year),
@@ -123,6 +126,7 @@ const MonthRow = ({
   const completedDisplay = useFormattedMinutes(completedMinutes)
   const plannedDisplay = useFormattedMinutes(plannedMinutes)
   const goalMinutes = Math.round(goalHours * 60)
+  const goalDisplay = useFormattedMinutes(goalMinutes)
   const deltaMinutes = completedMinutes - goalMinutes
   const deltaDisplay = useFormattedMinutes(Math.abs(deltaMinutes))
 
@@ -160,19 +164,44 @@ const MonthRow = ({
       })}
     >
       <XView style={{ justifyContent: 'space-between', gap: 12 }}>
-        <XView style={{ gap: 8, flexShrink: 1 }}>
-          <Text
-            style={{
-              fontFamily: theme.fonts.semiBold,
-              fontSize: theme.fontSize('md'),
-              color: theme.colors.text,
-              minWidth: 44,
-            }}
-          >
-            {monthYearLabel}
-          </Text>
-          {isCurrent ? <CurrentMonthIcon /> : null}
-        </XView>
+        <View style={{ gap: 4, flexShrink: 1 }}>
+          <XView style={{ gap: 8 }}>
+            <Text
+              style={{
+                fontFamily: theme.fonts.semiBold,
+                fontSize: theme.fontSize('md'),
+                color: theme.colors.text,
+                minWidth: 44,
+              }}
+            >
+              {monthYearLabel}
+            </Text>
+            {isCurrent ? <CurrentMonthIcon /> : null}
+          </XView>
+          {isOverridden ? (
+            <View
+              style={{
+                alignSelf: 'flex-start',
+                paddingHorizontal: 6,
+                paddingVertical: 2,
+                borderRadius: theme.numbers.borderRadiusSm,
+                backgroundColor: theme.colors.accentTranslucent,
+              }}
+            >
+              <Text
+                style={{
+                  color: theme.colors.accent,
+                  fontFamily: theme.fonts.semiBold,
+                  fontSize: theme.fontSize('xs'),
+                }}
+              >
+                {i18n.t('monthGoalEditor.goalBadge', {
+                  goal: goalDisplay.formatted,
+                })}
+              </Text>
+            </View>
+          ) : null}
+        </View>
         <XView style={{ gap: 12 }}>
           <Text
             style={{
@@ -238,10 +267,7 @@ const ProgressYearTab = ({
     return list
   }, [year])
 
-  const { hasAnnualGoal } = usePublisher()
-
-  const { role, publisherHours } = usePreferences()
-  const monthlyGoalHours = publisherHours[role]
+  const { hasAnnualGoal, monthlyGoalHours } = usePublisher()
   const showDeltaColumn = monthlyGoalHours > 0
 
   // Stable reference so ProjectedTotalCard's memoized derivations don't

--- a/src/features/service-reports/components/GoalProgressStats.tsx
+++ b/src/features/service-reports/components/GoalProgressStats.tsx
@@ -41,6 +41,8 @@ type GoalProgressStatsProps = {
    * its View Report affordance without owning a duplicate row.
    */
   headerRightSlot?: ReactNode
+  /** Suppress the plain goal suffix when the parent renders an editable goal. */
+  hideGoalLabel?: boolean
 }
 
 const tierCopyKey = (tier: AchievementTier) => {
@@ -66,6 +68,7 @@ const GoalProgressStats = ({
   achievementTier,
   sealAnimatedStyle,
   headerRightSlot,
+  hideGoalLabel = false,
 }: GoalProgressStatsProps) => {
   const theme = useTheme()
   const { timeDisplayFormat } = usePreferences()
@@ -121,10 +124,10 @@ const GoalProgressStats = ({
   } else if (periodState === 'current') {
     pillText = `${remainingDisplay.formatted} ${i18n.t('hoursLeft')}`
     if (remainingLabel) trailingParts.push(remainingLabel)
-    trailingParts.push(goalSuffix)
+    if (!hideGoalLabel) trailingParts.push(goalSuffix)
   } else if (periodState === 'past') {
     pillText = i18n.t('hrsShort', { value: remainingDisplay.formatted })
-    trailingParts.push(goalSuffix)
+    if (!hideGoalLabel) trailingParts.push(goalSuffix)
   } else if (periodState === 'future' && totalLabel) {
     trailingParts.push(totalLabel)
   }

--- a/src/features/service-reports/components/HourEntryCard.tsx
+++ b/src/features/service-reports/components/HourEntryCard.tsx
@@ -18,12 +18,12 @@ import Text from '@/components/ui/MyText'
 import { formatMinutes } from '@/lib/minutes'
 import { RootStackNavigation } from '@/types/rootStack'
 import { HomeTabStackNavigation } from '@/types/homeStack'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
 
 export default function HourEntryCard() {
   const theme = useTheme()
   const {
     role,
-    publisherHours,
     displayDetailsOnProgressBarHomeScreen,
     timeDisplayFormat,
     overrideCreditLimit,
@@ -33,7 +33,11 @@ export default function HourEntryCard() {
   const navigation = useNavigation<
     HomeTabStackNavigation & RootStackNavigation
   >()
-  const goalHours = publisherHours[role]
+  const now = moment()
+  const { effectiveGoalHours: goalHours, isOverridden } = useMonthlyGoal({
+    month: now.month(),
+    year: now.year(),
+  })
   const monthReports = useMemo(
     () => getMonthsReports(serviceReports, moment().month(), moment().year()),
     [serviceReports]
@@ -276,7 +280,11 @@ export default function HourEntryCard() {
                     textAlign: 'center',
                   }}
                 >
-                  {i18n.t('goalBasedOnPublisherType')}
+                  {i18n.t(
+                    isOverridden
+                      ? 'goalAdjustedForMonth'
+                      : 'goalBasedOnPublisherType'
+                  )}
                 </Text>
               </View>
             ) : null}

--- a/src/features/service-reports/components/MonthGoalButton.tsx
+++ b/src/features/service-reports/components/MonthGoalButton.tsx
@@ -1,0 +1,62 @@
+import { ViewStyle } from 'react-native'
+
+import Button from '@/components/ui/Button'
+import Text from '@/components/ui/MyText'
+import useTheme from '@/contexts/theme'
+import i18n from '@/lib/locales'
+import { useFormattedMinutes } from '@/lib/minutes'
+
+type Props = {
+  goalHours: number
+  isOverridden?: boolean
+  onPress: () => void
+  style?: ViewStyle
+}
+
+const MonthGoalButton = ({
+  goalHours,
+  isOverridden = false,
+  onPress,
+  style,
+}: Props) => {
+  const theme = useTheme()
+  const goalDisplay = useFormattedMinutes(Math.round(goalHours * 60))
+  const label = i18n.t('projectedTotal.legend.goal', {
+    value: goalDisplay.formatted,
+  })
+
+  return (
+    <Button
+      noTransform
+      accessibilityRole='button'
+      accessibilityLabel={i18n.t('monthGoalEditor.editAccessibility', {
+        goal: goalDisplay.formatted,
+      })}
+      onPress={onPress}
+      style={{
+        alignSelf: 'flex-start',
+        borderWidth: 1,
+        borderColor: isOverridden ? theme.colors.accent : theme.colors.border,
+        borderRadius: theme.numbers.borderRadiusSm,
+        backgroundColor: isOverridden
+          ? theme.colors.accentTranslucent
+          : 'transparent',
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        ...style,
+      }}
+    >
+      <Text
+        style={{
+          color: isOverridden ? theme.colors.accent : theme.colors.textAlt,
+          fontFamily: theme.fonts.semiBold,
+          fontSize: theme.fontSize('sm'),
+        }}
+      >
+        {label} ›
+      </Text>
+    </Button>
+  )
+}
+
+export default MonthGoalButton

--- a/src/features/service-reports/components/MonthGoalEditorSheet.tsx
+++ b/src/features/service-reports/components/MonthGoalEditorSheet.tsx
@@ -1,0 +1,292 @@
+import moment from 'moment'
+import { useEffect, useRef, useState } from 'react'
+import { Pressable, TextInput as RNTextInput, View } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import { Sheet } from 'tamagui'
+
+import ActionButton from '@/components/ui/ActionButton'
+import Button from '@/components/ui/Button'
+import Text from '@/components/ui/MyText'
+import TextInput from '@/components/ui/TextInput'
+import useTheme from '@/contexts/theme'
+import i18n from '@/lib/locales'
+import { useFormattedMinutes } from '@/lib/minutes'
+
+export interface MonthGoalEditorSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Zero-based calendar month, matching Moment and JavaScript Date. */
+  month: number
+  year: number
+  regularGoalHours: number
+  effectiveGoalHours: number
+  annualGoalHours: number | null
+  onSaveGoal: (goalHours: number) => void
+  onUseRegularGoal: () => void
+}
+
+const normalizeDecimalInput = (value: string): string => {
+  const normalized = value.replace(',', '.').replace(/[^0-9.]/g, '')
+  const [whole = '', ...decimalParts] = normalized.split('.')
+
+  if (decimalParts.length === 0) return whole
+
+  return `${whole}.${decimalParts.join('').slice(0, 2)}`
+}
+
+const MonthGoalEditorSheet = ({
+  open,
+  onOpenChange,
+  month,
+  year,
+  regularGoalHours,
+  effectiveGoalHours,
+  annualGoalHours,
+  onSaveGoal,
+  onUseRegularGoal,
+}: MonthGoalEditorSheetProps) => {
+  const theme = useTheme()
+  const inputRef = useRef<RNTextInput>(null)
+  const [draftGoal, setDraftGoal] = useState(String(effectiveGoalHours))
+  const [showValidationError, setShowValidationError] = useState(false)
+
+  const regularGoalDisplay = useFormattedMinutes(
+    Math.round(regularGoalHours * 60)
+  )
+  useEffect(() => {
+    if (!open) return
+    setDraftGoal(String(effectiveGoalHours))
+    setShowValidationError(false)
+  }, [effectiveGoalHours, open])
+
+  const parsedGoal = Number.parseFloat(draftGoal)
+  const hasValidGoal = Number.isFinite(parsedGoal) && parsedGoal >= 0
+  const hasOverride =
+    Math.abs(effectiveGoalHours - regularGoalHours) > Number.EPSILON
+  const monthLabel = moment({ year, month }).format('MMMM YYYY')
+
+  const handleSave = () => {
+    if (!hasValidGoal) {
+      setShowValidationError(true)
+      inputRef.current?.focus()
+      return
+    }
+
+    onSaveGoal(parsedGoal)
+    onOpenChange(false)
+  }
+
+  const handleUseRegularGoal = () => {
+    onUseRegularGoal()
+    onOpenChange(false)
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissOnSnapToBottom
+      modal
+      moveOnKeyboardChange
+      snapPoints={[72]}
+    >
+      <Sheet.Handle />
+      <Sheet.Overlay zIndex={100_000 - 1} />
+      <Sheet.Frame backgroundColor={theme.colors.backgroundLighter}>
+        <KeyboardAwareScrollView
+          keyboardShouldPersistTaps='handled'
+          extraScrollHeight={20}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            paddingHorizontal: 24,
+            paddingTop: 22,
+            paddingBottom: 32,
+            gap: 20,
+          }}
+        >
+          <Text
+            accessibilityRole='header'
+            style={{
+              color: theme.colors.text,
+              fontFamily: theme.fonts.semiBold,
+              fontSize: theme.fontSize('xl'),
+            }}
+          >
+            {i18n.t('monthGoalEditor.title', { month: monthLabel })}
+          </Text>
+
+          <View
+            style={{
+              gap: 16,
+              padding: 16,
+              borderRadius: theme.numbers.borderRadiusMd,
+              backgroundColor: theme.colors.background,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 16,
+              }}
+            >
+              <Text
+                style={{
+                  color: theme.colors.textAlt,
+                  fontSize: theme.fontSize('sm'),
+                }}
+              >
+                {i18n.t('monthGoalEditor.regularGoal')}
+              </Text>
+              <Text
+                style={{
+                  color: theme.colors.text,
+                  fontFamily: theme.fonts.semiBold,
+                  fontSize: theme.fontSize('md'),
+                }}
+              >
+                {regularGoalDisplay.formatted}
+              </Text>
+            </View>
+
+            <View
+              style={{
+                height: 1,
+                backgroundColor: theme.colors.border,
+              }}
+            />
+
+            <View style={{ gap: 8 }}>
+              <Pressable
+                accessibilityRole='button'
+                accessibilityLabel={i18n.t('monthGoalEditor.monthGoal')}
+                accessibilityHint={i18n.t('monthGoalEditor.inputHint')}
+                hitSlop={{ top: 8, bottom: 8 }}
+                onPress={() => inputRef.current?.focus()}
+              >
+                <Text
+                  style={{
+                    color: theme.colors.text,
+                    fontFamily: theme.fonts.semiBold,
+                    fontSize: theme.fontSize('md'),
+                  }}
+                >
+                  {i18n.t('monthGoalEditor.monthGoal')}
+                </Text>
+              </Pressable>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 10,
+                }}
+              >
+                <TextInput
+                  ref={inputRef}
+                  accessibilityLabel={i18n.t('monthGoalEditor.monthGoal')}
+                  accessibilityHint={i18n.t('monthGoalEditor.inputHint')}
+                  value={draftGoal}
+                  onChangeText={(value) => {
+                    setDraftGoal(normalizeDecimalInput(value))
+                    setShowValidationError(false)
+                  }}
+                  onSubmitEditing={() => inputRef.current?.blur()}
+                  keyboardType='decimal-pad'
+                  returnKeyType='done'
+                  selectTextOnFocus
+                  maxLength={7}
+                  textAlign='left'
+                  style={{
+                    flex: 1,
+                    minHeight: 46,
+                    paddingHorizontal: 12,
+                    paddingVertical: 10,
+                    borderWidth: 1,
+                    borderColor: showValidationError
+                      ? theme.colors.error
+                      : theme.colors.border,
+                    borderRadius: theme.numbers.borderRadiusSm,
+                    color: theme.colors.text,
+                    fontFamily: theme.fonts.semiBold,
+                    fontSize: theme.fontSize('lg'),
+                    backgroundColor: theme.colors.backgroundLighter,
+                  }}
+                />
+                <Text
+                  style={{
+                    color: theme.colors.textAlt,
+                    fontSize: theme.fontSize('md'),
+                  }}
+                >
+                  {i18n.t('hours_lowercase')}
+                </Text>
+              </View>
+              {showValidationError && (
+                <Text
+                  accessibilityRole='alert'
+                  style={{
+                    color: theme.colors.error,
+                    fontSize: theme.fontSize('sm'),
+                  }}
+                >
+                  {i18n.t('monthGoalEditor.invalidGoal')}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          <Text
+            style={{
+              color: theme.colors.textAlt,
+              fontSize: theme.fontSize('sm'),
+              lineHeight: 20,
+            }}
+          >
+            {annualGoalHours === null
+              ? i18n.t('monthGoalEditor.explanationWithoutAnnualGoal', {
+                  month: monthLabel,
+                })
+              : i18n.t('monthGoalEditor.explanation', { month: monthLabel })}
+          </Text>
+
+          {hasOverride && (
+            <Button
+              noTransform
+              accessibilityRole='button'
+              onPress={handleUseRegularGoal}
+              variant='outline'
+              style={{
+                justifyContent: 'center',
+                paddingVertical: 12,
+              }}
+            >
+              <Text
+                style={{
+                  color: theme.colors.accent,
+                  fontFamily: theme.fonts.semiBold,
+                  fontSize: theme.fontSize('sm'),
+                }}
+              >
+                {i18n.t('monthGoalEditor.useRegularGoal', {
+                  goal: regularGoalDisplay.formatted,
+                })}
+              </Text>
+            </Button>
+          )}
+
+          <ActionButton
+            noTransform
+            accessibilityRole='button'
+            disabled={!hasValidGoal}
+            onPress={handleSave}
+          >
+            {i18n.t('save')}
+          </ActionButton>
+        </KeyboardAwareScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  )
+}
+
+export default MonthGoalEditorSheet

--- a/src/features/service-reports/components/MonthReport.tsx
+++ b/src/features/service-reports/components/MonthReport.tsx
@@ -19,7 +19,7 @@ import {
 import { plannedMinutesToCurrentDayForMonth } from '@/lib/recurrence'
 import useServiceReport from '@/stores/serviceReport'
 import useCategories from '@/stores/categories'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useTheme from '@/contexts/theme'
 import { TimeEntry } from '@/types/timeEntry'
 import { CategorySegment } from '@/features/service-reports/components/CategorySegmentBar'
@@ -62,6 +62,10 @@ import {
 import useFireworks from '@/hooks/useFireworks'
 import { FIREWORKS_AFTER_LOTTIE_BUFFER_MS } from '@/providers/ConfettiProvider'
 import { formatMonthDayCompact } from '@/lib/dates'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import usePublisher from '@/hooks/usePublisher'
+import MonthGoalButton from '@/features/service-reports/components/MonthGoalButton'
+import MonthGoalEditorSheet from '@/features/service-reports/components/MonthGoalEditorSheet'
 
 interface MonthReportProps {
   monthsReports: TimeEntry[] | null
@@ -73,6 +77,8 @@ interface MonthReportProps {
   hideTitle?: boolean
   noDetails?: boolean
   highlightAsCurrentMonth?: boolean
+  /** Exposes the selected month's goal editor on the Progress Month screen. */
+  allowGoalEditing?: boolean
 }
 
 const MonthReport = ({
@@ -84,19 +90,27 @@ const MonthReport = ({
   hideTitle,
   noDetails,
   highlightAsCurrentMonth,
+  allowGoalEditing = false,
 }: MonthReportProps) => {
   const theme = useTheme()
   const {
     role,
-    publisherHours,
     overrideCreditLimit,
     customCreditLimitHours,
     celebratedTiers,
     markTierCelebrated,
     timeDisplayFormat,
   } = usePreferences()
+  const {
+    baseGoalHours,
+    effectiveGoalHours: goalHours,
+    isOverridden,
+    setOverride: setMonthlyGoalOverride,
+    clearOverride: clearMonthlyGoalOverride,
+  } = useMonthlyGoal({ month, year })
+  const { annualGoalHours, hasAnnualGoal } = usePublisher()
+  const [goalEditorOpen, setGoalEditorOpen] = useState(false)
   const { categories } = useCategories()
-  const goalHours = publisherHours[role]
   const navigation = useNavigation<RootStackNavigation>()
   const tabNavigation = useNavigation<HomeTabStackNavigation>()
   const rollover = useRollover()
@@ -125,6 +139,10 @@ const MonthReport = ({
   const { serviceReports, dayPlans, recurringPlans } = useServiceReport()
   const prevMonth = month === 0 ? 11 : month - 1
   const prevMonthYear = month === 0 ? year - 1 : year
+  const { effectiveGoalHours: previousMonthGoalHours } = useMonthlyGoal({
+    month: prevMonth,
+    year: prevMonthYear,
+  })
   const lastMonthMinutes = useMemo(() => {
     const reports = getMonthsReports(serviceReports, prevMonth, prevMonthYear)
     if (!reports.length) return null
@@ -157,7 +175,7 @@ const MonthReport = ({
   const bothMonthsMetGoal =
     hasMetGoal &&
     lastMonthMinutes !== null &&
-    lastMonthMinutes / 60 >= goalHours
+    lastMonthMinutes / 60 >= previousMonthGoalHours
 
   // Pace vs plan — mirrors the widget's ahead/behind calc. Compares logged
   // (credit-capped) minutes against the sum of day + recurring plans up to
@@ -390,14 +408,31 @@ const MonthReport = ({
     return (
       <View>
         <Card>
-          <Text
+          <View
             style={{
-              fontSize: theme.fontSize('xl'),
-              fontFamily: theme.fonts.bold,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
             }}
           >
-            {i18n.t('noTimeReports')}
-          </Text>
+            <Text
+              style={{
+                flex: 1,
+                fontSize: theme.fontSize('xl'),
+                fontFamily: theme.fonts.bold,
+              }}
+            >
+              {i18n.t('noTimeReports')}
+            </Text>
+            {allowGoalEditing && baseGoalHours > 0 ? (
+              <MonthGoalButton
+                goalHours={goalHours}
+                isOverridden={isOverridden}
+                onPress={() => setGoalEditorOpen(true)}
+              />
+            ) : null}
+          </View>
           <Text
             style={{
               fontSize: theme.fontSize('sm'),
@@ -428,6 +463,19 @@ const MonthReport = ({
             </ActionButton>
           )}
         </Card>
+        {allowGoalEditing && baseGoalHours > 0 ? (
+          <MonthGoalEditorSheet
+            open={goalEditorOpen}
+            onOpenChange={setGoalEditorOpen}
+            month={month}
+            year={year}
+            regularGoalHours={baseGoalHours}
+            effectiveGoalHours={goalHours}
+            annualGoalHours={hasAnnualGoal ? annualGoalHours : null}
+            onSaveGoal={setMonthlyGoalOverride}
+            onUseRegularGoal={clearMonthlyGoalOverride}
+          />
+        ) : null}
       </View>
     )
   }
@@ -477,6 +525,26 @@ const MonthReport = ({
             </View>
           )}
 
+          {allowGoalEditing && baseGoalHours > 0 ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 8,
+              }}
+            >
+              <MonthGoalButton
+                goalHours={goalHours}
+                isOverridden={isOverridden}
+                onPress={() => setGoalEditorOpen(true)}
+              />
+              {hideTitle && showReportButton ? (
+                <ViewReportButton month={month} year={year} />
+              ) : null}
+            </View>
+          ) : null}
+
           {/* Hero + secondary line. When the parent suppressed the title row
             the report-export affordance is passed into GoalProgressStats'
             header slot so it sits to the right of the tier badge (or alone
@@ -493,8 +561,9 @@ const MonthReport = ({
               totalLabel={`${daysInMonth} ${i18n.t('days_lowercase')}`}
               achievementTier={celebratingTier}
               sealAnimatedStyle={sealAnimatedStyle}
+              hideGoalLabel={allowGoalEditing}
               headerRightSlot={
-                hideTitle && showReportButton ? (
+                !allowGoalEditing && hideTitle && showReportButton ? (
                   <ViewReportButton month={month} year={year} />
                 ) : undefined
               }
@@ -706,6 +775,20 @@ const MonthReport = ({
             </Text>
           </View>
         )}
+
+      {allowGoalEditing && baseGoalHours > 0 ? (
+        <MonthGoalEditorSheet
+          open={goalEditorOpen}
+          onOpenChange={setGoalEditorOpen}
+          month={month}
+          year={year}
+          regularGoalHours={baseGoalHours}
+          effectiveGoalHours={goalHours}
+          annualGoalHours={hasAnnualGoal ? annualGoalHours : null}
+          onSaveGoal={setMonthlyGoalOverride}
+          onUseRegularGoal={clearMonthlyGoalOverride}
+        />
+      ) : null}
     </View>
   )
 }

--- a/src/features/service-reports/components/MonthServiceReportProgressBar.tsx
+++ b/src/features/service-reports/components/MonthServiceReportProgressBar.tsx
@@ -13,6 +13,7 @@ import { goalProgress } from '@/lib/goalProgress'
 import Text from '@/components/ui/MyText'
 import i18n from '@/lib/locales'
 import Circle from '@/components/ui/Circle'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
 
 interface ProgressBarSegmentBaseProps extends ViewProps {
   borderRadiusLeft?: boolean
@@ -136,8 +137,8 @@ const MonthServiceReportProgressBar = ({
   const theme = useTheme()
   const { serviceReports } = useServiceReport()
   const { categories } = useCategories()
-  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
-    usePreferences()
+  const { role, overrideCreditLimit, customCreditLimitHours } = usePreferences()
+  const { effectiveGoalHours: goalHours } = useMonthlyGoal({ month, year })
 
   // Animation setup
   const pulseAnimation = useRef(new Animated.Value(0)).current
@@ -147,8 +148,6 @@ const MonthServiceReportProgressBar = ({
     () => getMonthsReports(serviceReports, month, year),
     [month, serviceReports, year]
   )
-  const goalHours = publisherHours[role]
-
   const adjustedMinutes = useMemo(
     () =>
       adjustedMinutesForSpecificMonth(monthReports, month, year, role, {

--- a/src/features/service-reports/lib/monthlyGoalCelebration.ts
+++ b/src/features/service-reports/lib/monthlyGoalCelebration.ts
@@ -1,0 +1,35 @@
+import {
+  resolveMonthlyGoalHours,
+  type CalendarMonth,
+  type MonthlyGoalOverrides,
+} from '@/lib/monthlyGoals'
+
+type MonthlyGoalCrossing = {
+  beforeMinutes: number
+  afterMinutes: number
+  baseGoalHours: number
+  monthlyGoalOverrides: MonthlyGoalOverrides
+  target: CalendarMonth
+}
+
+/**
+ * True only for the transition from below to at-or-above the target month's
+ * goal.
+ */
+export const didCrossMonthlyGoal = ({
+  beforeMinutes,
+  afterMinutes,
+  baseGoalHours,
+  monthlyGoalOverrides,
+  target,
+}: MonthlyGoalCrossing): boolean => {
+  const goalHours = resolveMonthlyGoalHours(
+    baseGoalHours,
+    monthlyGoalOverrides,
+    target
+  )
+  if (goalHours <= 0) return false
+
+  const goalMinutes = goalHours * 60
+  return beforeMinutes < goalMinutes && afterMinutes >= goalMinutes
+}

--- a/src/features/service-reports/screens/AddTimeScreen.tsx
+++ b/src/features/service-reports/screens/AddTimeScreen.tsx
@@ -40,6 +40,8 @@ import { RootStackNavigation, RootStackParamList } from '@/types/rootStack'
 import Haptics from '@/lib/haptics'
 import { CONFETTI_DELAY_MS } from '@/providers/AnimationViewProvider'
 import useCelebrationQueue from '@/features/service-reports/stores/celebrationQueue'
+import { didCrossMonthlyGoal } from '@/features/service-reports/lib/monthlyGoalCelebration'
+import { resolveMonthlyGoalHours } from '@/lib/monthlyGoals'
 
 type AddTimeScreenProps = NativeStackScreenProps<RootStackParamList, 'Add Time'>
 
@@ -48,8 +50,13 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
   const insets = useSafeAreaInsets()
   const navigation = useNavigation<RootStackNavigation>()
   const noteInput = useRef<RNTextInput>(null)
-  const { role, publisherHours, overrideCreditLimit, customCreditLimitHours } =
-    usePreferences()
+  const {
+    role,
+    publisherHours,
+    monthlyGoalOverrides,
+    overrideCreditLimit,
+    customCreditLimitHours,
+  } = usePreferences()
   const { playConfetti } = useAnimation()
   const { categories } = useCategories()
 
@@ -166,11 +173,16 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
     // queue anything, so the fireworks don't fire on every submission. The
     // queue is keyed by `(month, year)` so it only pops when the user is
     // actually viewing the month they crossed.
-    const goalHours = publisherHours[role]
-    if (goalHours > 0) {
-      const reportMoment = moment(serviceReport.date)
-      const reportMonth = reportMoment.month()
-      const reportYear = reportMoment.year()
+    const reportMoment = moment(serviceReport.date)
+    const reportMonth = reportMoment.month()
+    const reportYear = reportMoment.year()
+    const goalTarget = { month: reportMonth, year: reportYear }
+    const effectiveGoalHours = resolveMonthlyGoalHours(
+      publisherHours[role],
+      monthlyGoalOverrides,
+      goalTarget
+    )
+    if (effectiveGoalHours > 0) {
       const creditOverride = {
         enabled: overrideCreditLimit,
         customLimitHours: customCreditLimitHours,
@@ -194,9 +206,13 @@ const AddTimeScreen = ({ route }: AddTimeScreenProps) => {
         role,
         creditOverride
       ).value
-      const goalMinutes = goalHours * 60
-      const crossedGoal =
-        beforeMinutes < goalMinutes && afterMinutes >= goalMinutes
+      const crossedGoal = didCrossMonthlyGoal({
+        beforeMinutes,
+        afterMinutes,
+        baseGoalHours: publisherHours[role],
+        monthlyGoalOverrides,
+        target: goalTarget,
+      })
       if (crossedGoal) {
         useCelebrationQueue.getState().queue(reportMonth, reportYear)
       }

--- a/src/hooks/useMonthlyGoal.ts
+++ b/src/hooks/useMonthlyGoal.ts
@@ -1,0 +1,52 @@
+import usePublisher from '@/hooks/usePublisher'
+import {
+  isValidMonthlyGoalHours,
+  monthlyGoalKey,
+  resolveMonthlyGoalHours,
+  type CalendarMonth,
+} from '@/lib/monthlyGoals'
+import { usePreferences } from '@/stores/preferences'
+
+export type MonthlyGoal = {
+  /** The regular, Publisher-derived Monthly Goal. */
+  baseGoalHours: number
+  /** The saved value for this month, or `undefined` when it uses the base. */
+  overrideGoalHours: number | undefined
+  /** The override when present, otherwise `baseGoalHours`. */
+  effectiveGoalHours: number
+  isOverridden: boolean
+  setOverride: (hours: number) => void
+  clearOverride: () => void
+}
+
+/**
+ * React-side Monthly Goal seam for one exact calendar month. `month` follows
+ * JavaScript/moment conventions (0 = January, 11 = December).
+ */
+const useMonthlyGoal = (target: CalendarMonth): MonthlyGoal => {
+  const { monthlyGoalHours: baseGoalHours } = usePublisher()
+  const {
+    monthlyGoalOverrides,
+    setMonthlyGoalOverride,
+    clearMonthlyGoalOverride,
+  } = usePreferences()
+  const savedOverride = monthlyGoalOverrides[monthlyGoalKey(target)]
+  const overrideGoalHours = isValidMonthlyGoalHours(savedOverride)
+    ? savedOverride
+    : undefined
+
+  return {
+    baseGoalHours,
+    overrideGoalHours,
+    effectiveGoalHours: resolveMonthlyGoalHours(
+      baseGoalHours,
+      monthlyGoalOverrides,
+      target
+    ),
+    isOverridden: overrideGoalHours !== undefined,
+    setOverride: (hours) => setMonthlyGoalOverride(target, hours),
+    clearOverride: () => clearMonthlyGoalOverride(target),
+  }
+}
+
+export default useMonthlyGoal

--- a/src/lib/assistantState.ts
+++ b/src/lib/assistantState.ts
@@ -6,6 +6,7 @@ import { isPlanCreditTime } from '@/lib/serviceReportCategory'
 
 export type RecommendationInputsHashInput = {
   loggedAdjustedMinutes: number
+  monthlyGoalMinutes: number
   dayPlanFingerprints: string[]
   recurringPlanFingerprints: string[]
   conversationDayKeys: string[]
@@ -63,6 +64,9 @@ export const recurringPlanFingerprint = (
  * states must produce the same hash regardless of array order — so we sort the
  * set-like fields before stringifying.
  *
+ * V3: includes the effective Monthly Goal so a one-month goal change re-arms a
+ * previously dismissed recommendation.
+ *
  * V2: plan fingerprints carry the plan's resolved credit-ness (Plan Type) —
  * re-typing a plan or flipping its Category's credit setting moves the
  * projection, so it must re-arm — plus the recurring pattern's recurrence,
@@ -72,8 +76,9 @@ export const computeRecommendationInputsHash = (
   input: RecommendationInputsHashInput
 ): string => {
   const parts: (string | number)[] = [
-    'v2',
+    'v3',
     input.loggedAdjustedMinutes,
+    input.monthlyGoalMinutes,
     input.dayPlanFingerprints.slice().sort().join('|'),
     input.recurringPlanFingerprints.slice().sort().join('|'),
     input.conversationDayKeys.slice().sort().join('|'),

--- a/src/lib/monthlyGoals.ts
+++ b/src/lib/monthlyGoals.ts
@@ -1,0 +1,98 @@
+/** A calendar month using JavaScript's zero-based month index (0 = January). */
+export type CalendarMonth = Readonly<{
+  year: number
+  month: number
+}>
+
+/**
+ * Per-calendar-month Monthly Goal overrides, keyed as `YYYY-MM`.
+ *
+ * The record is intentionally a single Preferences value: iCloud's per-key
+ * last-writer-wins merge treats the set of overrides as one piece of user
+ * intent, just like report comment overrides and achievement state.
+ */
+export type MonthlyGoalOverrides = Record<string, number>
+
+export const isValidMonthlyGoalHours = (hours: unknown): hours is number =>
+  typeof hours === 'number' && Number.isFinite(hours) && hours >= 0
+
+const MONTHLY_GOAL_KEY_PATTERN = /^(\d{4})-(0[1-9]|1[0-2])$/
+
+/** Filters imported/persisted override maps down to canonical keys and goals. */
+export const normalizeMonthlyGoalOverrides = (
+  value: unknown
+): MonthlyGoalOverrides => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+
+  const normalized: MonthlyGoalOverrides = {}
+  for (const [key, hours] of Object.entries(value)) {
+    if (MONTHLY_GOAL_KEY_PATTERN.test(key) && isValidMonthlyGoalHours(hours)) {
+      normalized[key] = hours
+    }
+  }
+  return normalized
+}
+
+const legacyMonthToKey = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    // Persisted Date values are ISO strings. Reading the written year/month
+    // avoids shifting a month when the payload crosses time zones.
+    const match = /^(\d{4})-(0[1-9]|1[0-2])/.exec(value)
+    return match ? `${match[1]}-${match[2]}` : null
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return monthlyGoalKey({
+      year: value.getFullYear(),
+      month: value.getMonth(),
+    })
+  }
+
+  return null
+}
+
+/**
+ * Converts the unused legacy `{ month: Date, hours }[]` preference shape to the
+ * canonical override map. When the same month appears more than once, the last
+ * valid entry wins, matching the user's most recent array entry.
+ */
+export const monthlyGoalOverridesFromLegacy = (
+  value: unknown
+): MonthlyGoalOverrides => {
+  if (!Array.isArray(value)) return {}
+
+  const overrides: MonthlyGoalOverrides = {}
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue
+    const { month, hours } = item as { month?: unknown; hours?: unknown }
+    const key = legacyMonthToKey(month)
+    if (key && isValidMonthlyGoalHours(hours)) overrides[key] = hours
+  }
+  return overrides
+}
+
+/** Returns the stable `YYYY-MM` key for an exact calendar month. */
+export const monthlyGoalKey = ({ year, month }: CalendarMonth): string => {
+  if (!Number.isInteger(year) || year < 0 || year > 9999) {
+    throw new RangeError('Monthly Goal year must be an integer from 0 to 9999')
+  }
+  if (!Number.isInteger(month) || month < 0 || month > 11) {
+    throw new RangeError('Monthly Goal month must be an integer from 0 to 11')
+  }
+
+  return `${String(year).padStart(4, '0')}-${String(month + 1).padStart(2, '0')}`
+}
+
+/**
+ * Pure Monthly Goal resolver for widgets and other non-React consumers. Invalid
+ * persisted values are ignored defensively so corrupt/imported state cannot
+ * turn progress math into `NaN` or a negative target.
+ */
+export const resolveMonthlyGoalHours = (
+  baseMonthlyGoalHours: number,
+  overrides: MonthlyGoalOverrides | undefined,
+  target: CalendarMonth
+): number => {
+  const override = overrides?.[monthlyGoalKey(target)]
+  return isValidMonthlyGoalHours(override) ? override : baseMonthlyGoalHours
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -107,7 +107,7 @@
   "contributionMore": "More",
   "whatTypePublisherAreYou": "What is your current publisher status?",
   "noHourRequirement": "No Hour Requirement",
-  "hourMonthlyRequirement": "{{count}} Hour Monthly Requirement",
+  "hourMonthlyRequirement": "Regular monthly goal: {{count}} hours",
   "publisher": "Publisher",
   "regularAuxiliary": "Regular Auxiliary",
   "regularPioneer": "Regular Pioneer",
@@ -203,6 +203,7 @@
   },
   "hoursLeft": "left",
   "goalBasedOnPublisherType": "Goal is based on your publisher type",
+  "goalAdjustedForMonth": "Custom goal for this month",
   "addTime": "Add Time",
   "updatedPlan": "Updated Plan",
   "editPlan": "Edit Plan",
@@ -397,7 +398,8 @@
   "todaysConversations": "Today's Conversations",
   "upcomingConversations": "Upcoming Conversations",
   "noTopicProvided": "No Topic Provided.",
-  "customHourRequirement": "Custom Hour Requirement",
+  "customHourRequirement": "Default Monthly Goal",
+  "defaultMonthlyGoal_description": "This applies to every month. To change one month, open Progress.",
   "custom": "Custom",
   "pleaseDescribeYourIssue": "Please describe your issue in detail",
   "invalidPhone": "Invalid Phone Number",
@@ -1261,6 +1263,17 @@
     "matched": "Matched",
     "noPlannedTime": "No planned time",
     "notStarted": "Not started"
+  },
+  "scheduleInsights": {
+    "schedulePace": "Schedule pace",
+    "goalPlanned": "Monthly goal planned",
+    "percentPlanned": "{{percent}}% planned",
+    "ofGoal": "of {{goal}} goal",
+    "monthlyGoal": "Monthly goal",
+    "leftToPlan": "Left to plan",
+    "paceDescriptionCurrent": "Compares logged time with your Plans through today.",
+    "paceDescriptionMonth": "Compares logged time with your Plans for the full month.",
+    "tapForDetails": "Tap for more details"
   },
   "planDay": "Plan Day",
   "weekly": "Weekly",
@@ -2169,6 +2182,22 @@
       "addedPlans": "Assistant added {{count}} plans"
     },
     "collapsedAfterAccept": "✓ You've planned enough"
+  },
+  "monthGoalEditor": {
+    "title": "Goal for {{month}}",
+    "regularGoal": "Regular monthly goal",
+    "monthGoal": "Goal this month",
+    "inputHint": "Enter the goal in hours. Decimals are allowed.",
+    "invalidGoal": "Enter a valid goal of zero hours or more.",
+    "editAccessibility": "Edit the {{goal}} goal for this month",
+    "goalBadge": "Goal {{goal}}",
+    "roleChangeTitle": "Keep custom monthly goals?",
+    "roleChangeDescription": "Your publisher type is changing. Choose whether current and future custom monthly goals should keep their existing values.",
+    "keepGoals": "Keep Goals",
+    "resetFutureGoals": "Reset Future Goals",
+    "explanation": "Only {{month}} changes. Your regular monthly goal and Annual Goal stay the same.",
+    "explanationWithoutAnnualGoal": "Only {{month}} changes. Your regular monthly goal stays the same.",
+    "useRegularGoal": "Use regular {{goal}} goal"
   },
   "projectedTotal": {
     "header": "Projected Total",

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -23,6 +23,14 @@ import type { ActiveFilter } from '@/lib/contactsFilters'
 import type { MarkerColors } from '@/types/markerColors'
 import type { StalenessBreakpoints } from '@/types/staleness'
 import { DEFAULT_STALENESS_BREAKPOINTS } from '@/constants/staleness'
+import {
+  isValidMonthlyGoalHours,
+  monthlyGoalOverridesFromLegacy,
+  monthlyGoalKey,
+  normalizeMonthlyGoalOverrides,
+  type CalendarMonth,
+  type MonthlyGoalOverrides,
+} from '@/lib/monthlyGoals'
 
 export type { MarkerColors }
 
@@ -46,11 +54,6 @@ export const builtInContactSortOptions: {
   { label: () => i18n.t('contacts_sortByState'), value: 'state' },
   { label: () => i18n.t('contacts_sortByZip'), value: 'zip' },
 ]
-
-export type GoalHours = {
-  month: Date
-  hours: number
-}
 
 const publisherHours: PublisherHours = {
   publisher: 0,
@@ -241,8 +244,13 @@ export const PREFERENCE_DEFAULTS = {
   role: 'publisher' as Publisher,
   publisherHours: publisherHours,
 
-  /** Overrides publisherHours hour requirement for given month. */
-  oneOffGoalHours: [] as GoalHours[],
+  /**
+   * Per-calendar-month Monthly Goal overrides keyed as `YYYY-MM`. A missing key
+   * means the Publisher-derived regular goal applies. This is syncable user
+   * intent and therefore participates in iCloud's per-preference LWW merge as
+   * one record.
+   */
+  monthlyGoalOverrides: {} as MonthlyGoalOverrides,
   onboardingComplete: false,
   // `name`, `avatar`, `customAvatarBackground`, and `hasCompletedProfileSetup`
   // moved to `@/stores/profile` in preferences v3 — see `src/lib/profileMigration.ts`
@@ -913,6 +921,11 @@ export const NON_SYNCABLE_PREFERENCE_KEYS = new Set<string>([
  *   an explicit override. The matching `preferenceUpdatedAt` timestamp is
  *   dropped alongside a dropped value so iCloud LWW lets an explicit value from
  *   another device win.
+ * - V5 → v6: replace the unused `oneOffGoalHours: { month: Date, hours }[]` shape
+ *   with `monthlyGoalOverrides: Record<YYYY-MM, number>`. Date values persisted
+ *   as ISO strings are converted without time-zone month drift;
+ *   malformed/negative goals are discarded. The matching iCloud LWW timestamp
+ *   key is renamed alongside the value.
  *
  * Exported for unit testing. Idempotent — re-running on an already-migrated
  * blob is a no-op.
@@ -939,6 +952,48 @@ export const migratePreferencesPersistedState = (
   if (version < 5) {
     next = migrateStartOfWeekZeroToAuto(next)
   }
+  if (version < 6) {
+    next = migrateOneOffGoalHoursToMonthlyGoalOverrides(next)
+  }
+  return next
+}
+
+/**
+ * V5 → v6: migrate the legacy array-based one-off goal placeholder to the
+ * canonical calendar-month override map. Exported so the iCloud payload
+ * compatibility layer can apply the exact same conversion before merging.
+ */
+export const migrateOneOffGoalHoursToMonthlyGoalOverrides = (
+  state: unknown
+): unknown => {
+  if (!state || typeof state !== 'object') return state
+  const record = state as Record<string, unknown>
+
+  const hasLegacy = 'oneOffGoalHours' in record
+  const hasCanonical = 'monthlyGoalOverrides' in record
+  if (!hasLegacy && !hasCanonical) return state
+
+  const { oneOffGoalHours, ...rest } = record
+  const next: Record<string, unknown> = { ...rest }
+  next.monthlyGoalOverrides = hasCanonical
+    ? normalizeMonthlyGoalOverrides(next.monthlyGoalOverrides)
+    : monthlyGoalOverridesFromLegacy(oneOffGoalHours)
+
+  if (
+    next.preferenceUpdatedAt &&
+    typeof next.preferenceUpdatedAt === 'object'
+  ) {
+    const timestamps = next.preferenceUpdatedAt as Record<string, unknown>
+    const { oneOffGoalHours: legacyTs, ...restTs } = timestamps
+    const nextTs: Record<string, unknown> = { ...restTs }
+    // As with earlier field renames, an existing canonical timestamp wins in a
+    // downgrade-then-upgrade payload carrying both keys.
+    if (legacyTs !== undefined && nextTs.monthlyGoalOverrides === undefined) {
+      nextTs.monthlyGoalOverrides = legacyTs
+    }
+    next.preferenceUpdatedAt = nextTs
+  }
+
   return next
 }
 
@@ -1207,6 +1262,48 @@ export const usePreferences = create(
           set({ overrideCreditLimit }),
         setCustomCreditLimitHours: (customCreditLimitHours: number) =>
           set({ customCreditLimitHours }),
+        /**
+         * Saves a Monthly Goal for one exact calendar month. Entering the
+         * Publisher-derived regular goal clears any existing override so a
+         * future role/custom-goal change naturally flows through that month.
+         */
+        setMonthlyGoalOverride: (target: CalendarMonth, hours: number) => {
+          if (!isValidMonthlyGoalHours(hours)) {
+            throw new RangeError(
+              'Monthly Goal hours must be a finite, nonnegative number'
+            )
+          }
+
+          const key = monthlyGoalKey(target)
+          set((state) => {
+            const baseGoalHours = state.publisherHours[state.role]
+            const existing = state.monthlyGoalOverrides[key]
+
+            if (hours === baseGoalHours) {
+              if (existing === undefined) return {}
+              const next = { ...state.monthlyGoalOverrides }
+              delete next[key]
+              return { monthlyGoalOverrides: next }
+            }
+
+            if (existing === hours) return {}
+            return {
+              monthlyGoalOverrides: {
+                ...state.monthlyGoalOverrides,
+                [key]: hours,
+              },
+            }
+          })
+        },
+        clearMonthlyGoalOverride: (target: CalendarMonth) => {
+          const key = monthlyGoalKey(target)
+          set((state) => {
+            if (!(key in state.monthlyGoalOverrides)) return {}
+            const next = { ...state.monthlyGoalOverrides }
+            delete next[key]
+            return { monthlyGoalOverrides: next }
+          })
+        },
         setAutoRolloverEnabled: (autoRolloverEnabled: boolean) =>
           set({ autoRolloverEnabled }),
         setRolloverIncludesCredit: (rolloverIncludesCredit: boolean) =>
@@ -1303,7 +1400,7 @@ export const usePreferences = create(
       storage: createJSONStorage(() =>
         hasMigratedFromAsyncStorage() ? MmkvStorage : GuardedAsyncStorage
       ),
-      version: 5,
+      version: 6,
       migrate: (persistedState, version) =>
         migratePreferencesPersistedState(persistedState, version),
     }


### PR DESCRIPTION
Adds month-specific goal overrides editable from Progress and Schedule, with compact expandable Schedule insight cards for pace and goal coverage. Effective goals flow through Home, projections, Assistant, achievements, widgets, and backdated entries while annual goals remain role-based.

Includes persisted and iCloud migration support, role-change handling, and Year-view markers for overridden months. Fixes #239