### PR TITLE
feat(home): add customizable ministry dashboard

### DIFF
--- a/src/__tests__/homeDashboardPreferences.test.ts
+++ b/src/__tests__/homeDashboardPreferences.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/mmkv', () => import('@/__tests__/mocks/mmkv'))
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { version: '1.0.0' } },
+}))
+vi.mock('expo-device', () => ({ DeviceType: { TABLET: 2 }, deviceType: 1 }))
+vi.mock('@/lib/locales', () => ({
+  default: { t: (key: string) => key },
+}))
+vi.mock('@/shaders/registry', () => ({
+  DEFAULT_SHADER_ID: 'holographic',
+}))
+
+import {
+  DEFAULT_HOME_DASHBOARD_CARD_ORDER,
+  DEFAULT_HOME_SCREEN_ELEMENTS_ORDER,
+  getEffectiveHomeDashboardCards,
+  getEffectiveHomeScreenOrder,
+  MAX_VISIBLE_HOME_DASHBOARD_CARDS,
+} from '@/stores/preferences'
+
+describe('Home dashboard preferences', () => {
+  it('uses three defaults for a new User', () => {
+    const result = getEffectiveHomeDashboardCards(undefined, undefined)
+
+    expect(result.order).toEqual(DEFAULT_HOME_DASHBOARD_CARD_ORDER)
+    expect(result.order.filter((key) => result.visibility[key])).toEqual([
+      'schedulePace',
+      'projectedMonth',
+      'remainingToGoal',
+    ])
+  })
+
+  it('preserves a valid custom order and appends newly introduced cards', () => {
+    const result = getEffectiveHomeDashboardCards(
+      ['plannedTotal', 'schedulePace'],
+      { plannedTotal: true }
+    )
+
+    expect(result.order.slice(0, 2)).toEqual(['plannedTotal', 'schedulePace'])
+    expect(result.order).toHaveLength(DEFAULT_HOME_DASHBOARD_CARD_ORDER.length)
+  })
+
+  it('drops unknown and duplicate keys from persisted state', () => {
+    const result = getEffectiveHomeDashboardCards(
+      ['unknown', 'creditTime', 'creditTime'],
+      { creditTime: true }
+    )
+
+    expect(result.order[0]).toBe('creditTime')
+    expect(result.order).not.toContain('unknown')
+    expect(new Set(result.order).size).toBe(result.order.length)
+  })
+
+  it('caps malformed persisted visibility at five cards in stored order', () => {
+    const allVisible = Object.fromEntries(
+      DEFAULT_HOME_DASHBOARD_CARD_ORDER.map((key) => [key, true])
+    )
+    const result = getEffectiveHomeDashboardCards(
+      DEFAULT_HOME_DASHBOARD_CARD_ORDER,
+      allVisible
+    )
+
+    expect(result.order.filter((key) => result.visibility[key])).toHaveLength(
+      MAX_VISIBLE_HOME_DASHBOARD_CARDS
+    )
+    expect(result.visibility.creditTime).toBe(false)
+  })
+
+  it('preserves a valid selection instead of resetting toggled cards', () => {
+    const result = getEffectiveHomeDashboardCards(
+      [
+        'schedulePace',
+        'projectedMonth',
+        'remainingToGoal',
+        'plannedTotal',
+        'serviceYearProgress',
+        'creditTime',
+      ],
+      {
+        schedulePace: true,
+        projectedMonth: true,
+        remainingToGoal: true,
+        plannedTotal: true,
+        serviceYearProgress: false,
+        creditTime: false,
+      }
+    )
+
+    expect(result.visibility.plannedTotal).toBe(true)
+    expect(result.order.filter((key) => result.visibility[key])).toHaveLength(4)
+  })
+
+  it('preserves an all-disabled selection so the editor can add cards again', () => {
+    const visibility = Object.fromEntries(
+      DEFAULT_HOME_DASHBOARD_CARD_ORDER.map((key) => [key, false])
+    )
+    const result = getEffectiveHomeDashboardCards(
+      DEFAULT_HOME_DASHBOARD_CARD_ORDER,
+      visibility
+    )
+
+    expect(result.order.some((key) => result.visibility[key])).toBe(false)
+  })
+
+  it('moves the dashboard below This Week for the previous PR preview', () => {
+    const result = getEffectiveHomeScreenOrder([
+      'approachingConversations',
+      'tabletServiceYearSummary',
+      'ministryDashboard',
+      'serviceReport',
+      'thisWeek',
+      'timer',
+      'didYouKnow',
+    ])
+
+    expect(result).toEqual(DEFAULT_HOME_SCREEN_ELEMENTS_ORDER)
+    expect(result.indexOf('ministryDashboard')).toBe(
+      result.indexOf('thisWeek') + 1
+    )
+    expect(result.at(-1)).toBe('didYouKnow')
+  })
+})

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -11,6 +11,7 @@ import useContacts from '@/stores/contactsStore'
 import { RefreshControl, View } from 'react-native'
 import { iCloudSync } from '@/app/sync/iCloudSync'
 import ServiceReportSection from '@/features/service-reports/components/ServiceReportSection'
+import ThisMonthDashboard from '@/features/service-reports/components/ThisMonthDashboard'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import XView from '@/components/ui/layout/XView'
@@ -27,6 +28,7 @@ import { useNavigation } from '@react-navigation/native'
 import usePublisher from '@/hooks/usePublisher'
 import {
   getEffectiveHomeScreenOrder,
+  getEffectiveHomeDashboardCards,
   HomeScreenElementKey,
   usePreferences,
 } from '@/stores/preferences'
@@ -43,6 +45,7 @@ import { isSupporterNudgeEligible } from '@/features/supporter/lib/supporterNudg
 import { HomeTabStackNavigation } from '@/types/homeStack'
 import { RootStackNavigation } from '@/types/rootStack'
 import { Fragment } from 'react'
