### PR TITLE
Prioritize refinement usage when imports are unlimited

### DIFF
--- a/src/features/notes-import/components/NotesImportUsage.tsx
+++ b/src/features/notes-import/components/NotesImportUsage.tsx
@@ -10,6 +10,7 @@ import Text from '@/components/ui/MyText'
 import useTheme from '@/contexts/theme'
 import i18n from '@/lib/locales'
 import {
+  notesImportPrimaryUsage,
   shouldShowNotesImportSupporterCta,
   type NotesImportCredits,
 } from '@/features/notes-import/lib/notesImportUsage'
@@ -112,12 +113,12 @@ const Detail = ({
 
 /**
  * The Scribe AI usage affordance: a ghost button whose ring fills with the
- * fraction of import credits spent (full and muted when imports are unlimited).
- * Tapping opens the usage popover — the same imports/refinements breakdown and
- * Supporter CTA as before. It lives inline in the composer's control row (the
- * remaining refinement count is shown per-message in the chat, so this no
- * longer spells out numbers), with the popover carrying the full detail one tap
- * away.
+ * relevant balance remaining: imports for metered users, or refinements when
+ * imports are unlimited. Tapping opens the usage popover — the same
+ * imports/refinements breakdown and Supporter CTA as before. It lives inline in
+ * the composer's control row (the remaining refinement count is shown
+ * per-message in the chat, so this no longer spells out numbers), with the
+ * popover carrying the full detail one tap away.
  */
 const NotesImportUsage = ({
   credits,
@@ -129,18 +130,17 @@ const NotesImportUsage = ({
   const { width: windowWidth } = useWindowDimensions()
   const contentWidth = Math.min(340, windowWidth - 24)
   const importsUnlimited = credits.isSupporter || credits.remaining === null
+  const primaryUsage = notesImportPrimaryUsage(credits)
 
-  // The ring shows the import-credit balance remaining. Unlimited plans show a
-  // full, muted ring; a depleted balance goes warn-colored.
-  const ringProgress =
-    importsUnlimited || credits.remaining === null || !credits.limit
-      ? 1
-      : credits.remaining / credits.limit
-  const ringColor = importsUnlimited
-    ? theme.colors.accentTranslucent
-    : credits.remaining === 0
+  const ringProgress = primaryUsage.limit
+    ? primaryUsage.remaining / primaryUsage.limit
+    : 1
+  const ringColor =
+    primaryUsage.remaining === 0
       ? theme.colors.warn
-      : theme.colors.accent
+      : primaryUsage.kind === 'refinements'
+        ? theme.colors.indigo
+        : theme.colors.accent
 
   const resolvePosition: ResolveAnchorPosition = ({
     anchor,

--- a/src/features/notes-import/lib/notesImportUsage.test.ts
+++ b/src/features/notes-import/lib/notesImportUsage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  notesImportPrimaryUsage,
   normalizeNotesImportCredits,
   shouldShowNotesImportSupporterCta,
 } from '@/features/notes-import/lib/notesImportUsage'
@@ -65,5 +66,47 @@ describe('normalizeNotesImportCredits', () => {
     )
     expect(credits.isSupporter).toBe(false)
     expect(shouldShowNotesImportSupporterCta(credits)).toBe(true)
+  })
+})
+
+describe('notesImportPrimaryUsage', () => {
+  it('shows import progress when import credits are metered', () => {
+    expect(
+      notesImportPrimaryUsage({
+        remaining: 3,
+        limit: 5,
+        isSupporter: false,
+        refinements: { remaining: 1, limit: 5 },
+      })
+    ).toEqual({ kind: 'imports', remaining: 3, limit: 5 })
+  })
+
+  it('shows refinement progress when imports are unlimited', () => {
+    expect(
+      notesImportPrimaryUsage({
+        remaining: null,
+        limit: null,
+        isSupporter: true,
+        refinements: { remaining: 2, limit: 5 },
+      })
+    ).toEqual({ kind: 'refinements', remaining: 2, limit: 5 })
+  })
+
+  it('shows refinement progress for dev-bypass usage', () => {
+    const credits = normalizeNotesImportCredits(
+      {
+        remaining: 3,
+        limit: 5,
+        isSupporter: false,
+        refinements: { remaining: 4, limit: 5 },
+      },
+      { unlimitedImports: true }
+    )
+
+    expect(notesImportPrimaryUsage(credits)).toEqual({
+      kind: 'refinements',
+      remaining: 4,
+      limit: 5,
+    })
   })
 })

--- a/src/features/notes-import/lib/notesImportUsage.ts
+++ b/src/features/notes-import/lib/notesImportUsage.ts
@@ -82,3 +82,22 @@ export const normalizeNotesImportCredits = (
 export const shouldShowNotesImportSupporterCta = (
   credits: Pick<NotesImportCredits, 'isSupporter'>
 ): boolean => !credits.isSupporter
+
+/**
+ * Chooses the balance shown by the compact usage meter beside the composer.
+ * Import credits are irrelevant when they are unlimited, so Supporters and
+ * dev-bypass users see the per-import refinement balance instead.
+ */
+export const notesImportPrimaryUsage = (
+  credits: NotesImportCredits
+): { kind: 'imports' | 'refinements'; remaining: number; limit: number } => {
+  if (credits.remaining === null || credits.limit === null) {
+    return { kind: 'refinements', ...credits.refinements }
+  }
+
+  return {
+    kind: 'imports',
+    remaining: credits.remaining,
+    limit: credits.limit,
+  }
+}


### PR DESCRIPTION
Shows refinement progress in the Scribe composer usage meter when imports are unlimited, including Supporter and development-bypass usage. Metered users continue to see import-credit progress.