### PR TITLE
Fix recurring plan override note dot

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -207,7 +207,7 @@ const PlannedDay = (
   const recurringPlanHasNote = props.recurringPlans?.some((plan) => {
     const effectiveNote = getEffectiveNoteForRecurringPlan(
       plan,
-      new Date(props.date!.dateString)
+      moment(props.date!.dateString).toDate()
     )
     return !!effectiveNote
   })


### PR DESCRIPTION
Ensures notes added to one-time Recurring Plan Overrides display their indicator dot on the correct calendar day across timezones.