+import HomeDashboardEditorSheet from '@/features/settings/components/HomeDashboardEditorSheet'
 
 export const HomeScreen = () => {
   const theme = useTheme()
@@ -75,6 +78,7 @@ export const HomeScreen = () => {
   const { isSupporter } = useIsSupporter()
   const { serviceReports } = useServiceReport()
   const [refreshing, setRefreshing] = useState(false)
+  const [dashboardEditorOpen, setDashboardEditorOpen] = useState(false)
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)
@@ -91,10 +95,23 @@ export const HomeScreen = () => {
   const { contacts } = useContacts()
   const { isTablet } = useDevice()
   const { hasAnnualGoal, showsTimer } = usePublisher()
-  const { homeScreenElements, homeScreenElementsOrder } = usePreferences()
+  const {
+    homeScreenElements,
+    homeScreenElementsOrder,
+    homeDashboardCardOrder,
+    homeDashboardCardVisibility,
+  } = usePreferences()
   const effectiveOrder = useMemo(
     () => getEffectiveHomeScreenOrder(homeScreenElementsOrder),
     [homeScreenElementsOrder]
+  )
+  const dashboardCards = useMemo(
+    () =>
+      getEffectiveHomeDashboardCards(
+        homeDashboardCardOrder,
+        homeDashboardCardVisibility
+      ),
+    [homeDashboardCardOrder, homeDashboardCardVisibility]
   )
   // Anchor the "Did you know" tip card to the bottom of the scroll view only
   // when the user has it in its default trailing position. Once they reorder
@@ -318,6 +335,19 @@ export const HomeScreen = () => {
                 if (!homeScreenElements.serviceReport) return null
                 return <ServiceReportSection key={key} />
 
+              case 'ministryDashboard':
+                if (homeScreenElements.ministryDashboard === false) return null
+                return (
+                  <ThisMonthDashboard
+                    key={key}
+                    orderedCardKeys={dashboardCards.order}
+                    visibleCardKeys={dashboardCards.order.filter(
+                      (cardKey) => dashboardCards.visibility[cardKey]
+                    )}
+                    onEdit={() => setDashboardEditorOpen(true)}
+                  />
+                )
+
               case 'thisWeek':
                 if (!homeScreenElements.thisWeek) return null
                 return (
@@ -348,6 +378,10 @@ export const HomeScreen = () => {
       <UpgradeLegacyTimeReportsSheet
         sheet={upgradeReportsSheet}
         setSheet={setUpgradeReportSheet}
+      />
+      <HomeDashboardEditorSheet
+        open={dashboardEditorOpen}
+        onOpenChange={setDashboardEditorOpen}
       />
     </View>
   )

--- a/src/features/service-reports/components/HourEntryCard.tsx
+++ b/src/features/service-reports/components/HourEntryCard.tsx
@@ -1,316 +1,87 @@
+import { useMemo } from 'react'
+import { View } from 'react-native'
+import moment from 'moment'
+import { Clock3 as ClockIcon } from 'lucide-react-native'
+import LucideIcon from '@/components/ui/LucideIcon'
+import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
-import { useNavigation } from '@react-navigation/native'
-import MonthServiceReportProgressBar from '@/features/service-reports/components/MonthServiceReportProgressBar'
-import { usePreferences } from '@/stores/preferences'
-import useServiceReport from '@/stores/serviceReport'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import usePublisher from '@/hooks/usePublisher'
+import { useFormattedMinutes } from '@/lib/minutes'
 import {
   adjustedMinutesForSpecificMonth,
-  getDaysLeftInCurrentMonth,
   getMonthsReports,
 } from '@/lib/serviceReport'
-import { goalProgress } from '@/lib/goalProgress'
-import moment from 'moment'
 import i18n from '@/lib/locales'
-import Button from '@/components/ui/Button'
-import { View } from 'react-native'
-import Text from '@/components/ui/MyText'
-import { formatMinutes } from '@/lib/minutes'
-import { RootStackNavigation } from '@/types/rootStack'
-import { HomeTabStackNavigation } from '@/types/homeStack'
-import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import { usePreferences } from '@/stores/preferences'
+import useServiceReport from '@/stores/serviceReport'
 
 export default function HourEntryCard() {
   const theme = useTheme()
-  const {
-    role,
-    displayDetailsOnProgressBarHomeScreen,
-    timeDisplayFormat,
-    overrideCreditLimit,
-    customCreditLimitHours,
-  } = usePreferences()
+  const { type: publisher } = usePublisher()
+  const { overrideCreditLimit, customCreditLimitHours } = usePreferences()
   const { serviceReports } = useServiceReport()
-  const navigation = useNavigation<
-    HomeTabStackNavigation & RootStackNavigation
-  >()
   const now = moment()
-  const { effectiveGoalHours: goalHours, isOverridden } = useMonthlyGoal({
-    month: now.month(),
-    year: now.year(),
-  })
-  const monthReports = useMemo(
-    () => getMonthsReports(serviceReports, moment().month(), moment().year()),
-    [serviceReports]
-  )
 
+  const monthReports = useMemo(
+    () => getMonthsReports(serviceReports, now.month(), now.year()),
+    [now, serviceReports]
+  )
   const adjustedMinutes = useMemo(
     () =>
       adjustedMinutesForSpecificMonth(
         monthReports,
-        moment().month(),
-        moment().year(),
-        role,
+        now.month(),
+        now.year(),
+        publisher,
         {
           enabled: overrideCreditLimit,
           customLimitHours: customCreditLimitHours,
         }
-      ),
-    [monthReports, role, overrideCreditLimit, customCreditLimitHours]
+      ).value,
+    [customCreditLimitHours, monthReports, now, overrideCreditLimit, publisher]
   )
-
-  const progress = useMemo(
-    () =>
-      goalProgress({
-        minutes: adjustedMinutes.value,
-        goalMinutes: goalHours * 60,
-      }).fraction,
-    [adjustedMinutes, goalHours]
-  )
-
-  const encouragementHourPhrase = useCallback((progress: number) => {
-    let phrases: string[] = []
-
-    if (progress < 0.6) {
-      phrases = [
-        i18n.t('phrasesFar.keepGoing'),
-        i18n.t('phrasesFar.youCanDoThis'),
-        i18n.t('phrasesFar.neverGiveUp'),
-        i18n.t('phrasesFar.preachTheWord'),
-        i18n.t('phrasesFar.stayFocused'),
-        i18n.t('phrasesFar.haveFaith'),
-        i18n.t('phrasesFar.stayStrong'),
-        i18n.t('phrasesFar.everyStepCounts'),
-        i18n.t('phrasesFar.youGotThis'),
-        i18n.t('phrasesFar.timeToShine'),
-        i18n.t('phrasesFar.makingProgress'),
-        i18n.t('phrasesFar.greatStart'),
-        i18n.t('phrasesFar.keepItUp'),
-        i18n.t('phrasesFar.momentumBuilding'),
-        i18n.t('phrasesFar.onYourWay'),
-        i18n.t('phrasesFar.smallStepsBigResults'),
-      ]
-    }
-
-    if (progress >= 0.6 && progress < 1) {
-      phrases = [
-        i18n.t('phrasesClose.oneStepCloser'),
-        i18n.t('phrasesClose.almostThere'),
-        i18n.t('phrasesClose.keepMovingForward'),
-        i18n.t('phrasesClose.successOnTheHorizon'),
-        i18n.t('phrasesClose.momentumIsYours'),
-        i18n.t('phrasesClose.nearingAchievement'),
-        i18n.t('phrasesClose.youreClosingIn'),
-        i18n.t('phrasesClose.closerThanEver'),
-        i18n.t('phrasesClose.homeStretch'),
-        i18n.t('phrasesClose.finishStrong'),
-        i18n.t('phrasesClose.soClose'),
-        i18n.t('phrasesClose.finalPush'),
-        i18n.t('phrasesClose.youreOnFire'),
-        i18n.t('phrasesClose.pushThroughToday'),
-        i18n.t('phrasesClose.goalInSight'),
-        i18n.t('phrasesClose.crushingIt'),
-        i18n.t('phrasesClose.unstoppable'),
-        i18n.t('phrasesClose.powerThrough'),
-      ]
-    }
-
-    if (progress >= 1) {
-      phrases = [
-        i18n.t('phrasesDone.youDidIt'),
-        i18n.t('phrasesDone.goalAchieved'),
-        i18n.t('phrasesDone.youNailedIt'),
-        i18n.t('phrasesDone.congratulations'),
-        i18n.t('phrasesDone.takeYourShoesOff'),
-        i18n.t('phrasesDone.hatsOffToYou'),
-        i18n.t('phrasesDone.missionComplete'),
-        i18n.t('phrasesDone.success'),
-        i18n.t('phrasesDone.phenomenal'),
-        i18n.t('phrasesDone.excellent'),
-        i18n.t('phrasesDone.outstanding'),
-        i18n.t('phrasesDone.incredible'),
-        i18n.t('phrasesDone.amazingWork'),
-        i18n.t('phrasesDone.goalCrushed'),
-        i18n.t('phrasesDone.victorious'),
-        i18n.t('phrasesDone.fantastic'),
-        i18n.t('phrasesDone.wellDone'),
-        i18n.t('phrasesDone.superb'),
-        i18n.t('phrasesDone.keepGoingStrong'),
-        i18n.t('phrasesDone.onARoll'),
-      ]
-    }
-
-    const random = Math.floor(Math.random() * phrases.length)
-    return phrases[random]
-  }, [])
-
-  const [encouragementPhrase, setEncouragementPhrase] = useState(
-    encouragementHourPhrase(progress)
-  )
-
-  useEffect(() => {
-    setEncouragementPhrase(encouragementHourPhrase(progress))
-  }, [encouragementHourPhrase, progress])
-
-  const minutesRemaining = useMemo(
-    () =>
-      goalProgress({
-        minutes: adjustedMinutes.value,
-        goalMinutes: goalHours * 60,
-      }).remaining,
-    [adjustedMinutes, goalHours]
-  )
-
-  const daysLeftInMonth = useMemo(() => getDaysLeftInCurrentMonth(), [])
-
-  // Returns minutes remaining if the last day of the month because x/0 = infinity.
-  // Which we don't want to display to the user
-  const minutesPerDayNeeded = useMemo(
-    () =>
-      daysLeftInMonth === 0
-        ? minutesRemaining
-        : Math.round(minutesRemaining / daysLeftInMonth),
-    [daysLeftInMonth, minutesRemaining]
-  )
-  const perDayDisplay = formatMinutes(
-    minutesPerDayNeeded,
-    timeDisplayFormat
-  ).formatted
-
-  const minutesWithFormat = formatMinutes(
-    adjustedMinutes.value,
-    timeDisplayFormat
-  )
+  const time = useFormattedMinutes(adjustedMinutes)
 
   return (
-    <View style={{ width: '100%' }}>
-      <Button
+    <View
+      style={{
+        flex: 1,
+        minHeight: 92,
+        justifyContent: 'center',
+        alignItems: 'flex-start',
+        gap: 8,
+        paddingVertical: 4,
+      }}
+    >
+      <View
         style={{
-          flexDirection: 'column',
-          borderRadius: theme.numbers.borderRadiusSm,
-          backgroundColor: theme.colors.backgroundLighter,
-          gap: 5,
-          paddingTop: 5,
-          position: 'relative',
-        }}
-        onPress={() =>
-          navigation.navigate('Progress', {
-            month: moment().month(),
-            year: moment().year(),
-          })
-        }
-      >
-        <View style={{ paddingHorizontal: 5, gap: 7 }}>
-          <MonthServiceReportProgressBar
-            month={moment().month()}
-            year={moment().year()}
-            minimal={!displayDetailsOnProgressBarHomeScreen}
-            style={{ paddingHorizontal: 10, paddingVertical: 10 }}
-          />
-          <View
-            style={{
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexDirection: 'column',
-              gap: 7,
-              paddingBottom: 10,
-            }}
-          >
-            <View>
-              <Text
-                style={{
-                  fontSize:
-                    timeDisplayFormat !== 'decimal'
-                      ? theme.fontSize('lg')
-                      : theme.fontSize('4xl'),
-                  fontFamily: theme.fonts.bold,
-                }}
-              >
-                {timeDisplayFormat === 'decimal'
-                  ? minutesWithFormat.decimalHours
-                  : minutesWithFormat.formatted}
-              </Text>
-              <View
-                style={{
-                  position: 'absolute',
-                  right: -25,
-                  bottom: 0,
-                }}
-              >
-                <Text
-                  style={{
-                    fontSize: 12,
-                    color: theme.colors.textAlt,
-                    fontFamily: theme.fonts.semiBold,
-                  }}
-                >
-                  /{goalHours}
-                </Text>
-              </View>
-            </View>
-
-            <Text style={{ fontFamily: theme.fonts.bold, maxWidth: 200 }}>
-              {encouragementPhrase}
-            </Text>
-            {minutesPerDayNeeded > 0 ? (
-              <View style={{ gap: 5 }}>
-                <View
-                  style={{
-                    borderRadius: theme.numbers.borderRadiusLg,
-                    backgroundColor: theme.colors.accent3,
-                    paddingHorizontal: 20,
-                    marginHorizontal: 15,
-                    paddingVertical: 5,
-                  }}
-                >
-                  <Text
-                    style={{
-                      fontSize: theme.fontSize('xs'),
-                      color: theme.colors.textInverse,
-                      fontFamily: theme.fonts.semiBold,
-                      display: 'flex',
-                    }}
-                  >
-                    {perDayDisplay} {i18n.t('hoursPerDayToGoal')}
-                  </Text>
-                </View>
-                <Text
-                  style={{
-                    fontSize: 8,
-                    color: theme.colors.textAlt,
-                    textAlign: 'center',
-                  }}
-                >
-                  {i18n.t(
-                    isOverridden
-                      ? 'goalAdjustedForMonth'
-                      : 'goalBasedOnPublisherType'
-                  )}
-                </Text>
-              </View>
-            ) : null}
-          </View>
-        </View>
-      </Button>
-      <Button
-        onPress={() => navigation.navigate('Add Time')}
-        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 16,
           alignItems: 'center',
+          justifyContent: 'center',
           backgroundColor: theme.colors.accentTranslucent,
-          paddingVertical: 10,
-          borderRadius: theme.numbers.borderRadiusSm,
-          borderWidth: 1,
-          borderColor: theme.colors.accent,
         }}
       >
-        <Text
-          style={{
-            color: theme.colors.accent,
-            fontFamily: theme.fonts.bold,
-          }}
-        >
-          {i18n.t('addTime')}
-        </Text>
-      </Button>
+        <LucideIcon icon={ClockIcon} size={17} color={theme.colors.accent} />
+      </View>
+      <Text
+        style={{
+          fontSize: theme.fontSize('2xl'),
+          fontFamily: theme.fonts.bold,
+        }}
+      >
+        {time.formatted}
+      </Text>
+      <Text
+        style={{
+          color: theme.colors.textAlt,
+          fontFamily: theme.fonts.semiBold,
+          fontSize: theme.fontSize('sm'),
+        }}
+      >
+        {i18n.t('hours')}
+      </Text>
     </View>
   )
 }

--- a/src/features/service-reports/components/PublisherCheckBoxCard.tsx
+++ b/src/features/service-reports/components/PublisherCheckBoxCard.tsx
@@ -1,146 +1,140 @@
-import { Square as SquareIcon } from 'lucide-react-native'
-import { getMonthsReports } from '@/lib/serviceReport'
-import { useServiceReport } from '@/stores/serviceReport'
+import {
+  CircleCheck as CircleCheckIcon,
+  Square as SquareIcon,
+} from 'lucide-react-native'
 import * as Crypto from 'expo-crypto'
-import LottieView from 'lottie-react-native'
-import Button from '@/components/ui/Button'
-import { TimeEntry } from '@/types/timeEntry'
-import useTheme from '@/contexts/theme'
-import Text from '@/components/ui/MyText'
-import i18n from '@/lib/locales'
-import { View } from 'react-native'
-import { useMemo, useState } from 'react'
 import moment from 'moment'
-import IconButton from '@/components/ui/IconButton'
-import Haptics from '@/lib/haptics'
+import { useMemo, useState } from 'react'
+import { View } from 'react-native'
+import Button from '@/components/ui/Button'
+import LucideIcon from '@/components/ui/LucideIcon'
+import Text from '@/components/ui/MyText'
 import useAnimation from '@/hooks/useAnimation'
+import useTheme from '@/contexts/theme'
+import Haptics from '@/lib/haptics'
+import i18n from '@/lib/locales'
+import { getMonthsReports } from '@/lib/serviceReport'
 import { CONFETTI_DELAY_MS } from '@/providers/AnimationViewProvider'
-
-const CheckMarkAnimationComponent = ({
-  undoReport,
-}: {
-  undoReport?: TimeEntry
-}) => {
-  const theme = useTheme()
-  const { deleteServiceReport } = useServiceReport()
-
-  return (
-    <View
-      style={{
-        backgroundColor: theme.colors.backgroundLighter,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flex: 1,
-      }}
-    >
-      <LottieView
-        autoPlay={true}
-        loop={false}
-        style={{
-          width: 140,
-          height: 120,
-        }}
-        speed={0.875}
-        // Find more Lottie files at https://lottiefiles.com/featured
-        source={require('@/assets/lottie/checkMark.json')}
-      />
-      {undoReport && (
-        <Button onPress={() => deleteServiceReport(undoReport)}>
-          <Text
-            style={{
-              fontSize: 10,
-              color: theme.colors.textAlt,
-              textDecorationLine: 'underline',
-            }}
-          >
-            {i18n.t('undo')}
-          </Text>
-        </Button>
-      )}
-    </View>
-  )
-}
+import { useServiceReport } from '@/stores/serviceReport'
+import { TimeEntry } from '@/types/timeEntry'
+import LottieView from 'lottie-react-native'
 
 export default function PublisherCheckBoxCard() {
   const theme = useTheme()
   const [undoReport, setUndoReport] = useState<TimeEntry>()
-  const { serviceReports, addServiceReport } = useServiceReport()
-
+  const { serviceReports, addServiceReport, deleteServiceReport } =
+    useServiceReport()
   const { playConfetti } = useAnimation()
   const monthReports = useMemo(
     () => getMonthsReports(serviceReports, moment().month(), moment().year()),
     [serviceReports]
   )
-  const hasGoneOutInServiceThisMonth = !!monthReports.length
+  const hasParticipated = monthReports.length > 0
 
   const handleSubmitDidService = () => {
-    const id = Crypto.randomUUID()
     const report: TimeEntry = {
       date: new Date(),
       hours: 0,
       minutes: 0,
-      id,
+      id: Crypto.randomUUID(),
     }
     addServiceReport(report)
     setUndoReport(report)
     Haptics.heavy()
-    setTimeout(() => {
-      Haptics.success()
-    }, CONFETTI_DELAY_MS + 100)
+    setTimeout(() => Haptics.success(), CONFETTI_DELAY_MS + 100)
     playConfetti()
   }
 
-  return (
-    <View>
-      {hasGoneOutInServiceThisMonth ? (
-        <View
+  if (hasParticipated) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          minHeight: 128,
+          gap: 8,
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        {undoReport ? (
+          <LottieView
+            autoPlay
+            loop={false}
+            speed={0.875}
+            style={{ width: 130, height: 96, marginVertical: -16 }}
+            source={require('@/assets/lottie/checkMark.json')}
+          />
+        ) : (
+          <LucideIcon
+            icon={CircleCheckIcon}
+            size={54}
+            color={theme.colors.accent}
+          />
+        )}
+        <Text
           style={{
-            backgroundColor: hasGoneOutInServiceThisMonth
-              ? theme.colors.backgroundLighter
-              : theme.colors.accent,
-            borderColor: theme.colors.border,
-            paddingVertical: hasGoneOutInServiceThisMonth ? 5 : 46,
-            justifyContent: 'center',
-            alignItems: 'center',
-            borderRadius: theme.numbers.borderRadiusSm,
-            overflow: 'hidden',
+            fontFamily: theme.fonts.semiBold,
+            fontSize: theme.fontSize('md'),
+            textAlign: 'center',
           }}
         >
-          <CheckMarkAnimationComponent undoReport={undoReport} />
-        </View>
-      ) : (
-        <Button
-          style={{
-            backgroundColor: hasGoneOutInServiceThisMonth
-              ? theme.colors.backgroundLighter
-              : theme.colors.accent,
-            borderColor: theme.colors.border,
-            paddingVertical: hasGoneOutInServiceThisMonth ? 5 : 46,
-            justifyContent: 'center',
-            alignItems: 'center',
-            borderRadius: theme.numbers.borderRadiusLg,
-            paddingHorizontal: 25,
-          }}
-          onPress={handleSubmitDidService}
-        >
-          <View style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
-            <IconButton
-              icon={SquareIcon}
-              size='xl'
-              iconStyle={{ color: theme.colors.textInverse }}
-            />
+          {i18n.t('sharedTheGoodNews')}
+        </Text>
+        {undoReport ? (
+          <Button onPress={() => deleteServiceReport(undoReport)}>
             <Text
               style={{
-                color: theme.colors.textInverse,
-                fontSize: 18,
-                fontFamily: theme.fonts.semiBold,
+                color: theme.colors.textAlt,
+                fontSize: theme.fontSize('xs'),
+                textDecorationLine: 'underline',
               }}
             >
-              {i18n.t('sharedTheGoodNews')}
+              {i18n.t('undo')}
             </Text>
-          </View>
-        </Button>
-      )}
-    </View>
+          </Button>
+        ) : null}
+      </View>
+    )
+  }
+
+  return (
+    <Button
+      accessibilityLabel={i18n.t('sharedTheGoodNews')}
+      onPress={handleSubmitDidService}
+      style={{
+        flex: 1,
+        minHeight: 128,
+        flexDirection: 'column',
+        gap: 12,
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingVertical: 4,
+        width: '100%',
+      }}
+    >
+      <View
+        style={{
+          width: 58,
+          height: 58,
+          borderRadius: 29,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.colors.accentTranslucent,
+        }}
+      >
+        <LucideIcon icon={SquareIcon} size={30} color={theme.colors.accent} />
+      </View>
+      <Text
+        style={{
+          color: theme.colors.text,
+          fontFamily: theme.fonts.semiBold,
+          fontSize: theme.fontSize('md'),
+          textAlign: 'center',
+        }}
+      >
+        {i18n.t('sharedTheGoodNews')}
+      </Text>
+    </Button>
   )
 }

--- a/src/features/service-reports/components/ServiceReportSection.tsx
+++ b/src/features/service-reports/components/ServiceReportSection.tsx
@@ -1,86 +1,91 @@
 import { View } from 'react-native'
+import {
+  ChevronRight as ChevronRightIcon,
+  Plus as PlusIcon,
+} from 'lucide-react-native'
 import useTheme from '@/contexts/theme'
 import usePublisher from '@/hooks/usePublisher'
 import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import LucideIcon from '@/components/ui/LucideIcon'
 import Text from '@/components/ui/MyText'
 import moment from 'moment'
 import i18n from '@/lib/locales'
-import useDevice from '@/hooks/useDevice'
 import HourEntryCard from '@/features/service-reports/components/HourEntryCard'
 import PublisherCheckBoxCard from '@/features/service-reports/components/PublisherCheckBoxCard'
 import StudiesCard from '@/features/service-reports/components/StudiesCard'
-import ViewReportButton from '@/features/service-reports/components/ViewReportButton'
 import SubmitPreviousReportButton from '@/features/service-reports/components/SubmitPreviousReportButton'
-
-const RowSectionTitle = ({
-  title,
-  underline,
-}: {
-  title: string
-  underline?: boolean
-}) => {
-  const theme = useTheme()
-
-  return (
-    <Text
-      style={{
-        color: theme.colors.textAlt,
-        fontFamily: theme.fonts.semiBold,
-        textDecorationLine: underline ? 'underline' : 'none',
-      }}
-    >
-      {title}
-    </Text>
-  )
-}
+import { useNavigation } from '@react-navigation/native'
+import { RootStackNavigation } from '@/types/rootStack'
 
 const ServiceReportSection = () => {
   const theme = useTheme()
   const { entryMode } = usePublisher()
-  const { isTablet } = useDevice()
+  const navigation = useNavigation<RootStackNavigation>()
+  const month = moment().month()
+  const year = moment().year()
+
+  const viewReport = () =>
+    navigation.navigate('ServiceReportView', { month, year })
 
   return (
-    <View style={{ gap: 10 }}>
-      <View
+    <Card
+      style={{
+        paddingHorizontal: 0,
+        paddingVertical: 0,
+        gap: 0,
+        overflow: 'hidden',
+      }}
+    >
+      <Button
+        accessibilityLabel={i18n.t('viewReport')}
+        onPress={viewReport}
         style={{
+          minHeight: 48,
+          paddingHorizontal: 20,
+          paddingVertical: 10,
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'space-between',
-          gap: 5,
         }}
       >
         <Text
           style={{
-            fontSize: 14,
+            fontSize: theme.fontSize('lg'),
             fontFamily: theme.fonts.semiBold,
-            marginLeft: 5,
           }}
         >
           {i18n.t('serviceReport')}
         </Text>
-        <ViewReportButton month={moment().month()} year={moment().year()} />
-      </View>
+        <LucideIcon
+          icon={ChevronRightIcon}
+          size={16}
+          color={theme.colors.textAlt}
+        />
+      </Button>
 
-      <SubmitPreviousReportButton />
-
-      <Card>
+      <View
+        style={{
+          gap: 18,
+          padding: 20,
+          paddingTop: 16,
+          borderTopWidth: 1,
+          borderTopColor: theme.colors.border,
+        }}
+      >
+        <SubmitPreviousReportButton />
         <View
           style={{
             flexDirection: 'row',
-            gap: 3,
+            gap: 18,
+            alignItems: 'stretch',
           }}
         >
           <View
             style={{
-              flex: 2,
-              gap: 5,
-              width: '100%',
-              maxWidth: isTablet ? 800 : '60%',
+              flex: entryMode === 'checkbox' ? 2 : 1,
             }}
           >
-            <View style={{ flexDirection: 'row' }}>
-              <RowSectionTitle title={i18n.t('hours')} />
-            </View>
             {entryMode === 'checkbox' ? (
               <PublisherCheckBoxCard />
             ) : (
@@ -89,18 +94,52 @@ const ServiceReportSection = () => {
           </View>
           <View
             style={{
-              flexDirection: 'column',
-              gap: 5,
-              flexGrow: 1,
-              maxWidth: '40%',
+              flex: 1,
+              paddingLeft: 18,
+              borderLeftWidth: 1,
+              borderLeftColor: theme.colors.border,
             }}
           >
-            <RowSectionTitle title={i18n.t('studies')} />
             <StudiesCard />
           </View>
         </View>
-      </Card>
-    </View>
+
+        {entryMode === 'hours' ? (
+          <Button
+            variant='glass'
+            glassTint={theme.colors.accent}
+            accessibilityLabel={i18n.t('addTime')}
+            onPress={() => navigation.navigate('Add Time')}
+            style={{
+              width: '100%',
+              minHeight: 48,
+              paddingVertical: 13,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              backgroundColor: theme.colors.accent,
+              borderRadius: theme.numbers.borderRadiusMd,
+            }}
+          >
+            <LucideIcon
+              icon={PlusIcon}
+              size={18}
+              color={theme.colors.textInverse}
+            />
+            <Text
+              style={{
+                color: theme.colors.textInverse,
+                fontFamily: theme.fonts.semiBold,
+                fontSize: theme.fontSize('md'),
+              }}
+            >
+              {i18n.t('addTime')}
+            </Text>
+          </Button>
+        ) : null}
+      </View>
+    </Card>
   )
 }
 

--- a/src/features/service-reports/components/StudiesCard.tsx
+++ b/src/features/service-reports/components/StudiesCard.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
+import { View } from 'react-native'
+import { BookOpenCheck as StudyIcon } from 'lucide-react-native'
+import LucideIcon from '@/components/ui/LucideIcon'
+import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
+import { getStudiesForGivenMonth } from '@/lib/contacts'
 import useContacts from '@/stores/contactsStore'
 import useConversations from '@/stores/conversationStore'
-import { getStudiesForGivenMonth } from '@/lib/contacts'
 import i18n from '@/lib/locales'
-import { View } from 'react-native'
-import Text from '@/components/ui/MyText'
 
 export default function StudiesCard() {
   const theme = useTheme()
@@ -16,88 +18,46 @@ export default function StudiesCard() {
       getStudiesForGivenMonth({ contacts, conversations, month: new Date() }),
     [contacts, conversations]
   )
-  const encouragementStudiesPhrase = (studies: number) => {
-    let phrases: string[] = []
 
-    if (studies === 0) {
-      phrases = [
-        i18n.t('phrasesStudiesNone.keepGoing'),
-        i18n.t('phrasesStudiesNone.stayStrong'),
-        i18n.t('phrasesStudiesNone.stayPositive'),
-        i18n.t('phrasesStudiesNone.grindOn'),
-        i18n.t('phrasesStudiesNone.keepSearching'),
-        i18n.t('phrasesStudiesNone.stayResilient'),
-      ]
-    }
-    if (studies > 0 && studies <= 15) {
-      phrases = [
-        i18n.t('phrasesStudiesDone.bravo'),
-        i18n.t('phrasesStudiesDone.wellDone'),
-        i18n.t('phrasesStudiesDone.amazingJob'),
-        i18n.t('phrasesStudiesDone.wayToGo'),
-        i18n.t('phrasesStudiesDone.victoryLap'),
-        i18n.t('phrasesStudiesDone.fantastic'),
-        i18n.t('phrasesStudiesDone.wow'),
-      ]
-    }
-    if (studies > 15) {
-      phrases = ['🤩🤯🎉']
-    }
-
-    const random = Math.floor(Math.random() * phrases.length)
-    return phrases[random]
-  }
-  const [encouragementPhrase, setEncouragementPhrase] = useState(
-    encouragementStudiesPhrase(studies)
-  )
-
-  useEffect(() => {
-    setEncouragementPhrase(encouragementStudiesPhrase(studies))
-  }, [studies])
   return (
     <View
       style={{
-        flexDirection: 'column',
-        paddingHorizontal: 6,
-        paddingVertical: 10,
-        backgroundColor: theme.colors.backgroundLighter,
-        borderRadius: theme.numbers.borderRadiusSm,
-        flexGrow: 1,
+        flex: 1,
+        minHeight: 92,
+        justifyContent: 'center',
+        alignItems: 'flex-start',
+        gap: 8,
+        paddingVertical: 4,
       }}
     >
       <View
         style={{
-          gap: 10,
-          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          borderRadius: 16,
           alignItems: 'center',
-          flexGrow: 1,
+          justifyContent: 'center',
+          backgroundColor: theme.colors.accentTranslucent,
         }}
       >
-        <Text
-          style={{
-            fontSize: theme.fontSize('4xl'),
-            fontFamily: theme.fonts.bold,
-          }}
-        >
-          {studies}
-        </Text>
-        <Text
-          style={{
-            fontFamily: theme.fonts.bold,
-            maxWidth: 125,
-          }}
-        >
-          {encouragementPhrase}
-        </Text>
+        <LucideIcon icon={StudyIcon} size={17} color={theme.colors.accent} />
       </View>
       <Text
         style={{
-          fontSize: 8,
-          color: theme.colors.textAlt,
-          textAlign: 'center',
+          fontSize: theme.fontSize('2xl'),
+          fontFamily: theme.fonts.bold,
         }}
       >
-        {i18n.t('basedOnContacts')}
+        {studies}
+      </Text>
+      <Text
+        style={{
+          color: theme.colors.textAlt,
+          fontFamily: theme.fonts.semiBold,
+          fontSize: theme.fontSize('sm'),
+        }}
+      >
+        {i18n.t('studies')}
       </Text>
     </View>
   )

--- a/src/features/service-reports/components/SubmitPreviousReportButton.tsx
+++ b/src/features/service-reports/components/SubmitPreviousReportButton.tsx
@@ -1,13 +1,19 @@
-import { Share as ShareIcon } from 'lucide-react-native'
+import {
+  ChevronRight as ChevronRightIcon,
+  Share as ShareIcon,
+} from 'lucide-react-native'
 import LucideIcon from '@/components/ui/LucideIcon'
 import { useNavigation } from '@react-navigation/native'
 import moment from 'moment'
 import Button from '@/components/ui/Button'
-import ShimmerText from '@/components/ui/ShimmerText'
+import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
 import i18n from '@/lib/locales'
 import { usePreferences } from '@/stores/preferences'
 import { RootStackNavigation } from '@/types/rootStack'
+import useServiceReport from '@/stores/serviceReport'
+import { getMonthsReports } from '@/lib/serviceReport'
+import { shouldShowPreviousReportReminder } from '@/features/service-reports/lib/previousReportReminder'
 
 /**
  * Post-rollover reminder to submit last month's report. Renders nothing once
@@ -18,10 +24,24 @@ import { RootStackNavigation } from '@/types/rootStack'
 const SubmitPreviousReportButton = () => {
   const theme = useTheme()
   const navigation = useNavigation<RootStackNavigation>()
-  const { submittedReportMonths } = usePreferences()
+  const { submittedReportMonths, installedOn } = usePreferences()
+  const serviceReports = useServiceReport((state) => state.serviceReports)
 
   const previousMonth = moment().subtract(1, 'month')
-  if (submittedReportMonths.includes(previousMonth.format('YYYY-MM'))) {
+  const previousMonthHasEntries =
+    getMonthsReports(
+      serviceReports,
+      previousMonth.month(),
+      previousMonth.year()
+    ).length > 0
+  if (
+    !shouldShowPreviousReportReminder({
+      installedOn,
+      now: new Date(),
+      previousMonthHasEntries,
+      submittedReportMonths,
+    })
+  ) {
     return null
   }
 
@@ -41,30 +61,31 @@ const SubmitPreviousReportButton = () => {
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'space-between',
         gap: 8,
         paddingVertical: 12,
         paddingHorizontal: 16,
-        backgroundColor: theme.colors.accent,
+        backgroundColor: theme.colors.accentTranslucent,
         borderRadius: theme.numbers.borderRadiusMd,
         borderCurve: 'continuous',
       }}
     >
-      <LucideIcon
-        icon={ShareIcon}
-        size={theme.fontSize('sm')}
-        style={{ color: theme.colors.textInverse }}
-      />
-      <ShimmerText
-        baseColor={theme.colors.textInverse}
-        strength={0.5}
+      <LucideIcon icon={ShareIcon} size={18} color={theme.colors.accent} />
+      <Text
         style={{
+          flex: 1,
+          color: theme.colors.accent,
           fontFamily: theme.fonts.semiBold,
           fontSize: theme.fontSize('md'),
         }}
       >
         {label}
-      </ShimmerText>
+      </Text>
+      <LucideIcon
+        icon={ChevronRightIcon}
+        size={14}
+        color={theme.colors.accent}
+      />
     </Button>
   )
 }

--- a/src/features/service-reports/components/ThisMonthDashboard.tsx
+++ b/src/features/service-reports/components/ThisMonthDashboard.tsx
@@ -1,0 +1,396 @@
+import { useNavigation } from '@react-navigation/native'
+import {
+  CalendarClock as CalendarClockIcon,
+  CalendarRange as CalendarRangeIcon,
+  ChartLine as ChartLineIcon,
+  ChevronRight as ChevronRightIcon,
+  CircleCheck as CircleCheckIcon,
+  Clock3 as ClockIcon,
+  Gauge as GaugeIcon,
+  Pencil as PencilIcon,
+  TrendingDown as TrendingDownIcon,
+  TrendingUp as TrendingUpIcon,
+} from 'lucide-react-native'
+import moment from 'moment'
+import { View } from 'react-native'
+
+import TiltableCard from '@/components/TiltableCard'
+import Card from '@/components/ui/Card'
+import IconButton from '@/components/ui/IconButton'
+import LucideIcon, { type AppIcon } from '@/components/ui/LucideIcon'
+import Text from '@/components/ui/MyText'
+import SimpleProgressBar from '@/components/ui/SimpleProgressBar'
+import useTheme from '@/contexts/theme'
+import useMonthlyGoal from '@/hooks/useMonthlyGoal'
+import useProjectedTotal from '@/hooks/useProjectedTotal'
+import usePublisher from '@/hooks/usePublisher'
+import i18n, { type TranslationKey } from '@/lib/locales'
+import { useFormattedMinutes } from '@/lib/minutes'
+import { calculateMonthlyPlannedMinutesOptimized } from '@/lib/recurrence'
+import {
+  adjustedMinutesForSpecificMonth,
+  getMonthsReports,
+} from '@/lib/serviceReport'
+import {
+  getScheduleStatusForMonth,
+  type ScheduleStatusState,
+} from '@/lib/scheduleStatus'
+import { getServiceYearFromDate } from '@/lib/serviceYear'
+import { usePreferences } from '@/stores/preferences'
+import useServiceReport from '@/stores/serviceReport'
+import type { HomeTabStackNavigation } from '@/types/homeStack'
+
+export const THIS_MONTH_DASHBOARD_CARD_KEYS = [
+  'schedulePace',
+  'projectedMonth',
+  'serviceYearProgress',
+  'creditTime',
+  'remainingToGoal',
+  'plannedTotal',
+] as const
+
+export type ThisMonthDashboardCardKey =
+  (typeof THIS_MONTH_DASHBOARD_CARD_KEYS)[number]
+
+type Props = {
+  visibleCardKeys: readonly ThisMonthDashboardCardKey[]
+  orderedCardKeys: readonly ThisMonthDashboardCardKey[]
+  onEdit: () => void
+}
+
+const STATUS_TITLE_KEYS: Record<ScheduleStatusState, TranslationKey> = {
+  ahead: 'scheduleStatus.ahead',
+  behind: 'scheduleStatus.behind',
+  onTrack: 'scheduleStatus.onTrack',
+  noPlan: 'scheduleStatus.noPlan',
+  notStarted: 'scheduleStatus.upcoming',
+}
+
+type DashboardCard = {
+  key: ThisMonthDashboardCardKey
+  icon: AppIcon
+  value: string
+  label: string
+  color?: string
+  destination: 'Progress' | 'Schedule'
+  progress?: number
+}
+
+const DashboardTile = ({
+  card,
+  onPress,
+}: {
+  card: DashboardCard
+  onPress: () => void
+}) => {
+  const theme = useTheme()
+
+  return (
+    <View
+      accessible
+      accessibilityRole='button'
+      accessibilityLabel={`${card.label}. ${card.value}`}
+      accessibilityHint={i18n.t('scheduleInsights.tapForDetails')}
+      onAccessibilityTap={onPress}
+      style={{ width: '48.5%' }}
+    >
+      <TiltableCard onTap={onPress} maxTilt={5}>
+        <Card
+          style={{
+            minHeight: 112,
+            padding: 12,
+            gap: 10,
+            justifyContent: 'space-between',
+          }}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <View
+              style={{
+                width: 30,
+                height: 30,
+                borderRadius: 15,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.colors.backgroundLighter,
+              }}
+            >
+              <LucideIcon
+                icon={card.icon}
+                color={card.color ?? theme.colors.textAlt}
+                size={16}
+              />
+            </View>
+            <LucideIcon
+              icon={ChevronRightIcon}
+              color={theme.colors.textAlt}
+              size={12}
+            />
+          </View>
+
+          <View style={{ gap: 2 }}>
+            <Text
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              style={{
+                color: card.color ?? theme.colors.text,
+                fontFamily: theme.fonts.bold,
+                fontSize: theme.fontSize('lg'),
+              }}
+            >
+              {card.value}
+            </Text>
+            <Text
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              style={{
+                color: theme.colors.textAlt,
+                fontFamily: theme.fonts.semiBold,
+                fontSize: theme.fontSize('sm'),
+              }}
+            >
+              {card.label}
+            </Text>
+            {card.progress !== undefined ? (
+              <SimpleProgressBar
+                percentage={card.progress}
+                color={card.color ?? theme.colors.accent}
+                height={4}
+                animated={false}
+              />
+            ) : null}
+          </View>
+        </Card>
+      </TiltableCard>
+    </View>
+  )
+}
+
+/** A glanceable, customizable month dashboard for Home. */
+const ThisMonthDashboard = ({
+  visibleCardKeys,
+  orderedCardKeys,
+  onEdit,
+}: Props) => {
+  const theme = useTheme()
+  const navigation = useNavigation<HomeTabStackNavigation>()
+  const now = moment()
+  const month = now.month()
+  const year = now.year()
+  const serviceYear = getServiceYearFromDate(now)
+  const {
+    entryMode,
+    hasAnnualGoal,
+    annualGoalHours,
+    type: publisher,
+  } = usePublisher()
+  const { overrideCreditLimit, customCreditLimitHours } = usePreferences()
+  const { effectiveGoalHours } = useMonthlyGoal({ month, year })
+  const serviceReports = useServiceReport((s) => s.serviceReports)
+  const dayPlans = useServiceReport((s) => s.dayPlans)
+  const recurringPlans = useServiceReport((s) => s.recurringPlans)
+
+  const goalMinutes = Math.round(effectiveGoalHours * 60)
+  const { projection: monthProjection } = useProjectedTotal(
+    { kind: 'month', month, year },
+    goalMinutes
+  )
+  const { projection: yearProjection } = useProjectedTotal(
+    { kind: 'serviceYear', serviceYear },
+    annualGoalHours * 60
+  )
+  const scheduleStatus = getScheduleStatusForMonth({
+    month,
+    year,
+    serviceReports,
+    dayPlans,
+    recurringPlans,
+    publisher,
+    creditLimit: {
+      enabled: overrideCreditLimit,
+      customLimitHours: customCreditLimitHours,
+    },
+  })
+  const totalPlannedMinutes = calculateMonthlyPlannedMinutesOptimized(
+    month,
+    year,
+    dayPlans,
+    recurringPlans
+  )
+  const monthAdjusted = adjustedMinutesForSpecificMonth(
+    getMonthsReports(serviceReports, month, year),
+    month,
+    year,
+    publisher,
+    {
+      enabled: overrideCreditLimit,
+      customLimitHours: customCreditLimitHours,
+    }
+  )
+
+  const paceDifference = useFormattedMinutes(
+    Math.abs(scheduleStatus.differenceMinutes)
+  )
+  const projected = useFormattedMinutes(monthProjection.projectedMinutes)
+  const yearLogged = useFormattedMinutes(yearProjection.loggedMinutes)
+  const credit = useFormattedMinutes(monthAdjusted.credit)
+  const remaining = useFormattedMinutes(
+    Math.max(0, goalMinutes - monthProjection.loggedMinutes)
+  )
+  const planned = useFormattedMinutes(totalPlannedMinutes)
+
+  const hasMonthlyGoal = entryMode === 'hours' && goalMinutes > 0
+  const paceColor =
+    scheduleStatus.state === 'behind'
+      ? theme.colors.warn
+      : scheduleStatus.state === 'ahead' || scheduleStatus.state === 'onTrack'
+        ? theme.colors.accent
+        : theme.colors.textAlt
+  const paceIcon: AppIcon =
+    scheduleStatus.state === 'ahead'
+      ? TrendingUpIcon
+      : scheduleStatus.state === 'behind'
+        ? TrendingDownIcon
+        : scheduleStatus.state === 'onTrack'
+          ? CircleCheckIcon
+          : CalendarClockIcon
+  const paceValue =
+    scheduleStatus.state === 'ahead'
+      ? `+${paceDifference.formatted}`
+      : scheduleStatus.state === 'behind'
+        ? `-${paceDifference.formatted}`
+        : i18n.t(STATUS_TITLE_KEYS[scheduleStatus.state])
+
+  const cards: DashboardCard[] = [
+    {
+      key: 'schedulePace',
+      icon: paceIcon,
+      value: paceValue,
+      label: i18n.t('scheduleInsights.schedulePace'),
+      color: paceColor,
+      destination: 'Schedule',
+    },
+    ...(hasMonthlyGoal
+      ? [
+          {
+            key: 'projectedMonth' as const,
+            icon: ChartLineIcon,
+            value: projected.formatted,
+            label: i18n.t('projectedTotal.headerMonth'),
+            destination: 'Progress' as const,
+          },
+        ]
+      : []),
+    ...(hasAnnualGoal && annualGoalHours > 0
+      ? [
+          {
+            key: 'serviceYearProgress' as const,
+            icon: GaugeIcon,
+            value: yearLogged.formatted,
+            label: i18n.t('serviceYear'),
+            destination: 'Progress' as const,
+            progress: yearProjection.loggedMinutes / (annualGoalHours * 60),
+          },
+        ]
+      : []),
+    ...(entryMode === 'hours'
+      ? [
+          {
+            key: 'creditTime' as const,
+            icon: ClockIcon,
+            value: credit.formatted,
+            label: i18n.t('credit'),
+            destination: 'Progress' as const,
+          },
+        ]
+      : []),
+    ...(hasMonthlyGoal
+      ? [
+          {
+            key: 'remainingToGoal' as const,
+            icon: GaugeIcon,
+            value: remaining.formatted,
+            label: i18n.t('remaining'),
+            destination: 'Progress' as const,
+          },
+        ]
+      : []),
+    {
+      key: 'plannedTotal',
+      icon: CalendarRangeIcon,
+      value: planned.formatted,
+      label: i18n.t('planned'),
+      destination: 'Schedule',
+    },
+  ]
+
+  const cardByKey = new Map(cards.map((card) => [card.key, card]))
+  const visible = new Set(visibleCardKeys)
+  const orderedCards = orderedCardKeys.flatMap((key) => {
+    const card = cardByKey.get(key)
+    return card && visible.has(key) ? [card] : []
+  })
+
+  const open = (destination: DashboardCard['destination']) => {
+    if (destination === 'Schedule') {
+      navigation.navigate('Schedule', { month, year })
+      return
+    }
+    navigation.navigate('Progress', { month, year })
+  }
+
+  return (
+    <View style={{ gap: 10 }}>
+      <View
+        style={{
+          minHeight: 32,
+          paddingLeft: 5,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 14,
+            fontFamily: theme.fonts.semiBold,
+          }}
+        >
+          {i18n.t('thisMonth')}
+        </Text>
+        <IconButton
+          icon={PencilIcon}
+          size='sm'
+          onPress={onEdit}
+          accessibilityLabel={i18n.t('edit')}
+        />
+      </View>
+
+      {orderedCards.length > 0 ? (
+        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+            gap: 10,
+          }}
+        >
+          {orderedCards.map((card) => (
+            <DashboardTile
+              key={card.key}
+              card={card}
+              onPress={() => open(card.destination)}
+            />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+export default ThisMonthDashboard

--- a/src/features/service-reports/lib/previousReportReminder.test.ts
+++ b/src/features/service-reports/lib/previousReportReminder.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowPreviousReportReminder } from '@/features/service-reports/lib/previousReportReminder'
+
+const now = new Date('2026-07-09T12:00:00.000Z')
+
+describe('shouldShowPreviousReportReminder', () => {
+  it('hides the previous report on a fresh install with no backfilled data', () => {
+    expect(
+      shouldShowPreviousReportReminder({
+        installedOn: new Date('2026-07-09T10:00:00.000Z'),
+        now,
+        previousMonthHasEntries: false,
+        submittedReportMonths: [],
+      })
+    ).toBe(false)
+  })
+
+  it('shows the previous report for an existing User', () => {
+    expect(
+      shouldShowPreviousReportReminder({
+        installedOn: new Date('2026-06-15T12:00:00.000Z'),
+        now,
+        previousMonthHasEntries: false,
+        submittedReportMonths: [],
+      })
+    ).toBe(true)
+  })
+
+  it('shows a backfilled previous report even on a fresh install', () => {
+    expect(
+      shouldShowPreviousReportReminder({
+        installedOn: new Date('2026-07-09T10:00:00.000Z'),
+        now,
+        previousMonthHasEntries: true,
+        submittedReportMonths: [],
+      })
+    ).toBe(true)
+  })
+
+  it('stays hidden once the previous report was submitted', () => {
+    expect(
+      shouldShowPreviousReportReminder({
+        installedOn: new Date('2025-01-01T00:00:00.000Z'),
+        now,
+        previousMonthHasEntries: true,
+        submittedReportMonths: ['2026-06'],
+      })
+    ).toBe(false)
+  })
+})

--- a/src/features/service-reports/lib/previousReportReminder.ts
+++ b/src/features/service-reports/lib/previousReportReminder.ts
@@ -1,0 +1,21 @@
+import moment from 'moment'
+
+export const shouldShowPreviousReportReminder = ({
+  installedOn,
+  now,
+  previousMonthHasEntries,
+  submittedReportMonths,
+}: {
+  installedOn: Date
+  now: Date
+  previousMonthHasEntries: boolean
+  submittedReportMonths: readonly string[]
+}): boolean => {
+  const currentMonth = moment(now).startOf('month')
+  const previousMonthKey = moment(now).subtract(1, 'month').format('YYYY-MM')
+
+  if (submittedReportMonths.includes(previousMonthKey)) return false
+  if (previousMonthHasEntries) return true
+
+  return moment(installedOn).isBefore(currentMonth)
+}

--- a/src/features/service-reports/screens/ServiceReportViewScreen.tsx
+++ b/src/features/service-reports/screens/ServiceReportViewScreen.tsx
@@ -1,4 +1,6 @@
 import {
+  ArrowLeft as ArrowLeftIcon,
+  ArrowRight as ArrowRightIcon,
   Check as CheckIcon,
   Copy as CopyIcon,
   Earth as EarthIcon,
@@ -22,7 +24,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as Clipboard from 'expo-clipboard'
 import moment from 'moment'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { LayoutChangeEvent } from 'react-native'
 import Svg, {
   Path,
@@ -35,6 +37,7 @@ import Svg, {
 } from 'react-native-svg'
 
 import IconButton from '@/components/ui/IconButton'
+import Button from '@/components/ui/Button'
 import SplitButton, { SplitButtonAction } from '@/components/ui/SplitButton'
 import Text from '@/components/ui/MyText'
 import { exportMethodSelectionOptions } from '@/components/DefaultExportMethodSelector'
@@ -84,6 +87,7 @@ const PAPER_HEIGHT_MIN = 480
 const RAGGED_INSET = 6
 const RAGGED_SEGMENTS_X = 14
 const RAGGED_SEGMENTS_Y = 20
+const SUBMIT_CONFIRMATION_DURATION_MS = 2000
 
 // Deterministic pseudo-random in [-1, 1] from a seed.
 function pseudoRandom(seed: number): number {
@@ -166,6 +170,18 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
     () => moment().month(month).year(year).format('MMMM YYYY'),
     [month, year]
   )
+  const selectedMonth = useMemo(
+    () => moment().month(month).year(year).startOf('month'),
+    [month, year]
+  )
+  const canNavigateForward = selectedMonth.isBefore(moment(), 'month')
+  const navigateMonth = useCallback(
+    (direction: -1 | 1) => {
+      const next = moment(selectedMonth).add(direction, 'month')
+      navigation.setParams({ month: next.month(), year: next.year() })
+    },
+    [navigation, selectedMonth]
+  )
 
   const { regular: handwritingFont, bold: handwritingFontBold } =
     useHandwritingFonts(_i18n.locale)
@@ -182,6 +198,40 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
 
   const [isEditingNotes, setIsEditingNotes] = useState(false)
   const [notesDraft, setNotesDraft] = useState('')
+  const [isSubmitConfirmed, setIsSubmitConfirmed] = useState(false)
+  const submitConfirmationTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+
+  useEffect(() => {
+    setIsEditingNotes(false)
+    setNotesDraft('')
+    setIsSubmitConfirmed(false)
+    Keyboard.dismiss()
+  }, [month, year])
+
+  useEffect(
+    () => () => {
+      if (submitConfirmationTimerRef.current !== null) {
+        clearTimeout(submitConfirmationTimerRef.current)
+      }
+    },
+    []
+  )
+
+  const confirmSubmission = useCallback(() => {
+    markReportSubmitted(reportMonthKey)
+    setIsSubmitConfirmed(true)
+    Haptics.success()
+
+    if (submitConfirmationTimerRef.current !== null) {
+      clearTimeout(submitConfirmationTimerRef.current)
+    }
+    submitConfirmationTimerRef.current = setTimeout(() => {
+      submitConfirmationTimerRef.current = null
+      setIsSubmitConfirmed(false)
+    }, SUBMIT_CONFIRMATION_DURATION_MS)
+  }, [markReportSubmitted, reportMonthKey])
 
   const handleStartEditNotes = useCallback(() => {
     setNotesDraft(data.notes)
@@ -226,14 +276,13 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
   const handleShareAction = useCallback(
     async (action: string) => {
       if (action === 'copy') {
-        Haptics.success()
         await Clipboard.setStringAsync(data.reportAsString())
-        markReportSubmitted(reportMonthKey)
+        confirmSubmission()
         return
       }
       if (action === 'share') {
         await Share.share({ message: data.reportAsString() })
-        markReportSubmitted(reportMonthKey)
+        confirmSubmission()
         return
       }
 
@@ -256,7 +305,7 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
             remarks,
           })
         )
-        markReportSubmitted(reportMonthKey)
+        confirmSubmission()
       } else if (action === 'nwpublisher' && data.isLastMonth) {
         await openURL(
           buildNwPublisherLink({
@@ -267,10 +316,10 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
             remarks,
           })
         )
-        markReportSubmitted(reportMonthKey)
+        confirmSubmission()
       }
     },
-    [data, month, year, markReportSubmitted, reportMonthKey]
+    [confirmSubmission, data, month, year]
   )
 
   // One-tap submit via the user's default method, always available on any
@@ -362,6 +411,65 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
         <View style={{ width: 18 }} />
       </View>
 
+      <View
+        style={{
+          paddingHorizontal: 16,
+          paddingTop: 6,
+          paddingBottom: 8,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Button
+          accessibilityLabel={moment(selectedMonth)
+            .subtract(1, 'month')
+            .format('MMMM YYYY')}
+          onPress={() => navigateMonth(-1)}
+          style={monthNavButtonStyle(theme)}
+        >
+          <LucideIcon
+            icon={ArrowLeftIcon}
+            size={15}
+            color={theme.colors.textAlt}
+          />
+          <Text style={{ color: theme.colors.textAlt }}>
+            {moment(selectedMonth).subtract(1, 'month').format('MMM')}
+          </Text>
+        </Button>
+
+        <Text
+          style={{
+            color: theme.colors.text,
+            fontFamily: theme.fonts.semiBold,
+            fontSize: theme.fontSize('md'),
+          }}
+        >
+          {monthYearLabel}
+        </Text>
+
+        {canNavigateForward ? (
+          <Button
+            accessibilityLabel={moment(selectedMonth)
+              .add(1, 'month')
+              .format('MMMM YYYY')}
+            onPress={() => navigateMonth(1)}
+            style={monthNavButtonStyle(theme)}
+          >
+            <Text style={{ color: theme.colors.textAlt }}>
+              {moment(selectedMonth).add(1, 'month').format('MMM')}
+            </Text>
+            <LucideIcon
+              icon={ArrowRightIcon}
+              size={15}
+              color={theme.colors.textAlt}
+            />
+          </Button>
+        ) : (
+          <View style={{ width: 72 }} />
+        )}
+      </View>
+
       <ScrollView
         automaticallyAdjustKeyboardInsets
         // Must flex — RN 0.86's Yoga no longer clamps an unflexed ScrollView
@@ -369,7 +477,7 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
         // and stops scrolling once the content exceeds the screen.
         style={{ flex: 1 }}
         contentContainerStyle={{
-          paddingTop: 28,
+          paddingTop: 18,
           paddingBottom: insets.bottom + 130,
           paddingHorizontal: 16,
           alignItems: 'center',
@@ -477,7 +585,11 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
         >
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
             <LucideIcon
-              icon={exportMethodCtaIcons[defaultExportMethod]}
+              icon={
+                isSubmitConfirmed
+                  ? CheckIcon
+                  : exportMethodCtaIcons[defaultExportMethod]
+              }
               size={15}
               style={{ color: theme.colors.textInverse }}
             />
@@ -488,9 +600,9 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
                 fontFamily: theme.fonts.bold,
               }}
             >
-              {submitCtaLabel}
+              {isSubmitConfirmed ? i18n.t('reportSubmitted') : submitCtaLabel}
             </Text>
-            {submitIsExternal && (
+            {submitIsExternal && !isSubmitConfirmed && (
               <LucideIcon
                 icon={ExternalLinkIcon}
                 size={11}
@@ -503,6 +615,19 @@ const ServiceReportViewScreen = ({ route, navigation }: Props) => {
     </View>
   )
 }
+
+const monthNavButtonStyle = (theme: ReturnType<typeof useTheme>) => ({
+  minWidth: 72,
+  paddingHorizontal: 12,
+  paddingVertical: 6,
+  borderWidth: 1,
+  borderColor: theme.colors.border,
+  borderRadius: theme.numbers.borderRadiusLg,
+  flexDirection: 'row' as const,
+  alignItems: 'center' as const,
+  justifyContent: 'center' as const,
+  gap: 5,
+})
 
 const BackPaperSheet = ({ height }: { height: number }) => {
   const path = useMemo(

--- a/src/features/settings/components/HomeDashboardEditorSheet.tsx
+++ b/src/features/settings/components/HomeDashboardEditorSheet.tsx
@@ -1,0 +1,249 @@
+import {
+  ArrowDown as ArrowDownIcon,
+  ArrowUp as ArrowUpIcon,
+} from 'lucide-react-native'
+import { ScrollView, Switch, View } from 'react-native'
+import { Sheet } from 'tamagui'
+
+import Button from '@/components/ui/Button'
+import IconButton from '@/components/ui/IconButton'
+import Text from '@/components/ui/MyText'
+import XView from '@/components/ui/layout/XView'
+import useTheme from '@/contexts/theme'
+import usePublisher from '@/hooks/usePublisher'
+import i18n from '@/lib/locales'
+import {
+  DEFAULT_HOME_DASHBOARD_CARD_ORDER,
+  DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY,
+  getEffectiveHomeDashboardCards,
+  type HomeDashboardCardKey,
+  MAX_VISIBLE_HOME_DASHBOARD_CARDS,
+  usePreferences,
+} from '@/stores/preferences'
+
+export interface HomeDashboardEditorSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const labelFor = (key: HomeDashboardCardKey): string =>
+  i18n.t(`homeDashboard.editor.cards.${key}`)
+
+/**
+ * Lets the User choose up to four secondary Home dashboard cards. Capability
+ * gates affect only the rows shown here; preferences for temporarily
+ * inapplicable cards remain intact for a future Publisher change.
+ */
+const HomeDashboardEditorSheet = ({
+  open,
+  onOpenChange,
+}: HomeDashboardEditorSheetProps) => {
+  const theme = useTheme()
+  const { homeDashboardCardOrder, homeDashboardCardVisibility, set } =
+    usePreferences()
+  const { entryMode, hasAnnualGoal, monthlyGoalHours } = usePublisher()
+  const hasMonthlyGoal = monthlyGoalHours > 0
+  const usesHours = entryMode === 'hours'
+
+  const { order, visibility } = getEffectiveHomeDashboardCards(
+    homeDashboardCardOrder,
+    homeDashboardCardVisibility
+  )
+  const applicableOrder = order.filter((key) => {
+    switch (key) {
+      case 'schedulePace':
+      case 'plannedTotal':
+        return true
+      case 'creditTime':
+        return usesHours
+      case 'projectedMonth':
+      case 'remainingToGoal':
+        return hasMonthlyGoal
+      case 'serviceYearProgress':
+        return hasAnnualGoal
+    }
+  })
+  const enabledCount = applicableOrder.filter((key) => visibility[key]).length
+
+  const setVisibility = (key: HomeDashboardCardKey, value: boolean) => {
+    if (value && enabledCount >= MAX_VISIBLE_HOME_DASHBOARD_CARDS) return
+    set({
+      homeDashboardCardVisibility: {
+        ...visibility,
+        [key]: value,
+      },
+    })
+  }
+
+  const move = (applicableIndex: number, direction: -1 | 1) => {
+    const targetIndex = applicableIndex + direction
+    if (targetIndex < 0 || targetIndex >= applicableOrder.length) return
+
+    const current = applicableOrder[applicableIndex]
+    const target = applicableOrder[targetIndex]
+    const next = [...order]
+    const currentIndex = next.indexOf(current)
+    const globalTargetIndex = next.indexOf(target)
+    ;[next[currentIndex], next[globalTargetIndex]] = [
+      next[globalTargetIndex],
+      next[currentIndex],
+    ]
+    set({ homeDashboardCardOrder: next })
+  }
+
+  const reset = () =>
+    set({
+      homeDashboardCardOrder: [...DEFAULT_HOME_DASHBOARD_CARD_ORDER],
+      homeDashboardCardVisibility: {
+        ...DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY,
+      },
+    })
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissOnSnapToBottom
+      modal
+      snapPoints={[72]}
+    >
+      <Sheet.Handle />
+      <Sheet.Overlay zIndex={100_000 - 1} />
+      <Sheet.Frame backgroundColor={theme.colors.backgroundLighter}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            paddingHorizontal: 24,
+            paddingTop: 22,
+            paddingBottom: 40,
+            gap: 20,
+          }}
+        >
+          <View style={{ gap: 6 }}>
+            <Text
+              accessibilityRole='header'
+              style={{
+                color: theme.colors.text,
+                fontFamily: theme.fonts.semiBold,
+                fontSize: theme.fontSize('xl'),
+              }}
+            >
+              {i18n.t('homeDashboard.editor.title')}
+            </Text>
+            <Text
+              style={{
+                color: theme.colors.textAlt,
+                fontSize: theme.fontSize('sm'),
+                lineHeight: 20,
+              }}
+            >
+              {i18n.t('homeDashboard.editor.description', {
+                count: MAX_VISIBLE_HOME_DASHBOARD_CARDS,
+              })}
+            </Text>
+          </View>
+
+          <View
+            style={{
+              borderRadius: theme.numbers.borderRadiusMd,
+              backgroundColor: theme.colors.background,
+              overflow: 'hidden',
+            }}
+          >
+            {applicableOrder.map((key, index) => {
+              const isEnabled = visibility[key]
+              const enableLimitReached =
+                !isEnabled && enabledCount >= MAX_VISIBLE_HOME_DASHBOARD_CARDS
+              return (
+                <XView
+                  key={key}
+                  style={{
+                    width: '100%',
+                    minHeight: 58,
+                    paddingHorizontal: 14,
+                    gap: 8,
+                    alignItems: 'center',
+                    borderBottomWidth:
+                      index === applicableOrder.length - 1 ? 0 : 1,
+                    borderBottomColor: theme.colors.border,
+                  }}
+                >
+                  <XView style={{ gap: 4 }}>
+                    <IconButton
+                      icon={ArrowUpIcon}
+                      noTransform
+                      onPress={index === 0 ? undefined : () => move(index, -1)}
+                      color={
+                        index === 0 ? theme.colors.border : theme.colors.textAlt
+                      }
+                      accessibilityLabel={i18n.t(
+                        'homeDashboard.editor.moveUp',
+                        { card: labelFor(key) }
+                      )}
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 0 }}
+                    />
+                    <IconButton
+                      icon={ArrowDownIcon}
+                      noTransform
+                      onPress={
+                        index === applicableOrder.length - 1
+                          ? undefined
+                          : () => move(index, 1)
+                      }
+                      color={
+                        index === applicableOrder.length - 1
+                          ? theme.colors.border
+                          : theme.colors.textAlt
+                      }
+                      accessibilityLabel={i18n.t(
+                        'homeDashboard.editor.moveDown',
+                        { card: labelFor(key) }
+                      )}
+                      hitSlop={{ top: 10, bottom: 10, left: 0, right: 10 }}
+                    />
+                  </XView>
+                  <Text style={{ flex: 1 }}>{labelFor(key)}</Text>
+                  <View style={{ width: 56, alignItems: 'flex-end' }}>
+                    <Switch
+                      value={isEnabled}
+                      disabled={enableLimitReached}
+                      accessibilityLabel={labelFor(key)}
+                      accessibilityHint={
+                        enableLimitReached
+                          ? i18n.t('homeDashboard.editor.limitReached', {
+                              count: MAX_VISIBLE_HOME_DASHBOARD_CARDS,
+                            })
+                          : undefined
+                      }
+                      onValueChange={(value) => setVisibility(key, value)}
+                    />
+                  </View>
+                </XView>
+              )
+            })}
+          </View>
+
+          <Button
+            noTransform
+            accessibilityRole='button'
+            variant='outline'
+            onPress={reset}
+            style={{ justifyContent: 'center', paddingVertical: 12 }}
+          >
+            <Text
+              style={{
+                color: theme.colors.accent,
+                fontFamily: theme.fonts.semiBold,
+                fontSize: theme.fontSize('sm'),
+              }}
+            >
+              {i18n.t('resetToDefaults')}
+            </Text>
+          </Button>
+        </ScrollView>
+      </Sheet.Frame>
+    </Sheet>
+  )
+}
+
+export default HomeDashboardEditorSheet

--- a/src/features/settings/components/preferences-sections/HomeScreenPreferencesSection.tsx
+++ b/src/features/settings/components/preferences-sections/HomeScreenPreferencesSection.tsx
@@ -20,58 +20,6 @@ import useDevice from '@/hooks/useDevice'
 import IconButton from '@/components/ui/IconButton'
 import { useMemo } from 'react'
 
-const DetailedProgressBar = () => {
-  const { displayDetailsOnProgressBarHomeScreen, set } = usePreferences()
-  const { entryMode } = usePublisher()
-  const theme = useTheme()
-
-  if (entryMode === 'checkbox') return null
-
-  return (
-    <InputRowContainer
-      lastInSection
-      style={{
-        flexDirection: 'column',
-        gap: 10,
-        alignItems: 'flex-start',
-      }}
-    >
-      <View
-        style={{
-          width: '100%',
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <Text
-          style={{
-            fontFamily: theme.fonts.semiBold,
-            flexDirection: 'column',
-            gap: 10,
-          }}
-        >
-          {i18n.t('detailedProgressBar')}
-        </Text>
-        <Switch
-          value={displayDetailsOnProgressBarHomeScreen}
-          onValueChange={(value) =>
-            set({ displayDetailsOnProgressBarHomeScreen: value })
-          }
-        />
-      </View>
-      <Text
-        style={{
-          fontSize: theme.fontSize('xs'),
-          color: theme.colors.textAlt,
-        }}
-      >
-        {i18n.t('detailedProgressBar_description')}
-      </Text>
-    </InputRowContainer>
-  )
-}
-
 const HideDonateHeart = () => {
   const { hideDonateHeart, set } = usePreferences()
 
@@ -138,6 +86,8 @@ const HomeElements = () => {
         return i18n.t('approachingConversations')
       case 'tabletServiceYearSummary':
         return i18n.t('serviceYearSummary')
+      case 'ministryDashboard':
+        return i18n.t('thisMonth')
       case 'serviceReport':
         return i18n.t('serviceReport')
       case 'thisWeek':
@@ -258,7 +208,6 @@ const HomeScreenPreferencesSection = () => {
         <HomeElements />
         <HideDonateHeart />
         <HideSupporterNudge />
-        <DetailedProgressBar />
       </Section>
     </View>
   )

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1275,6 +1275,23 @@
     "paceDescriptionMonth": "Compares logged time with your Plans for the full month.",
     "tapForDetails": "Tap for more details"
   },
+  "homeDashboard": {
+    "editor": {
+      "title": "Customize This Month",
+      "description": "Choose and arrange up to {{count}} cards.",
+      "moveUp": "Move {{card}} up",
+      "moveDown": "Move {{card}} down",
+      "limitReached": "You can show up to {{count}} cards.",
+      "cards": {
+        "schedulePace": "Schedule pace",
+        "projectedMonth": "Projected month",
+        "serviceYearProgress": "Service Year progress",
+        "creditTime": "Credit Time",
+        "remainingToGoal": "Remaining to goal",
+        "plannedTotal": "Planned total"
+      }
+    }
+  },
   "planDay": "Plan Day",
   "weekly": "Weekly",
   "bi-weekly": "Bi-Weekly",
@@ -1311,6 +1328,7 @@
   "howDoYouSubmitYourReport": "How do you submit your report?",
   "howDoYouSubmitYourReport_description": "At the end of each month, WitnessWork reminds you to submit your report and makes it one tap using your preferred method. You can change this anytime in Preferences.",
   "submitMonthsReport": "Submit {{month}}'s Report",
+  "reportSubmitted": "Report Submitted",
   "submitToApp": "Submit to {{app}}",
   "changeSubmissionMethod": "Change submission method",
   "dontSeeYourCongregationsApp": "Don't see your congregation's app?",

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -198,6 +198,7 @@ export type AppIconVariant =
 export type HomeScreenElementKey =
   | 'approachingConversations'
   | 'tabletServiceYearSummary'
+  | 'ministryDashboard'
   | 'serviceReport'
   | 'thisWeek'
   | 'timer'
@@ -208,9 +209,84 @@ export const DEFAULT_HOME_SCREEN_ELEMENTS_ORDER: HomeScreenElementKey[] = [
   'tabletServiceYearSummary',
   'serviceReport',
   'thisWeek',
+  'ministryDashboard',
   'timer',
   'didYouKnow',
 ]
+
+/** Customizable cards in the Home progress dashboard. */
+export type HomeDashboardCardKey =
+  | 'schedulePace'
+  | 'projectedMonth'
+  | 'serviceYearProgress'
+  | 'creditTime'
+  | 'remainingToGoal'
+  | 'plannedTotal'
+
+export const DEFAULT_HOME_DASHBOARD_CARD_ORDER: HomeDashboardCardKey[] = [
+  'schedulePace',
+  'projectedMonth',
+  'remainingToGoal',
+  'plannedTotal',
+  'serviceYearProgress',
+  'creditTime',
+]
+
+export const MAX_VISIBLE_HOME_DASHBOARD_CARDS = 5
+
+export type HomeDashboardCardVisibility = Record<HomeDashboardCardKey, boolean>
+
+export const DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY: HomeDashboardCardVisibility =
+  {
+    schedulePace: true,
+    projectedMonth: true,
+    remainingToGoal: true,
+    plannedTotal: false,
+    serviceYearProgress: false,
+    creditTime: false,
+  }
+
+/**
+ * Normalizes persisted/synced dashboard preferences. Unknown and duplicate keys
+ * are removed, newly introduced cards are appended, and visibility is capped
+ * without disturbing the User's chosen order.
+ */
+export function getEffectiveHomeDashboardCards(
+  storedOrder: string[] | undefined,
+  storedVisibility: Partial<Record<string, boolean>> | undefined
+): {
+  order: HomeDashboardCardKey[]
+  visibility: HomeDashboardCardVisibility
+} {
+  const valid = new Set<HomeDashboardCardKey>(DEFAULT_HOME_DASHBOARD_CARD_ORDER)
+  const order: HomeDashboardCardKey[] = []
+  for (const key of storedOrder ?? []) {
+    if (
+      valid.has(key as HomeDashboardCardKey) &&
+      !order.includes(key as HomeDashboardCardKey)
+    ) {
+      order.push(key as HomeDashboardCardKey)
+    }
+  }
+  for (const key of DEFAULT_HOME_DASHBOARD_CARD_ORDER) {
+    if (!order.includes(key)) order.push(key)
+  }
+
+  let visibleCount = 0
+  const visibility = { ...DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY }
+  for (const key of order) {
+    const requested = storedVisibility?.[key]
+    const isVisible =
+      requested === undefined
+        ? DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY[key]
+        : requested
+    visibility[key] =
+      isVisible && visibleCount < MAX_VISIBLE_HOME_DASHBOARD_CARDS
+    if (visibility[key]) visibleCount += 1
+  }
+
+  return { order, visibility }
+}
 
 /**
  * Returns the user's stored order with any missing keys appended in their
@@ -220,6 +296,19 @@ export const DEFAULT_HOME_SCREEN_ELEMENTS_ORDER: HomeScreenElementKey[] = [
 export function getEffectiveHomeScreenOrder(
   stored: string[] | undefined
 ): HomeScreenElementKey[] {
+  const previousPreviewDefault: HomeScreenElementKey[] = [
+    'approachingConversations',
+    'tabletServiceYearSummary',
+    'ministryDashboard',
+    'serviceReport',
+    'thisWeek',
+    'timer',
+    'didYouKnow',
+  ]
+  if (stored?.join('|') === previousPreviewDefault.join('|')) {
+    return [...DEFAULT_HOME_SCREEN_ELEMENTS_ORDER]
+  }
+
   const valid = new Set<HomeScreenElementKey>(
     DEFAULT_HOME_SCREEN_ELEMENTS_ORDER
   )
@@ -417,6 +506,7 @@ export const PREFERENCE_DEFAULTS = {
     approachingConversations: true,
     monthlyRoutine: true,
     tabletServiceYearSummary: true,
+    ministryDashboard: true,
     thisWeek: true,
     serviceReport: true,
     timer: true,
@@ -430,6 +520,12 @@ export const PREFERENCE_DEFAULTS = {
    */
   homeScreenElementsOrder:
     DEFAULT_HOME_SCREEN_ELEMENTS_ORDER as HomeScreenElementKey[],
+  /** User-selected order and visibility for Home's secondary data cards. */
+  homeDashboardCardOrder:
+    DEFAULT_HOME_DASHBOARD_CARD_ORDER as HomeDashboardCardKey[],
+  homeDashboardCardVisibility: {
+    ...DEFAULT_HOME_DASHBOARD_CARD_VISIBILITY,
+  } as HomeDashboardCardVisibility,
   colorScheme: undefined as 'light' | 'dark' | undefined,
   /**
    * Toggles the Skia-backed shader overlay on `ProfileCard`. Off by default


### PR DESCRIPTION
Separates the Home Service Report into a compact congregation-facing summary and adds a customizable This Month dashboard with monthly progress, the existing Schedule pace calculation, projections, and optional supporting cards. Removes the old hours-per-day-to-goal badge and its obsolete Home preference.

Fixes #409. Human UI review: check Home as an hours-entry Publisher both with and without Plans, then as a Regular Publisher; focus on section hierarchy, card density, tile ordering, and the customization sheet interactions.